### PR TITLE
Enable TLS 1.2 support.

### DIFF
--- a/src/Presentation/Nop.Web/Global.asax.cs
+++ b/src/Presentation/Nop.Web/Global.asax.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Net;
 using System.Threading;
 using System.Web;
 using System.Web.Mvc;
@@ -43,6 +44,9 @@ namespace Nop.Web
 
         protected void Application_Start()
         {
+            // Most of the API providers require TLS 1.2 nowadys
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             //disable "X-AspNetMvc-Version" header name
             MvcHandler.DisableMvcResponseHeader = true;
 


### PR DESCRIPTION
Most of the API providers require TLS 1.2 to call their methods. The change enables TLS 1.2 in nopCommerce itself instead of adding this support to every single plugin.
