### PR TITLE
changed google analytics plugin widget location to head according to …

### DIFF
--- a/src/Plugins/Nop.Plugin.Widgets.GoogleAnalytics/GoogleAnalyticPlugin.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.GoogleAnalytics/GoogleAnalyticPlugin.cs
@@ -27,7 +27,7 @@ namespace Nop.Plugin.Widgets.GoogleAnalytics
         {
             return new List<string>
             { 
-                "body_end_html_tag_before"
+                "head_html_tag"
             };
         }
 


### PR DESCRIPTION
Hi,

According to GA documentation, GA script location should be in the head, not body:

https://support.google.com/analytics/answer/1008080?hl=en

I fixed this in the google analytics plugin.

Thanks in advance