### PR TITLE
Allow setting colors to predefined product attribute values

### DIFF
--- a/src/Libraries/Nop.Core/Domain/Catalog/PredefinedProductAttributeValue.cs
+++ b/src/Libraries/Nop.Core/Domain/Catalog/PredefinedProductAttributeValue.cs
@@ -18,6 +18,11 @@ namespace Nop.Core.Domain.Catalog
         public string Name { get; set; }
 
         /// <summary>
+        /// Gets or sets the color RGB value (used with "Color squares" attribute type)
+        /// </summary>
+        public string ColorSquaresRgb { get; set; }
+
+        /// <summary>
         /// Gets or sets the price adjustment
         /// </summary>
         public decimal PriceAdjustment { get; set; }

--- a/src/Libraries/Nop.Data/Mapping/Catalog/PredefinedProductAttributeValueMap.cs
+++ b/src/Libraries/Nop.Data/Mapping/Catalog/PredefinedProductAttributeValueMap.cs
@@ -9,6 +9,7 @@ namespace Nop.Data.Mapping.Catalog
             this.ToTable("PredefinedProductAttributeValue");
             this.HasKey(pav => pav.Id);
             this.Property(pav => pav.Name).IsRequired().HasMaxLength(400);
+            this.Property(pav => pav.ColorSquaresRgb).HasMaxLength(100);
 
             this.Property(pav => pav.PriceAdjustment).HasPrecision(18, 4);
             this.Property(pav => pav.WeightAdjustment).HasPrecision(18, 4);

--- a/src/Presentation/Nop.Web/Administration/Controllers/ProductAttributeController.cs
+++ b/src/Presentation/Nop.Web/Administration/Controllers/ProductAttributeController.cs
@@ -283,6 +283,7 @@ namespace Nop.Admin.Controllers
                         Id = x.Id,
                         ProductAttributeId = x.ProductAttributeId,
                         Name = x.Name,
+                        ColorSquaresRgb = x.ColorSquaresRgb,
                         PriceAdjustment = x.PriceAdjustment,
                         PriceAdjustmentStr = x.PriceAdjustment.ToString("G29"),
                         WeightAdjustment = x.WeightAdjustment,
@@ -310,6 +311,7 @@ namespace Nop.Admin.Controllers
 
             var model = new PredefinedProductAttributeValueModel();
             model.ProductAttributeId = productAttributeId;
+            model.ColorSquaresRgb = "#000000";
 
             //locales
             AddLocales(_languageService, model.Locales);
