### PR TITLE
Updated PayPal Payment Processor to use TLS 1.2

### DIFF
--- a/src/Plugins/Nop.Plugin.Payments.PayPalDirect/PayPalDirectPaymentProcessor.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalDirect/PayPalDirectPaymentProcessor.cs
@@ -55,6 +55,10 @@ namespace Nop.Plugin.Payments.PayPalDirect
             this._currencySettings = currencySettings;
             this._webHelper = webHelper;
             this._orderTotalCalculationService = orderTotalCalculationService;
+
+            //Ensure connections to PayPal are TLS 1.2
+            //See https://www.paypal-knowledge.com/infocenter/index?page=content&widgetview=true&id=FAQ1914&viewlocale=en_US
+            System.Net.ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
         }
 
         #endregion


### PR DESCRIPTION
Added code to force the connection to PayPal uses TLS 1.2 which fixes the error:
'Invalid HTTP response The request was aborted: Could not create SSL/TLS secure channel.' when trying to access the PayPal API.

See https://www.paypal-knowledge.com/infocenter/index?page=content&widgetview=true&id=FAQ1914&viewlocale=en_US


