### PR TITLE
#1758 Disallow /admin from robots.txt

### DIFF
--- a/src/Presentation/Nop.Web/Controllers/CommonController.cs
+++ b/src/Presentation/Nop.Web/Controllers/CommonController.cs
@@ -930,6 +930,7 @@ namespace Nop.Web.Controllers
                     "/country/getstatesbycountryid",
                     "/install",
                     "/setproductreviewhelpfulness",
+                    "/admin",
                     "/admin/"
                 };
                 var localizableDisallowPaths = new List<string>

--- a/src/Presentation/Nop.Web/Controllers/CommonController.cs
+++ b/src/Presentation/Nop.Web/Controllers/CommonController.cs
@@ -930,6 +930,7 @@ namespace Nop.Web.Controllers
                     "/country/getstatesbycountryid",
                     "/install",
                     "/setproductreviewhelpfulness",
+                    "/admin/"
                 };
                 var localizableDisallowPaths = new List<string>
                 {


### PR DESCRIPTION
Added disallow rules to robots.txt.

/admin
/admin/

First is to block crawlers from "foo.bar/admin"
Second is to block crawlers from "foo.bar/admin/{controller}"

It requires both, otherwise crawlers still try to open "foo.bar/admin"