### PR TITLE
Added dynamic detection of plugin view locations

### DIFF
--- a/src/Presentation/Nop.Web.Framework/Controllers/ThemeablePluginViewLocationAttribute.cs
+++ b/src/Presentation/Nop.Web.Framework/Controllers/ThemeablePluginViewLocationAttribute.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace Nop.Web.Framework.Controllers
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class ThemeablePluginViewLocationAttribute : Attribute
+    {
+        public string BaseViewLocation { get; set; }
+    }
+}

--- a/src/Presentation/Nop.Web.Framework/Nop.Web.Framework.csproj
+++ b/src/Presentation/Nop.Web.Framework/Nop.Web.Framework.csproj
@@ -143,6 +143,7 @@
     <Compile Include="CheckAffiliateAttribute.cs" />
     <Compile Include="Controllers\BaseController.cs" />
     <Compile Include="Controllers\BasePluginController.cs" />
+    <Compile Include="Controllers\ThemeablePluginViewLocationAttribute.cs" />
     <Compile Include="Controllers\ParameterBasedOnFormNameAndValueAttribute.cs" />
     <Compile Include="Kendoui\DataSourceRequest.cs" />
     <Compile Include="Kendoui\DataSourceResult.cs" />

--- a/src/Presentation/Nop.Web.Framework/Themes/ThemeableRazorViewEngine.cs
+++ b/src/Presentation/Nop.Web.Framework/Themes/ThemeableRazorViewEngine.cs
@@ -99,8 +99,11 @@ namespace Nop.Web.Framework.Themes
             if (pluginLocation != null)
                 return path.Replace(PluginReplacementString, pluginLocation.BaseViewLocation);
 
+            if (!path.StartsWith("~/"))
+                path = "~/" + path;
+
             // return default location base on controller namespace
-            return path.Replace(PluginReplacementString, "~/" + controllerType.Namespace);
+            return path;
         }
 
         protected override IView CreatePartialView(ControllerContext controllerContext, string partialPath)

--- a/src/Presentation/Nop.Web.Framework/Themes/ThemeableRazorViewEngine.cs
+++ b/src/Presentation/Nop.Web.Framework/Themes/ThemeableRazorViewEngine.cs
@@ -1,12 +1,38 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
+using System.Web.Hosting;
 using System.Web.Mvc;
+using Nop.Core.Plugins;
 
 namespace Nop.Web.Framework.Themes
 {
     public class ThemeableRazorViewEngine : ThemeableVirtualPathProviderViewEngine
     {
+        private const string InstalledPluginsFilePath = "~/App_Data/InstalledPlugins.txt";
+        private const string PluginReplacementString = "%PluginSystemName%";
+        private const string PluginsLocationFormat = "~/Plugins/" + PluginReplacementString + "/Views/{1}/{0}.cshtml";
+
         public ThemeableRazorViewEngine()
         {
+            var installedPluginSystemNames = PluginFileParser.ParseInstalledPluginsFile(HostingEnvironment.MapPath(InstalledPluginsFilePath));
+
+            var customViewLocationFormats = new List<string>()
+                                                {
+                                                    //themes
+                                                    "~/Themes/{2}/Views/{1}/{0}.cshtml",
+                                                    "~/Themes/{2}/Views/Shared/{0}.cshtml",
+
+                                                    //default
+                                                    "~/Views/{1}/{0}.cshtml",
+                                                    "~/Views/Shared/{0}.cshtml",
+
+                                                    //Admin
+                                                    "~/Administration/Views/{1}/{0}.cshtml",
+                                                    "~/Administration/Views/Shared/{0}.cshtml"
+                                                };
+
+            customViewLocationFormats.AddRange(installedPluginSystemNames.Select(systemName => PluginsLocationFormat.Replace(PluginReplacementString, systemName)));
+
             AreaViewLocationFormats = new[]
                                           {
                                               //themes
@@ -40,21 +66,8 @@ namespace Nop.Web.Framework.Themes
                                                     "~/Areas/{2}/Views/{1}/{0}.cshtml",
                                                     "~/Areas/{2}/Views/Shared/{0}.cshtml"
                                                  };
-
-            ViewLocationFormats = new[]
-                                      {
-                                            //themes
-                                            "~/Themes/{2}/Views/{1}/{0}.cshtml", 
-                                            "~/Themes/{2}/Views/Shared/{0}.cshtml",
-
-                                            //default
-                                            "~/Views/{1}/{0}.cshtml", 
-                                            "~/Views/Shared/{0}.cshtml",
-
-                                            //Admin
-                                            "~/Administration/Views/{1}/{0}.cshtml",
-                                            "~/Administration/Views/Shared/{0}.cshtml",
-                                      };
+            
+            ViewLocationFormats = customViewLocationFormats.ToArray();
 
             MasterLocationFormats = new[]
                                         {
@@ -67,20 +80,7 @@ namespace Nop.Web.Framework.Themes
                                             "~/Views/Shared/{0}.cshtml"
                                         };
 
-            PartialViewLocationFormats = new[]
-                                             {
-                                                 //themes
-                                                "~/Themes/{2}/Views/{1}/{0}.cshtml",
-                                                "~/Themes/{2}/Views/Shared/{0}.cshtml",
-
-                                                //default
-                                                "~/Views/{1}/{0}.cshtml", 
-                                                "~/Views/Shared/{0}.cshtml", 
-
-                                                //Admin
-                                                "~/Administration/Views/{1}/{0}.cshtml",
-                                                "~/Administration/Views/Shared/{0}.cshtml",
-                                             };
+            PartialViewLocationFormats = customViewLocationFormats.ToArray();
 
             FileExtensions = new[] { "cshtml" };
         }
@@ -88,6 +88,7 @@ namespace Nop.Web.Framework.Themes
         protected override IView CreatePartialView(ControllerContext controllerContext, string partialPath)
         {
             IEnumerable<string> fileExtensions = base.FileExtensions;
+
             return new RazorView(controllerContext, partialPath, null, false, fileExtensions);
             //return new RazorView(controllerContext, partialPath, layoutPath, runViewStartPages, fileExtensions, base.ViewPageActivator);
         }

--- a/src/Presentation/Nop.Web.Framework/Themes/ThemeableRazorViewEngine.cs
+++ b/src/Presentation/Nop.Web.Framework/Themes/ThemeableRazorViewEngine.cs
@@ -100,7 +100,7 @@ namespace Nop.Web.Framework.Themes
                 return path.Replace(PluginReplacementString, pluginLocation.BaseViewLocation);
 
             // return default location base on controller namespace
-            return path.Replace(PluginReplacementString, controllerType.Namespace);
+            return path.Replace(PluginReplacementString, "~/" + controllerType.Namespace);
         }
 
         protected override IView CreatePartialView(ControllerContext controllerContext, string partialPath)


### PR DESCRIPTION
I originally wrote this code inside a custom view engine but it seems like it would work and play nicely with the core framework / default view engine. Upon installation of a plugin w/ restart it will add that plugins folder location with standard conventions to the list of locations. 