### PR TITLE
Category navigation speed up

### DIFF
--- a/src/Libraries/Nop.Services/Catalog/CategoryService.cs
+++ b/src/Libraries/Nop.Services/Catalog/CategoryService.cs
@@ -598,7 +598,37 @@ namespace Nop.Services.Catalog
                 .Select(p => new {p.ProductId, p.CategoryId}).ToList()
                 .GroupBy(a => a.ProductId)
                 .ToDictionary(items => items.Key, items => items.Select(a => a.CategoryId).ToArray());
-        } 
+        }
+
+        /// <summary>
+        /// Get categories for navigation tree
+        /// </summary>
+        /// <param name="CategoryId">Category ID of category navigated to</param>
+        /// <returns>Categories list</returns>
+        public virtual IList<Category> GetCategoryTree(int CategoryId)
+        {
+            List<Category> tree = new List<Category>();
+            var currentcategory = GetCategoryById(CategoryId);
+
+            int parentid = currentcategory.ParentCategoryId;
+
+            while (parentid != 0)
+            {
+                var children = GetAllCategoriesByParentCategoryId(parentid);
+                if (children.Count > 0)
+                {
+                    tree.AddRange(children);
+                    var parentcategory = GetCategoryById(children[0].ParentCategoryId);
+                    parentid = parentcategory.ParentCategoryId;
+                }
+                else break;
+            }
+            tree.AddRange(GetAllCategoriesByParentCategoryId(0));
+            return tree;
+        }
+
+
+
         #endregion
     }
 }

--- a/src/Libraries/Nop.Services/Catalog/CategoryService.cs
+++ b/src/Libraries/Nop.Services/Catalog/CategoryService.cs
@@ -608,20 +608,23 @@ namespace Nop.Services.Catalog
         public virtual IList<Category> GetCategoryTree(int CategoryId)
         {
             List<Category> tree = new List<Category>();
-            var currentcategory = GetCategoryById(CategoryId);
-
-            int parentid = currentcategory.ParentCategoryId;
-
-            while (parentid != 0)
+            if (CategoryId != 0)
             {
-                var children = GetAllCategoriesByParentCategoryId(parentid);
-                if (children.Count > 0)
+                var currentcategory = GetCategoryById(CategoryId);
+
+                int parentid = currentcategory.ParentCategoryId;
+
+                while (parentid != 0)
                 {
-                    tree.AddRange(children);
-                    var parentcategory = GetCategoryById(children[0].ParentCategoryId);
-                    parentid = parentcategory.ParentCategoryId;
+                    var children = GetAllCategoriesByParentCategoryId(parentid);
+                    if (children.Count > 0)
+                    {
+                        tree.AddRange(children);
+                        var parentcategory = GetCategoryById(children[0].ParentCategoryId);
+                        parentid = parentcategory.ParentCategoryId;
+                    }
+                    else break;
                 }
-                else break;
             }
             tree.AddRange(GetAllCategoriesByParentCategoryId(0));
             return tree;

--- a/src/Libraries/Nop.Services/Catalog/ICategoryService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ICategoryService.cs
@@ -128,5 +128,12 @@ namespace Nop.Services.Catalog
         /// <param name="productIds">Products IDs</param>
         /// <returns>Category IDs for products</returns>
         IDictionary<int, int[]> GetProductCategoryIds(int[] productIds);
+
+        /// <summary>
+        /// Get categories for navigation tree
+        /// </summary>
+        /// <param name="CategoryId">Category ID of category navigated to</param>
+        /// <returns>Categories list</returns>
+        IList<Category> GetCategoryTree(int CategoryId);
     }
 }

--- a/src/Presentation/Nop.Web/Controllers/CatalogController.cs
+++ b/src/Presentation/Nop.Web/Controllers/CatalogController.cs
@@ -649,12 +649,12 @@ namespace Nop.Web.Controllers
                 _workContext.WorkingLanguage.Id,
                 string.Join(",", _workContext.CurrentCustomer.GetCustomerRoleIds()), 
                 _storeContext.CurrentStore.Id);
-            var cachedModel = _cacheManager.Get(cacheKey, () => PrepareCategorySimpleModels(0).ToList());
 
+            var tree = _categoryService.GetCategoryTree(activeCategoryId);
             var model = new CategoryNavigationModel
             {
                 CurrentCategoryId = activeCategoryId,
-                Categories = cachedModel
+                Categories = PrepareCategorySimpleModels(0, allCategories: tree).ToList()
             };
 
             return PartialView(model);


### PR DESCRIPTION
Load only categories that are needed in tree generation. Especially useful when there are a lot of categories in database.
