### PR TITLE
return empty content if there's noly one currency in database

### DIFF
--- a/src/Presentation/Nop.Web/Controllers/CommonController.cs
+++ b/src/Presentation/Nop.Web/Controllers/CommonController.cs
@@ -331,7 +331,7 @@ namespace Nop.Web.Controllers
             };
 
             if (model.AvailableCurrencies.Count == 1)
-                Content("");
+                return Content("");
 
             return PartialView(model);
         }


### PR DESCRIPTION
I think you missed the 'return' keyword when there's only one currency.