### PR TITLE
Top Menu first time load speed up

### DIFF
--- a/src/Libraries/Nop.Services/Catalog/ICategoryService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ICategoryService.cs
@@ -128,5 +128,12 @@ namespace Nop.Services.Catalog
         /// <param name="productIds">Products IDs</param>
         /// <returns>Category IDs for products</returns>
         IDictionary<int, int[]> GetProductCategoryIds(int[] productIds);
+
+        /// <summary>
+        /// Get top menu categories
+        /// </summary>
+        /// <returns>List of top menu categories limited to current store and not limited to store</returns>
+        IList<Category> GetTopMenuCategories();
+
     }
 }

--- a/src/Libraries/Nop.Services/Nop.Services.csproj
+++ b/src/Libraries/Nop.Services/Nop.Services.csproj
@@ -40,6 +40,14 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="EPPlus, Version=4.0.5.0, Culture=neutral, PublicKeyToken=ea159fdaa78159a1, processorArchitecture=MSIL">
       <HintPath>..\..\packages\EPPlus.4.0.5\lib\net20\EPPlus.dll</HintPath>
       <Private>True</Private>
@@ -107,6 +115,7 @@
       <HintPath>..\..\packages\nopCommerceCustom\PerlRegex.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.EnterpriseServices" />

--- a/src/Libraries/Nop.Services/app.config
+++ b/src/Libraries/Nop.Services/app.config
@@ -1,18 +1,22 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <configSections>
-        <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-            <section name="Nop.Services.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
-        </sectionGroup>
-    </configSections>
-    <applicationSettings>
-        <Nop.Services.Properties.Settings>
-            <setting name="Nop_Services_EuropaCheckVatService_checkVatService" serializeAs="String">
-                <value>http://ec.europa.eu/taxation_customs/vies/services/checkVatService</value>
-            </setting>
-        </Nop.Services.Properties.Settings>
-    </applicationSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" /></startup>
+  <configSections>
+    <sectionGroup name="applicationSettings" type="System.Configuration.ApplicationSettingsGroup, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+      <section name="Nop.Services.Properties.Settings" type="System.Configuration.ClientSettingsSection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+    </sectionGroup>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
+  <applicationSettings>
+    <Nop.Services.Properties.Settings>
+      <setting name="Nop_Services_EuropaCheckVatService_checkVatService" serializeAs="String">
+        <value>http://ec.europa.eu/taxation_customs/vies/services/checkVatService</value>
+      </setting>
+    </Nop.Services.Properties.Settings>
+  </applicationSettings>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1" />
+  </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
@@ -41,4 +45,14 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
+  <entityFramework>
+    <defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
+      <parameters>
+        <parameter value="mssqllocaldb" />
+      </parameters>
+    </defaultConnectionFactory>
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
 </configuration>

--- a/src/Libraries/Nop.Services/packages.config
+++ b/src/Libraries/Nop.Services/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net451" />
+  <package id="EntityFramework" version="6.1.3" targetFramework="net451" />
   <package id="EPPlus" version="4.0.5" targetFramework="net451" />
   <package id="ImageResizer" version="3.4.3" targetFramework="net451" />
   <package id="ImageResizer.Plugins.PrettyGifs" version="3.4.3" targetFramework="net451" />

--- a/src/Presentation/Nop.Web/Controllers/CatalogController.cs
+++ b/src/Presentation/Nop.Web/Controllers/CatalogController.cs
@@ -668,7 +668,7 @@ namespace Nop.Web.Controllers
                 _workContext.WorkingLanguage.Id,
                 string.Join(",", _workContext.CurrentCustomer.GetCustomerRoleIds()), 
                 _storeContext.CurrentStore.Id);
-            var cachedCategoriesModel = _cacheManager.Get(categoryCacheKey, () => PrepareCategorySimpleModels(0));
+            var cachedCategoriesModel = _cacheManager.Get(categoryCacheKey, () => PrepareCategorySimpleModels(0, allCategories: _categoryService.GetTopMenuCategories()));
 
             //top menu topics
             string topicCacheKey = string.Format(ModelCacheEventConsumer.TOPIC_TOP_MENU_MODEL_KEY, 


### PR DESCRIPTION
1 function added to category service + it is used in CatalogController
Else is EntityFramework added into Services.dll to use SqlQuery.
Just the idea how and what to do.
For example if there are 20000 categories. Then all of them are loaded from db. Then all loaded are parsed in cshtml file for includeintopmenu flag (and parsed again and again with each request). It's long. We should load from db only needed categories.

p.s. nearly same problem is exist for category navigation. All categories are loaded (and cached) first time (and it's around 5-7 seconds for 20000 categories). Then cache is used for else (these requests are faster < 1 second). As I see cache is cleared even if application pool is not recycled. It makes all categories reload after a while.