@@ -333,6 +335,7 @@ namespace Nop.Admin.Controllers
                 {
                     ProductAttributeId = model.ProductAttributeId,
                     Name = model.Name,
+                    ColorSquaresRgb = model.ColorSquaresRgb,
                     PriceAdjustment = model.PriceAdjustment,
                     WeightAdjustment = model.WeightAdjustment,
                     Cost = model.Cost,
@@ -367,6 +370,7 @@ namespace Nop.Admin.Controllers
             {
                 ProductAttributeId = ppav.ProductAttributeId,
                 Name = ppav.Name,
+                ColorSquaresRgb = ppav.ColorSquaresRgb,
                 PriceAdjustment = ppav.PriceAdjustment,
                 WeightAdjustment = ppav.WeightAdjustment,
                 Cost = ppav.Cost,
@@ -394,6 +398,7 @@ namespace Nop.Admin.Controllers
             if (ModelState.IsValid)
             {
                 ppav.Name = model.Name;
+                ppav.ColorSquaresRgb = model.ColorSquaresRgb;
                 ppav.PriceAdjustment = model.PriceAdjustment;
                 ppav.WeightAdjustment = model.WeightAdjustment;
                 ppav.Cost = model.Cost;

--- a/src/Presentation/Nop.Web/Administration/Controllers/ProductController.cs
+++ b/src/Presentation/Nop.Web/Administration/Controllers/ProductController.cs
@@ -3402,6 +3402,7 @@ namespace Nop.Admin.Controllers
                     ProductAttributeMappingId = productAttributeMapping.Id,
                     AttributeValueType = AttributeValueType.Simple,
                     Name = predefinedValue.Name,
+                    ColorSquaresRgb = predefinedValue.ColorSquaresRgb,
                     PriceAdjustment = predefinedValue.PriceAdjustment,
                     WeightAdjustment = predefinedValue.WeightAdjustment,
                     Cost = predefinedValue.Cost,

--- a/src/Presentation/Nop.Web/Administration/Models/Catalog/ProductAttributeModel.cs
+++ b/src/Presentation/Nop.Web/Administration/Models/Catalog/ProductAttributeModel.cs
@@ -69,6 +69,9 @@ namespace Nop.Admin.Models.Catalog
         [AllowHtml]
         public string Name { get; set; }
 
+        [NopResourceDisplayName("Admin.Catalog.Attributes.ProductAttributes.PredefinedValues.Fields.ColorSquaresRgb")]
+        public string ColorSquaresRgb { get; set; }
+
         [NopResourceDisplayName("Admin.Catalog.Attributes.ProductAttributes.PredefinedValues.Fields.PriceAdjustment")]
         public decimal PriceAdjustment { get; set; }
         [NopResourceDisplayName("Admin.Catalog.Attributes.ProductAttributes.PredefinedValues.Fields.PriceAdjustment")]

--- a/src/Presentation/Nop.Web/Administration/Views/ProductAttribute/_CreateOrUpdatePredefinedProductAttributeValue.cshtml
+++ b/src/Presentation/Nop.Web/Administration/Views/ProductAttribute/_CreateOrUpdatePredefinedProductAttributeValue.cshtml
@@ -1,4 +1,8 @@
 ﻿@model PredefinedProductAttributeValueModel
+@{
+    Html.AddScriptParts("~/Scripts/farbtastic.js");
+    Html.AddCssFileParts("~/Content/farbtastic/farbtastic.css");
+}
 @Html.ValidationSummary(false)
 @Html.HiddenFor(model => model.Id)
 @Html.HiddenFor(model => model.ProductAttributeId)
@@ -67,6 +71,21 @@
         <td class="adminData">
             @Html.EditorFor(model => model.Cost)
             @Html.ValidationMessageFor(model => model.Cost)
+        </td>
+    </tr>
+    <tr>
+        <td class="adminTitle">
+            @Html.NopLabelFor(model => model.ColorSquaresRgb):
+        </td>
+        <td class="adminData">
+            @Html.EditorFor(model => model.ColorSquaresRgb)
+            <div id="color-picker"></div>
+            <script type="text/javascript">
+                    $(document).ready(function(){
+                        $('#color-picker').farbtastic('#@Html.FieldIdFor(model => model.ColorSquaresRgb)');
+                    });
+            </script>
+            @Html.ValidationMessageFor(model => model.ColorSquaresRgb)
         </td>
     </tr>
     <tr>

--- a/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
+++ b/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
@@ -1473,6 +1473,12 @@
   <LocaleResource Name="Admin.Catalog.Attributes.ProductAttributes.PredefinedValues.Fields.Name.Required">
     <Value>Please provide a name.</Value>
   </LocaleResource>
+  <LocaleResource Name="Admin.Catalog.Attributes.ProductAttributes.PredefinedValues.Fields.ColorSquaresRgb">
+    <Value>RGB color</Value>
+  </LocaleResource>
+  <LocaleResource Name="Admin.Catalog.Attributes.ProductAttributes.PredefinedValues.Fields.ColorSquaresRgb.Hint">
+    <Value>Choose color to be used with the color squares attribute control.</Value>
+  </LocaleResource>
   <LocaleResource Name="Admin.Catalog.Attributes.ProductAttributes.PredefinedValues.Fields.PriceAdjustment">
     <Value>Price adjustment</Value>
   </LocaleResource>

--- a/src/Tests/Nop.Data.Tests/Catalog/PredefinedProductAttributeValuePersistenceTests.cs
+++ b/src/Tests/Nop.Data.Tests/Catalog/PredefinedProductAttributeValuePersistenceTests.cs
@@ -13,6 +13,7 @@ namespace Nop.Data.Tests.Catalog
             var pav = new PredefinedProductAttributeValue
             {
                 Name = "Name 1",
+                ColorSquaresRgb = "#FFFFFF",
                 PriceAdjustment = 1.1M,
                 WeightAdjustment = 2.1M,
                 Cost = 3.1M,
@@ -27,6 +28,7 @@ namespace Nop.Data.Tests.Catalog
             var fromDb = SaveAndLoadEntity(pav);
             fromDb.ShouldNotBeNull();
             fromDb.Name.ShouldEqual("Name 1");
+            fromDb.ColorSquaresRgb.ShouldEqual("#FFFFFF");
             fromDb.PriceAdjustment.ShouldEqual(1.1M);
             fromDb.WeightAdjustment.ShouldEqual(2.1M);
             fromDb.Cost.ShouldEqual(3.1M);


### PR DESCRIPTION
Before that you needed to pick colors for each product by hand. Predefining colors is useful for example for paint or textile: there are vendor-defined palettes from which a customer should be able to choose a color.
