### PR TITLE
Fix for bundling CSS under a virtual directrory (fixes relative urls i…

### DIFF
--- a/src/Presentation/Nop.Web.Framework/UI/CssRewriteUrlTransformFixed.cs
+++ b/src/Presentation/Nop.Web.Framework/UI/CssRewriteUrlTransformFixed.cs
@@ -1,0 +1,64 @@
+// code copied from https://github.com/benmccallum/AspNetBundling/blob/master/AspNetBundling/CssRewriteUrlTransformFixed.cs
+
+namespace System.Web.Optimization
+{
+    using System.Text.RegularExpressions;
+
+    /// <summary>
+    /// Fixes for the standard System.Web.Optimization.CssRewriteUrlTransform. 
+    /// Now plays nice with:
+    ///  * Data URIs, including svgs (https://aspnetoptimization.codeplex.com/workitem/88)
+    ///  * URLs to other resources that are already absolute 
+    ///  * Virtual directories (http://aspnetoptimization.codeplex.com/workitem/83)
+    /// </summary>
+    public class CssRewriteUrlTransformFixed : IItemTransform
+    {
+        private static string RebaseUrlToAbsolute(string baseUrl, string url, string prefix, string suffix)
+        {
+            if (string.IsNullOrWhiteSpace(url) || string.IsNullOrWhiteSpace(baseUrl) || url.StartsWith("/", StringComparison.OrdinalIgnoreCase)
+				 || url.StartsWith("http://") || url.StartsWith("https://"))
+            {
+                return url;
+            }
+
+            if (url.StartsWith("data:"))
+            {
+                // Keep the prefix and suffix quotation chars as is in case they are needed (e.g. non-base64 encoded svg)
+                return prefix + url + suffix; 
+            }
+
+            if (!baseUrl.EndsWith("/", StringComparison.OrdinalIgnoreCase))
+            {
+                baseUrl += "/";
+            }
+
+            return VirtualPathUtility.ToAbsolute(baseUrl + url);
+        }
+        private static string ConvertUrlsToAbsolute(string baseUrl, string content)
+        {
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                return content;
+            }
+
+            var regex = new Regex("url\\((?<prefix>['\"]?)(?<url>[^)]+?)(?<suffix>['\"]?)\\)");
+
+            return regex.Replace(content, (Match match) => "url(" + CssRewriteUrlTransformFixed.RebaseUrlToAbsolute(baseUrl, match.Groups["url"].Value, match.Groups["prefix"].Value, match.Groups["suffix"].Value) + ")");
+        }
+        public string Process(string includedVirtualPath, string input)
+        {
+            if (includedVirtualPath == null)
+            {
+                throw new ArgumentNullException("includedVirtualPath");
+            }
+            if (includedVirtualPath.Length < 1 || includedVirtualPath[0] != '~')
+            {
+                throw new ArgumentException("includedVirtualPath must be valid ( i.e. have a length and start with ~ )");
+            }
+
+            var directory = VirtualPathUtility.GetDirectory(includedVirtualPath);
+
+            return CssRewriteUrlTransformFixed.ConvertUrlsToAbsolute(directory, input);
+        }
+    }
+}

--- a/src/Presentation/Nop.Web.Framework/UI/PageHeadBuilder.cs
+++ b/src/Presentation/Nop.Web.Framework/UI/PageHeadBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
@@ -91,7 +91,7 @@ namespace Nop.Web.Framework.UI
 
         protected virtual IItemTransform GetCssTranform()
         {
-            return new CssRewriteUrlTransform();
+            return new CssRewriteUrlTransformFixed();
         }
 
         #endregion


### PR DESCRIPTION
This is a fix for websites under a virtual directory. there is a bug in the Microsoft.AspNet.Web.Optimization project where the code does not take into account the application path when transforming relative links.

e.g. a css line of:
background: url('../img/rss-icon.png');

gets transformed to /img/rss-icon.png when it should get transformed to /virtualdir/img/rss-icon.png

It does not look like that code is being maintained as this fix has been available for some time. The original fix I took from https://github.com/benmccallum/AspNetBundling/blob/master/AspNetBundling/CssRewriteUrlTransformFixed.cs

Note, you may want to move the CssRewriteUrlTransformFixed.cs file and its namespace to somewhere more suitable. 
