### PR TITLE
Change FakeHttpContext->Items to Hashtable

### DIFF
--- a/src/Libraries/Nop.Core/Fakes/FakeHttpContext.cs
+++ b/src/Libraries/Nop.Core/Fakes/FakeHttpContext.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Security.Principal;
 using System.Web;
@@ -37,7 +36,7 @@ namespace Nop.Core.Fakes
         {
         }
 
-        public FakeHttpContext(string relativeUrl, 
+        public FakeHttpContext(string relativeUrl,
             IPrincipal principal, NameValueCollection formParams,
             NameValueCollection queryStringParams, HttpCookieCollection cookies,
             SessionStateItemCollection sessionItems, NameValueCollection serverVariables)
@@ -59,7 +58,7 @@ namespace Nop.Core.Fakes
             _sessionItems = sessionItems;
             _serverVariables = serverVariables;
 
-            _items = new Dictionary<object, object>();
+            _items = new Hashtable();
         }
 
         public override HttpRequestBase Request


### PR DESCRIPTION
Changed _items Instance from Dictionary to Hashtable like in Original
Implementation
(http://referencesource.microsoft.com/#System.Web/HttpContext.cs,a38a77eb7b62f64d,references)

I think it's not useful to change FakeHttpContext Items to
ConcurrentDictionary because default HttpContext also not use it and you
can run into same behavior like described in the issue with async calls
in default HttpContext.

Partialy solve #986