### PR TITLE
Show more detailed information of loaded assemblies

### DIFF
--- a/src/Presentation/Nop.Web/Administration/Models/Common/SystemInfoModel.cs
+++ b/src/Presentation/Nop.Web/Administration/Models/Common/SystemInfoModel.cs
@@ -56,6 +56,8 @@ namespace Nop.Admin.Models.Common
         {
             public string FullName { get; set; }
             public string Location { get; set; }
+            public bool IsDebug { get; set; }
+            public DateTime? BuildDate { get; set; }
         }
     }
 }

--- a/src/Presentation/Nop.Web/Administration/Views/Common/SystemInfo.cshtml
+++ b/src/Presentation/Nop.Web/Administration/Views/Common/SystemInfo.cshtml
@@ -122,12 +122,11 @@
                         <div class="col-md-9">
                             <a id="serverVariablesShowHide" href="javascript:toggleLoadedServerVariables();">@T("Admin.Common.Show")</a>
                             <div id="pnlServerVariables" style="display: none; word-break: break-all">
-                                <ul class="common-list">
+                                <ul>
                                     @foreach (var serverVariable in Model.ServerVariables)
                                     {
                                         <li>
-                                            @serverVariable.Name<text>:</text>
-                                            @serverVariable.Value
+                                            <strong>@serverVariable.Name</strong>: @serverVariable.Value
                                         </li>
                                     }
                                 </ul>
@@ -141,15 +140,31 @@
                         <div class="col-md-9">
                             <a id="loadedAssembliesShowHide" href="javascript:toggleLoadedAssemblies();">@T("Admin.Common.Show")</a>
                             <div id="pnlLoadedAssemblies" style="display: none">
-                                <ul class="common-list">
+                                <ul>
                                     @foreach (var assembly in Model.LoadedAssemblies)
                                     {
                                         <li>
-                                            <div>@assembly.FullName</div>
+                                            <div>
+                                                <strong>@assembly.FullName</strong>
+                                                @if (assembly.IsDebug)
+                                                {
+                                                    <span class="label label-warning">Debug</span>
+                                                }
+                                                else
+                                                {
+                                                    <span class="label label-success">Release</span>
+                                                }
+                                            </div>
                                             @if (!String.IsNullOrEmpty(assembly.Location))
                                             {
-                                                <div>
+                                                <div style="white-space: nowrap;">
                                                     <em>@assembly.Location</em>
+                                                </div>
+                                            }
+                                            @if (assembly.BuildDate.HasValue)
+                                            {
+                                                <div>
+                                                    @assembly.BuildDate.Value.ToString("s")
                                                 </div>
                                             }
                                         </li>


### PR DESCRIPTION
As explained here: http://www.nopcommerce.com/boards/t/45058/show-more-assembly-information-in-the-system-information-page.aspx#178867

* Show server variables and assemblies in a proper list (with bullets)
* Show server variable name in bold letters
* Hide server variables with raw HTTP header information that is repeated below
* Show assembly name in bold letters
* Show if assembly is in debug/release mode
* If in full trust, show assembly location (is commented out but CommonHelper has a method to get Trust)
* If in full trust, show assembly build date (we find this information useful when diagnosing problems)