### PR TITLE
Fix: Terms of services. Checkbox labels should be clickable #1717

### DIFF
--- a/src/Presentation/Nop.Web/Views/Checkout/Confirm.cshtml
+++ b/src/Presentation/Nop.Web/Views/Checkout/Confirm.cshtml
@@ -56,10 +56,10 @@
                         </div>
                         <div class="terms-of-service">
                             <input id="termsofservice" type="checkbox" name="termsofservice"/>
-                            <span>
+                            <label for="termsofservice">
                                 @T("Checkout.TermsOfService.IAccept")
                                 <a class="read" id="read-terms">@T("Checkout.TermsOfService.Read")</a>
-                            </span>
+                            </label>
                             <script>
                                 $(document).ready(function() {
                                     $('#read-terms').on('click', function(e) {

--- a/src/Presentation/Nop.Web/Views/Checkout/OpcConfirmOrder.cshtml
+++ b/src/Presentation/Nop.Web/Views/Checkout/OpcConfirmOrder.cshtml
@@ -35,12 +35,12 @@
         </div>
         <div class="terms-of-service">
             <input id="termsofservice" type="checkbox" name="termsofservice"/>
-            <span>
+            <label for="termsofservice">
                 @T("Checkout.TermsOfService.IAccept")
                 <a class="read" id="read-terms">
                     @T("Checkout.TermsOfService.Read")
                 </a>
-            </span>
+            </label>
             <script>
                 $(document).ready(function() {
                     $('#read-terms').on('click', function(e) {

--- a/src/Presentation/Nop.Web/Views/ShoppingCart/OrderSummary.cshtml
+++ b/src/Presentation/Nop.Web/Views/ShoppingCart/OrderSummary.cshtml
@@ -255,12 +255,12 @@
                        </div>
                        <div class="terms-of-service">
                            <input id="termsofservice" type="checkbox" name="termsofservice"/>
-                           <span>
-                                @T("Checkout.TermsOfService.IAccept")
+                           <label for="termsofservice">
+                               @T("Checkout.TermsOfService.IAccept")
                                <a class="read" id="read-terms">
-                                    @T("Checkout.TermsOfService.Read")
-                                </a>
-                            </span>
+                                   @T("Checkout.TermsOfService.Read")
+                               </a>
+                           </label>
                            <script>
                                $(document).ready(function() {
                                    $('#read-terms').on('click', function(e) {


### PR DESCRIPTION
Replace span with label with "for" attribute.
