### PR TITLE
Set LastSuccessUtc in Task constructor

### DIFF
--- a/src/Libraries/Nop.Services/Tasks/Task.cs
+++ b/src/Libraries/Nop.Services/Tasks/Task.cs
@@ -33,6 +33,7 @@ namespace Nop.Services.Tasks
             this.Enabled = task.Enabled;
             this.StopOnError = task.StopOnError;
             this.Name = task.Name;
+            this.LastSuccessUtc = task.LastSuccessUtc;
         }
 
         #endregion


### PR DESCRIPTION
Set LastSuccessUtc property to the database value in the constructor as well. Without it, if the task throws an exception, the LastSuccessUtc column in the database will be overwritten with NULL since the property is never initialized.