### PR TITLE
Shipping plugin should be tell checkout to limited to show payment method

### DIFF
--- a/src/Libraries/Nop.Core/Domain/Shipping/ShippingOption.cs
+++ b/src/Libraries/Nop.Core/Domain/Shipping/ShippingOption.cs
@@ -13,6 +13,11 @@ namespace Nop.Core.Domain.Shipping
     /// </summary>
     public partial class ShippingOption
     {
+        public ShippingOption()
+        {
+            LimitPaymentList = new List<string>();
+        }
+
         /// <summary>
         /// Gets or sets the system name of shipping rate computation method
         /// </summary>
@@ -32,6 +37,11 @@ namespace Nop.Core.Domain.Shipping
         /// Gets or sets a shipping option description
         /// </summary>
         public string Description { get; set; }
+
+        /// <summary>
+        /// Get or sets limit payment's name list.
+        /// </summary>
+        public List<string> LimitPaymentList { get; set; }
     }
 
 

--- a/src/Presentation/Nop.Web/Controllers/CheckoutController.cs
+++ b/src/Presentation/Nop.Web/Controllers/CheckoutController.cs
@@ -350,6 +350,9 @@ namespace Nop.Web.Controllers
                 }
             }
 
+            var selectedShippingOption = _workContext.CurrentCustomer.GetAttribute<ShippingOption>(
+                SystemCustomerAttributeNames.SelectedShippingOption, _storeContext.CurrentStore.Id);
+
             //filter by country
             var paymentMethods = _paymentService
                 .LoadActivePaymentMethods(_workContext.CurrentCustomer.Id, _storeContext.CurrentStore.Id, filterByCountryId)
@@ -360,6 +363,13 @@ namespace Nop.Web.Controllers
             {
                 if (cart.IsRecurring() && pm.RecurringPaymentType == RecurringPaymentType.NotSupported)
                     continue;
+
+                //Shipping plugin can add limit payment (by system name) to hide other payments
+                if (selectedShippingOption != null && selectedShippingOption.LimitPaymentList.Count > 0)
+                {
+                    if (!selectedShippingOption.LimitPaymentList.Contains(pm.PluginDescriptor.SystemName))
+                        continue;
+                }
 
                 var pmModel = new CheckoutPaymentMethodModel.PaymentMethodModel
                 {


### PR DESCRIPTION
I post #1379 issue and this is my first time contribute project on github.
I think shipping plugin sometimes would be relation other payment method.
In my case, I need to send the product to customer and collect money by carrier, so if customer select this shipping method, checkout should be hide other payment method.
