### PR TITLE
Feature  rounding options configurable from admin. Related #677, #1424

### DIFF
--- a/src/Libraries/Nop.Core/Domain/Catalog/CatalogSettings.cs
+++ b/src/Libraries/Nop.Core/Domain/Catalog/CatalogSettings.cs
@@ -358,5 +358,20 @@ namespace Nop.Core.Domain.Catalog
         /// Gets or sets a value indicating whether need create dropdown list for export
         /// </summary>
         public bool ExportImportUseDropdownlistsForAssociatedEntities { get; set; }
+
+        /// <summary>
+        /// Gets or sets a the number of significant digits in the RoundingHelper
+        /// </summary>
+        public int RoundingPrecision { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether or not to show rounding precision digits for pricing
+        /// </summary>
+        public bool UseRoundingPrecisionForPriceDisplay { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the RoundingHelper should round away from zero
+        /// </summary>
+        public bool RoundAwayFromZero { get; set; }
     }
 }

--- a/src/Libraries/Nop.Services/Catalog/PriceCalculationService.cs
+++ b/src/Libraries/Nop.Services/Catalog/PriceCalculationService.cs
@@ -581,7 +581,7 @@ namespace Nop.Services.Catalog
             
             //rounding
             if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                finalPrice = RoundingHelper.RoundPrice(finalPrice);
+                finalPrice = RoundingHelper.RoundPrice(finalPrice, _catalogSettings);
 
             return finalPrice;
         }

--- a/src/Libraries/Nop.Services/Catalog/PriceFormatter.cs
+++ b/src/Libraries/Nop.Services/Catalog/PriceFormatter.cs
@@ -79,16 +79,34 @@ namespace Nop.Services.Catalog
             {
                 if (!String.IsNullOrEmpty(targetCurrency.DisplayLocale))
                 {
-                    NumberFormatInfo nfi = new CultureInfo(targetCurrency.DisplayLocale, false).NumberFormat;
-                    nfi.CurrencyDecimalDigits = _catalogSettings.RoundingPrecision;
-                    //default behavior
-                    result = amount.ToString("C", nfi);
+                    if (_catalogSettings.UseRoundingPrecisionForPriceDisplay)
+                    {
+                        NumberFormatInfo nfi = new CultureInfo(targetCurrency.DisplayLocale, false).NumberFormat;
+                        nfi.CurrencyDecimalDigits = _catalogSettings.RoundingPrecision;
+                        result = amount.ToString("C", nfi);
+                    }
+                    else
+                    {
+                        //default behavior
+                        result = amount.ToString("C");
+                    }
                 }
                 else
                 {
                     //not possible because "DisplayLocale" should be always specified
                     //but anyway let's just handle this behavior
-                    result = String.Format("{0} ({1})", amount.ToString("N"), targetCurrency.CurrencyCode);
+                    if (_catalogSettings.UseRoundingPrecisionForPriceDisplay)
+                    {
+                        NumberFormatInfo nfi = new CultureInfo(targetCurrency.DisplayLocale, false).NumberFormat;
+                        nfi.CurrencyDecimalDigits = _catalogSettings.RoundingPrecision;
+                        result = String.Format("{0} ({1})", amount.ToString("N", nfi), targetCurrency.CurrencyCode);
+                    }
+                    else
+                    {
+                        //default behavior
+                        result = String.Format("{0:N} ({1})", amount, targetCurrency.CurrencyCode);
+                    }
+                   
                     return result;
                 }
             }

--- a/src/Libraries/Nop.Services/Catalog/PriceFormatter.cs
+++ b/src/Libraries/Nop.Services/Catalog/PriceFormatter.cs
@@ -22,6 +22,7 @@ namespace Nop.Services.Catalog
         private readonly ILocalizationService _localizationService;
         private readonly TaxSettings _taxSettings;
         private readonly CurrencySettings _currencySettings;
+        private readonly CatalogSettings _catalogSettings;
 
         #endregion
 
@@ -31,13 +32,14 @@ namespace Nop.Services.Catalog
             ICurrencyService currencyService,
             ILocalizationService localizationService,
             TaxSettings taxSettings,
-            CurrencySettings currencySettings)
+            CurrencySettings currencySettings, CatalogSettings catalogSettings)
         {
             this._workContext = workContext;
             this._currencyService = currencyService;
             this._localizationService = localizationService;
             this._taxSettings = taxSettings;
             this._currencySettings = currencySettings;
+            _catalogSettings = catalogSettings;
         }
 
         #endregion
@@ -77,8 +79,10 @@ namespace Nop.Services.Catalog
             {
                 if (!String.IsNullOrEmpty(targetCurrency.DisplayLocale))
                 {
+                    NumberFormatInfo nfi = new CultureInfo(targetCurrency.DisplayLocale, false).NumberFormat;
+                    nfi.CurrencyDecimalDigits = _catalogSettings.RoundingPrecision;
                     //default behavior
-                    result = amount.ToString("C", new CultureInfo(targetCurrency.DisplayLocale));
+                    result = amount.ToString("C", nfi);
                 }
                 else
                 {
@@ -207,7 +211,7 @@ namespace Nop.Services.Catalog
             Currency targetCurrency, Language language, bool priceIncludesTax, bool showTax)
         {
             //we should round it no matter of "ShoppingCartSettings.RoundPricesDuringCalculation" setting
-            price = RoundingHelper.RoundPrice(price);
+            price = RoundingHelper.RoundPrice(price, _catalogSettings);
             
             string currencyString = GetCurrencyString(price, showCurrency, targetCurrency);
             if (showTax)

--- a/src/Libraries/Nop.Services/Catalog/RoundingHelper.cs
+++ b/src/Libraries/Nop.Services/Catalog/RoundingHelper.cs
@@ -23,7 +23,6 @@ namespace Nop.Services.Catalog
 
             //using Swiss Franc (CHF)? just uncomment the line below
             //return Math.Round(value * 20, 0) / 20;
-
             catalogSettings = catalogSettings ?? EngineContext.Current.Resolve<CatalogSettings>();
             var roundingPrecision = catalogSettings.RoundingPrecision;
             return catalogSettings.RoundAwayFromZero ?  Math.Round(value, roundingPrecision, MidpointRounding.AwayFromZero) : Math.Round(value, roundingPrecision);

--- a/src/Libraries/Nop.Services/Catalog/RoundingHelper.cs
+++ b/src/Libraries/Nop.Services/Catalog/RoundingHelper.cs
@@ -1,4 +1,6 @@
 using System;
+using Nop.Core.Domain.Catalog;
+using Nop.Core.Infrastructure;
 
 namespace Nop.Services.Catalog
 {
@@ -11,8 +13,9 @@ namespace Nop.Services.Catalog
         /// Round a product or order total
         /// </summary>
         /// <param name="value">Value to round</param>
+        /// <param name="catalogSettings">Optional CatalogSettings for determining rounding options</param>
         /// <returns>Rounded value</returns>
-        public static decimal RoundPrice(decimal value)
+        public static decimal RoundPrice(decimal value, CatalogSettings catalogSettings = null)
         {
             //we use this method because some currencies (e.g. Gungarian Forint or Swiss Franc) use non-standard rules for rounding
             //you can implement any rounding logic here
@@ -21,8 +24,9 @@ namespace Nop.Services.Catalog
             //using Swiss Franc (CHF)? just uncomment the line below
             //return Math.Round(value * 20, 0) / 20;
 
-            //default round
-            return Math.Round(value, 2);
+            catalogSettings = catalogSettings ?? EngineContext.Current.Resolve<CatalogSettings>();
+            var roundingPrecision = catalogSettings.RoundingPrecision;
+            return catalogSettings.RoundAwayFromZero ?  Math.Round(value, roundingPrecision, MidpointRounding.AwayFromZero) : Math.Round(value, roundingPrecision);
         }
     }
 }

--- a/src/Libraries/Nop.Services/Installation/CodeFirstInstallationService.cs
+++ b/src/Libraries/Nop.Services/Installation/CodeFirstInstallationService.cs
@@ -5903,7 +5903,10 @@ namespace Nop.Services.Installation
                 ShowProductReviewsTabOnAccountPage = true,
                 ProductReviewsPageSizeOnAccountPage = 10,
                 ExportImportProductAttributes = true,
-                ExportImportUseDropdownlistsForAssociatedEntities = true
+                ExportImportUseDropdownlistsForAssociatedEntities = true,
+                RoundingPrecision = 2,
+                UseRoundingPrecisionForPriceDisplay = false,
+                RoundAwayFromZero = false
             });
 
             settingService.SaveSetting(new LocalizationSettings

--- a/src/Libraries/Nop.Services/Orders/OrderTotalCalculationService.cs
+++ b/src/Libraries/Nop.Services/Orders/OrderTotalCalculationService.cs
@@ -167,7 +167,7 @@ namespace Nop.Services.Orders
                 shippingDiscountAmount = decimal.Zero;
 
             if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                shippingDiscountAmount = RoundingHelper.RoundPrice(shippingDiscountAmount);
+                shippingDiscountAmount = RoundingHelper.RoundPrice(shippingDiscountAmount, _catalogSettings);
 
             return shippingDiscountAmount;
         }
@@ -202,7 +202,7 @@ namespace Nop.Services.Orders
                 discountAmount = decimal.Zero;
 
             if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                discountAmount = RoundingHelper.RoundPrice(discountAmount);
+                discountAmount = RoundingHelper.RoundPrice(discountAmount, _catalogSettings);
 
             return discountAmount;
         }
@@ -326,7 +326,7 @@ namespace Nop.Services.Orders
                 subTotalWithoutDiscount = decimal.Zero;
 
             if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                subTotalWithoutDiscount = RoundingHelper.RoundPrice(subTotalWithoutDiscount);
+                subTotalWithoutDiscount = RoundingHelper.RoundPrice(subTotalWithoutDiscount, _catalogSettings);
 
             //We calculate discount amount on order subtotal excl tax (discount first)
             //calculate discount amount ('Applied to order subtotal' discount)
@@ -354,7 +354,7 @@ namespace Nop.Services.Orders
                         discountAmountInclTax += discountTax;
                         taxValue = taxRates[taxRate] - discountTax;
                         if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                            taxValue = RoundingHelper.RoundPrice(taxValue);
+                            taxValue = RoundingHelper.RoundPrice(taxValue, _catalogSettings);
                         taxRates[taxRate] = taxValue;
                     }
 
@@ -365,8 +365,8 @@ namespace Nop.Services.Orders
 
             if (_shoppingCartSettings.RoundPricesDuringCalculation)
             {
-                discountAmountInclTax = RoundingHelper.RoundPrice(discountAmountInclTax);
-                discountAmountExclTax = RoundingHelper.RoundPrice(discountAmountExclTax);
+                discountAmountInclTax = RoundingHelper.RoundPrice(discountAmountInclTax, _catalogSettings);
+                discountAmountExclTax = RoundingHelper.RoundPrice(discountAmountExclTax, _catalogSettings);
             }
 
             if (includingTax)
@@ -384,7 +384,7 @@ namespace Nop.Services.Orders
                 subTotalWithDiscount = decimal.Zero;
 
             if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                subTotalWithDiscount = RoundingHelper.RoundPrice(subTotalWithDiscount);
+                subTotalWithDiscount = RoundingHelper.RoundPrice(subTotalWithDiscount, _catalogSettings);
         }
 
         /// <summary>
@@ -482,10 +482,10 @@ namespace Nop.Services.Orders
             //rounding
             if (_shoppingCartSettings.RoundPricesDuringCalculation)
             {
-                subTotalExclTax = RoundingHelper.RoundPrice(subTotalExclTax);
-                subTotalInclTax = RoundingHelper.RoundPrice(subTotalInclTax);
-                discountAmountExclTax = RoundingHelper.RoundPrice(discountAmountExclTax);
-                discountAmountInclTax = RoundingHelper.RoundPrice(discountAmountInclTax);
+                subTotalExclTax = RoundingHelper.RoundPrice(subTotalExclTax, _catalogSettings);
+                subTotalInclTax = RoundingHelper.RoundPrice(subTotalInclTax, _catalogSettings);
+                discountAmountExclTax = RoundingHelper.RoundPrice(discountAmountExclTax, _catalogSettings);
+                discountAmountInclTax = RoundingHelper.RoundPrice(discountAmountInclTax, _catalogSettings);
             }
 
             updatedOrder.OrderSubtotalExclTax = subTotalExclTax;
@@ -607,8 +607,8 @@ namespace Nop.Services.Orders
                     //rounding
                     if (_shoppingCartSettings.RoundPricesDuringCalculation)
                     {
-                        shippingTotalExclTax = RoundingHelper.RoundPrice(shippingTotalExclTax);
-                        shippingTotalInclTax = RoundingHelper.RoundPrice(shippingTotalInclTax);
+                        shippingTotalExclTax = RoundingHelper.RoundPrice(shippingTotalExclTax, _catalogSettings);
+                        shippingTotalInclTax = RoundingHelper.RoundPrice(shippingTotalInclTax, _catalogSettings);
                     }
 
                     //change shipping status
@@ -697,7 +697,7 @@ namespace Nop.Services.Orders
 
             //round tax
             if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                taxTotal = RoundingHelper.RoundPrice(taxTotal);
+                taxTotal = RoundingHelper.RoundPrice(taxTotal, _catalogSettings);
 
             updatedOrder.OrderTax = taxTotal;
             updatedOrder.TaxRates = taxRates.Aggregate(string.Empty, (current, next) =>
@@ -757,7 +757,7 @@ namespace Nop.Services.Orders
             if (total < decimal.Zero)
                 total = decimal.Zero;
             if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                total = RoundingHelper.RoundPrice(total);
+                total = RoundingHelper.RoundPrice(total, _catalogSettings);
 
             updatedOrder.OrderDiscount = discountAmountTotal;
             updatedOrder.OrderTotal = total;
@@ -860,7 +860,7 @@ namespace Nop.Services.Orders
                 adjustedRate = decimal.Zero;
 
             if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                adjustedRate = RoundingHelper.RoundPrice(adjustedRate);
+                adjustedRate = RoundingHelper.RoundPrice(adjustedRate, _catalogSettings);
 
             return adjustedRate;
         }
@@ -982,7 +982,7 @@ namespace Nop.Services.Orders
 
                 //round
                 if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                    shippingTotal = RoundingHelper.RoundPrice(shippingTotal.Value);
+                    shippingTotal = RoundingHelper.RoundPrice(shippingTotal.Value, _catalogSettings);
 
                 shippingTotalTaxed = _taxService.GetShippingPrice(shippingTotal.Value,
                     includingTax,
@@ -991,7 +991,7 @@ namespace Nop.Services.Orders
                 
                 //round
                 if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                    shippingTotalTaxed = RoundingHelper.RoundPrice(shippingTotalTaxed.Value);
+                    shippingTotalTaxed = RoundingHelper.RoundPrice(shippingTotalTaxed.Value, _catalogSettings);
             }
 
             return shippingTotalTaxed;
@@ -1127,7 +1127,7 @@ namespace Nop.Services.Orders
                 taxTotal = decimal.Zero;
             //round tax
             if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                taxTotal = RoundingHelper.RoundPrice(taxTotal);
+                taxTotal = RoundingHelper.RoundPrice(taxTotal, _catalogSettings);
             return taxTotal;
         }
 
@@ -1240,7 +1240,7 @@ namespace Nop.Services.Orders
             resultTemp += paymentMethodAdditionalFeeWithoutTax;
             resultTemp += shoppingCartTax;
             if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                resultTemp = RoundingHelper.RoundPrice(resultTemp);
+                resultTemp = RoundingHelper.RoundPrice(resultTemp, _catalogSettings);
 
             #region Order total discount
 
@@ -1256,7 +1256,7 @@ namespace Nop.Services.Orders
             if (resultTemp < decimal.Zero)
                 resultTemp = decimal.Zero;
             if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                resultTemp = RoundingHelper.RoundPrice(resultTemp);
+                resultTemp = RoundingHelper.RoundPrice(resultTemp, _catalogSettings);
 
             #endregion
 
@@ -1292,7 +1292,7 @@ namespace Nop.Services.Orders
             if (resultTemp < decimal.Zero)
                 resultTemp = decimal.Zero;
             if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                resultTemp = RoundingHelper.RoundPrice(resultTemp);
+                resultTemp = RoundingHelper.RoundPrice(resultTemp, _catalogSettings);
 
             if (!shoppingCartShipping.HasValue)
             {
@@ -1336,7 +1336,7 @@ namespace Nop.Services.Orders
 
             orderTotal = orderTotal - redeemedRewardPointsAmount;
             if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                orderTotal = RoundingHelper.RoundPrice(orderTotal);
+                orderTotal = RoundingHelper.RoundPrice(orderTotal, _catalogSettings);
             return orderTotal;
         }
 
@@ -1356,7 +1356,7 @@ namespace Nop.Services.Orders
 
             var result = rewardPoints * _rewardPointsSettings.ExchangeRate;
             if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                result = RoundingHelper.RoundPrice(result);
+                result = RoundingHelper.RoundPrice(result, _catalogSettings);
             return result;
         }
 

--- a/src/Libraries/Nop.Services/Payments/PaymentService.cs
+++ b/src/Libraries/Nop.Services/Payments/PaymentService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Nop.Core;
+using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Customers;
 using Nop.Core.Domain.Orders;
 using Nop.Core.Domain.Payments;
@@ -22,6 +23,7 @@ namespace Nop.Services.Payments
         private readonly IPluginFinder _pluginFinder;
         private readonly ISettingService _settingService;
         private readonly ShoppingCartSettings _shoppingCartSettings;
+        private readonly CatalogSettings _catalogSettings;
 
         #endregion
 
@@ -37,12 +39,13 @@ namespace Nop.Services.Payments
         public PaymentService(PaymentSettings paymentSettings, 
             IPluginFinder pluginFinder,
             ISettingService settingService,
-            ShoppingCartSettings shoppingCartSettings)
+            ShoppingCartSettings shoppingCartSettings, CatalogSettings catalogSettings)
         {
             this._paymentSettings = paymentSettings;
             this._pluginFinder = pluginFinder;
             this._settingService = settingService;
             this._shoppingCartSettings = shoppingCartSettings;
+            _catalogSettings = catalogSettings;
         }
 
         #endregion
@@ -242,7 +245,7 @@ namespace Nop.Services.Payments
                 result = decimal.Zero;
             if (_shoppingCartSettings.RoundPricesDuringCalculation)
             {
-                result = RoundingHelper.RoundPrice(result);
+                result = RoundingHelper.RoundPrice(result, _catalogSettings);
             }
             return result;
         }

--- a/src/Libraries/Nop.Services/Shipping/ShippingService.cs
+++ b/src/Libraries/Nop.Services/Shipping/ShippingService.cs
@@ -58,6 +58,7 @@ namespace Nop.Services.Shipping
         private readonly IEventPublisher _eventPublisher;
         private readonly ShoppingCartSettings _shoppingCartSettings;
         private readonly ICacheManager _cacheManager;
+        private readonly CatalogSettings _catalogSettings;
 
         #endregion
 
@@ -95,7 +96,7 @@ namespace Nop.Services.Shipping
             IStoreContext storeContext,
             IEventPublisher eventPublisher,
             ShoppingCartSettings shoppingCartSettings,
-            ICacheManager cacheManager)
+            ICacheManager cacheManager, CatalogSettings catalogSettings)
         {
             this._shippingMethodRepository = shippingMethodRepository;
             this._warehouseRepository = warehouseRepository;
@@ -112,6 +113,7 @@ namespace Nop.Services.Shipping
             this._eventPublisher = eventPublisher;
             this._shoppingCartSettings = shoppingCartSettings;
             this._cacheManager = cacheManager;
+            _catalogSettings = catalogSettings;
         }
 
         #endregion
@@ -852,7 +854,7 @@ namespace Nop.Services.Shipping
                         if (String.IsNullOrEmpty(so.ShippingRateComputationMethodSystemName))
                             so.ShippingRateComputationMethodSystemName = srcm.PluginDescriptor.SystemName;
                         if (_shoppingCartSettings.RoundPricesDuringCalculation)
-                            so.Rate = RoundingHelper.RoundPrice(so.Rate);
+                            so.Rate = RoundingHelper.RoundPrice(so.Rate, _catalogSettings);
                         result.ShippingOptions.Add(so);
                     }
                 }

--- a/src/Presentation/Nop.Web/Administration/Controllers/SettingController.cs
+++ b/src/Presentation/Nop.Web/Administration/Controllers/SettingController.cs
@@ -837,6 +837,7 @@ namespace Nop.Admin.Controllers
                 model.ExportImportProductAttributes_OverrideForStore = _settingService.SettingExists(catalogSettings, x => x.ExportImportProductAttributes, storeScope);
                 model.RoundAwayFromZero_OverrideForStore = _settingService.SettingExists(catalogSettings, x => x.RoundAwayFromZero, storeScope);
                 model.RoundingPrecision_OverrideForStore = _settingService.SettingExists(catalogSettings, x => x.RoundingPrecision, storeScope);
+                model.RoundingPrecision_OverrideForStore = _settingService.SettingExists(catalogSettings, x => x.UseRoundingPrecisionForPriceDisplay, storeScope);
             }
             return View(model);
         }
@@ -911,6 +912,7 @@ namespace Nop.Admin.Controllers
             _settingService.SaveSettingOverridablePerStore(catalogSettings, x => x.ExportImportProductAttributes, model.ExportImportProductAttributes_OverrideForStore, storeScope, false);
             _settingService.SaveSettingOverridablePerStore(catalogSettings, x => x.RoundAwayFromZero, model.RoundAwayFromZero_OverrideForStore, storeScope, false);
             _settingService.SaveSettingOverridablePerStore(catalogSettings, x => x.RoundingPrecision, model.RoundingPrecision_OverrideForStore, storeScope, false);
+            _settingService.SaveSettingOverridablePerStore(catalogSettings, x => x.UseRoundingPrecisionForPriceDisplay, model.UseRoundingPrecisionForPriceDisplay_OverrideForStore, storeScope, false);
             //now settings not overridable per store
             _settingService.SaveSetting(catalogSettings, x => x.IgnoreDiscounts, 0, false);
             _settingService.SaveSetting(catalogSettings, x => x.IgnoreFeaturedProducts, 0, false);

--- a/src/Presentation/Nop.Web/Administration/Controllers/SettingController.cs
+++ b/src/Presentation/Nop.Web/Administration/Controllers/SettingController.cs
@@ -835,6 +835,8 @@ namespace Nop.Admin.Controllers
                 model.ShowProductReviewsOnAccountPage_OverrideForStore = _settingService.SettingExists(catalogSettings, x => x.ShowProductReviewsTabOnAccountPage, storeScope);
                 model.ProductReviewsPageSizeOnAccountPage_OverrideForStore = _settingService.SettingExists(catalogSettings, x=> x.ProductReviewsPageSizeOnAccountPage, storeScope);
                 model.ExportImportProductAttributes_OverrideForStore = _settingService.SettingExists(catalogSettings, x => x.ExportImportProductAttributes, storeScope);
+                model.RoundAwayFromZero_OverrideForStore = _settingService.SettingExists(catalogSettings, x => x.RoundAwayFromZero, storeScope);
+                model.RoundingPrecision_OverrideForStore = _settingService.SettingExists(catalogSettings, x => x.RoundingPrecision, storeScope);
             }
             return View(model);
         }
@@ -907,6 +909,8 @@ namespace Nop.Admin.Controllers
             _settingService.SaveSettingOverridablePerStore(catalogSettings, x => x.ShowProductReviewsTabOnAccountPage, model.ShowProductReviewsOnAccountPage_OverrideForStore, storeScope, false);
             _settingService.SaveSettingOverridablePerStore(catalogSettings, x => x.ProductReviewsPageSizeOnAccountPage, model.ProductReviewsPageSizeOnAccountPage_OverrideForStore, storeScope, false);
             _settingService.SaveSettingOverridablePerStore(catalogSettings, x => x.ExportImportProductAttributes, model.ExportImportProductAttributes_OverrideForStore, storeScope, false);
+            _settingService.SaveSettingOverridablePerStore(catalogSettings, x => x.RoundAwayFromZero, model.RoundAwayFromZero_OverrideForStore, storeScope, false);
+            _settingService.SaveSettingOverridablePerStore(catalogSettings, x => x.RoundingPrecision, model.RoundingPrecision_OverrideForStore, storeScope, false);
             //now settings not overridable per store
             _settingService.SaveSetting(catalogSettings, x => x.IgnoreDiscounts, 0, false);
             _settingService.SaveSetting(catalogSettings, x => x.IgnoreFeaturedProducts, 0, false);

--- a/src/Presentation/Nop.Web/Administration/Models/Settings/CatalogSettingsModel.cs
+++ b/src/Presentation/Nop.Web/Administration/Models/Settings/CatalogSettingsModel.cs
@@ -237,5 +237,16 @@ namespace Nop.Admin.Models.Settings
         [NopResourceDisplayName("Admin.Configuration.Settings.Catalog.CacheProductPrices")]
         public bool CacheProductPrices { get; set; }
 
+        [NopResourceDisplayName("Admin.Configuration.Settings.Catalog.RoundingPrecision")]
+        public int RoundingPrecision { get; set; }
+        public bool RoundingPrecision_OverrideForStore { get; set; }
+
+        [NopResourceDisplayName("Admin.Configuration.Settings.Catalog.UseRoundingPrecisionForPriceDisplay")]
+        public bool UseRoundingPrecisionForPriceDisplay { get; set; }
+        public bool UseRoundingPrecisionForPriceDisplay_OverrideForStore { get; set; }
+
+        [NopResourceDisplayName("Admin.Configuration.Settings.Catalog.RoundAwayFromZero")]
+        public bool RoundAwayFromZero { get; set; }
+        public bool RoundAwayFromZero_OverrideForStore { get; set; }
     }
 }

--- a/src/Presentation/Nop.Web/Administration/Views/Setting/Catalog.cshtml
+++ b/src/Presentation/Nop.Web/Administration/Views/Setting/Catalog.cshtml
@@ -103,33 +103,33 @@
                         </div>
                     </div>
                     <script type="text/javascript">
-                    $(document).ready(function() {
-                        $("#@Html.FieldIdFor(model => model.SearchPageAllowCustomersToSelectPageSize)").click(toggleSearchPagePageSize);
-                        $("#@Html.FieldIdFor(model => model.ProductSearchAutoCompleteEnabled)").click(toggleProductSearchAutoComplete);
+                        $(document).ready(function () {
+                            $("#@Html.FieldIdFor(model => model.SearchPageAllowCustomersToSelectPageSize)").click(toggleSearchPagePageSize);
+                            $("#@Html.FieldIdFor(model => model.ProductSearchAutoCompleteEnabled)").click(toggleProductSearchAutoComplete);
 
-                        toggleSearchPagePageSize();
-                        toggleProductSearchAutoComplete();
-                    });
+                            toggleSearchPagePageSize();
+                            toggleProductSearchAutoComplete();
+                        });
 
-                    function toggleSearchPagePageSize() {
-                        if ($('#@Html.FieldIdFor(model => model.SearchPageAllowCustomersToSelectPageSize)').is(':checked')) {
-                            $('#pnlSearchPageProductsPerPage').hide();
-                            $('#pnlSearchPagePageSizeOptions').show();
-                        } else {
-                            $('#pnlSearchPageProductsPerPage').show();
-                            $('#pnlSearchPagePageSizeOptions').hide();
+                        function toggleSearchPagePageSize() {
+                            if ($('#@Html.FieldIdFor(model => model.SearchPageAllowCustomersToSelectPageSize)').is(':checked')) {
+                                $('#pnlSearchPageProductsPerPage').hide();
+                                $('#pnlSearchPagePageSizeOptions').show();
+                            } else {
+                                $('#pnlSearchPageProductsPerPage').show();
+                                $('#pnlSearchPagePageSizeOptions').hide();
+                            }
                         }
-                    }
 
-                    function toggleProductSearchAutoComplete() {
-                        if ($('#@Html.FieldIdFor(model => model.ProductSearchAutoCompleteEnabled)').is(':checked')) {
-                            $('#pnlProductSearchAutoCompleteNumberOfProducts').show();
-                            $('#pnlShowProductImagesInSearchAutoComplete').show();
-                        } else {
-                            $('#pnlProductSearchAutoCompleteNumberOfProducts').hide();
-                            $('#pnlShowProductImagesInSearchAutoComplete').hide();
+                        function toggleProductSearchAutoComplete() {
+                            if ($('#@Html.FieldIdFor(model => model.ProductSearchAutoCompleteEnabled)').is(':checked')) {
+                                $('#pnlProductSearchAutoCompleteNumberOfProducts').show();
+                                $('#pnlShowProductImagesInSearchAutoComplete').show();
+                            } else {
+                                $('#pnlProductSearchAutoCompleteNumberOfProducts').hide();
+                                $('#pnlShowProductImagesInSearchAutoComplete').hide();
+                            }
                         }
-                    }
                     </script>
                 </div>
 
@@ -207,19 +207,19 @@
                         </div>
                     </div>
                     <script type="text/javascript">
-                $(document).ready(function() {
-                    $("#@Html.FieldIdFor(model => model.ShowProductReviewsTabOnAccountPage)").click(toggleProductReviewsPageSizeOnAccountPage);
+                        $(document).ready(function () {
+                            $("#@Html.FieldIdFor(model => model.ShowProductReviewsTabOnAccountPage)").click(toggleProductReviewsPageSizeOnAccountPage);
 
-                    toggleProductReviewsPageSizeOnAccountPage();
-                });
+                            toggleProductReviewsPageSizeOnAccountPage();
+                        });
 
-                function toggleProductReviewsPageSizeOnAccountPage() {
-                    if ($('#@Html.FieldIdFor(model => model.ShowProductReviewsTabOnAccountPage)').is(':checked')) {
-                        $('#pnlProductReviewsPageSizeOnAccountPage').show();
-                    } else {
-                        $('#pnlProductReviewsPageSizeOnAccountPage').hide();
-                    }
-                }
+                        function toggleProductReviewsPageSizeOnAccountPage() {
+                            if ($('#@Html.FieldIdFor(model => model.ShowProductReviewsTabOnAccountPage)').is(':checked')) {
+                                $('#pnlProductReviewsPageSizeOnAccountPage').show();
+                            } else {
+                                $('#pnlProductReviewsPageSizeOnAccountPage').hide();
+                            }
+                        }
                     </script>
                 </div>
 
@@ -296,7 +296,7 @@
                             </div>
                         </div>
                         <script type="text/javascript">
-                            $(document).ready(function() {
+                            $(document).ready(function () {
                                 $("#@Html.FieldIdFor(model => model.ShowShareButton)").click(togglePageShareCode);
                                 togglePageShareCode();
                             });
@@ -345,7 +345,7 @@
                             </div>
                         </div>
                         <script type="text/javascript">
-                            $(document).ready(function() {
+                            $(document).ready(function () {
                                 $("#@Html.FieldIdFor(model => model.CompareProductsEnabled)").click(toggleCompareProductsEnabled);
                                 toggleCompareProductsEnabled();
                             });
@@ -638,7 +638,7 @@
                     </div>
 
                     <script type="text/javascript">
-                        $(document).ready(function() {
+                        $(document).ready(function () {
                             $("#@Html.FieldIdFor(model => model.ShowCategoryProductNumber)").click(toggleShowCategoryProductNumberIncludingSubcategories);
                             $("#@Html.FieldIdFor(model => model.EmailAFriendEnabled)").click(toggleEmailAFriend);
                             $("#@Html.FieldIdFor(model => model.RecentlyViewedProductsEnabled)").click(toggleRecentlyViewedProducts);
@@ -782,10 +782,45 @@
                         </div>
                     </div>
                 </div>
-                
+
                 <div class="panel panel-default advanced-setting">
                     <div class="panel-body">
-                        
+                        <div class="form-group">
+                            <div class="col-md-3">
+                                @Html.OverrideStoreCheckboxFor(model => model.RoundingPrecision_OverrideForStore, model => model.RoundingPrecision, Model.ActiveStoreScopeConfiguration)
+                                @Html.NopLabelFor(model => model.RoundingPrecision)
+                            </div>
+                            <div class="col-md-9">
+                                @Html.NopEditorFor(model => model.RoundingPrecision)
+                                @Html.ValidationMessageFor(model => model.RoundingPrecision)
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <div class="col-md-3">
+                                @Html.OverrideStoreCheckboxFor(model => model.UseRoundingPrecisionForPriceDisplay_OverrideForStore, model => model.UseRoundingPrecisionForPriceDisplay, Model.ActiveStoreScopeConfiguration)
+                                @Html.NopLabelFor(model => model.UseRoundingPrecisionForPriceDisplay)
+                            </div>
+                            <div class="col-md-9">
+                                @Html.NopEditorFor(model => model.UseRoundingPrecisionForPriceDisplay)
+                                @Html.ValidationMessageFor(model => model.UseRoundingPrecisionForPriceDisplay)
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <div class="col-md-3">
+                                @Html.OverrideStoreCheckboxFor(model => model.RoundAwayFromZero_OverrideForStore, model => model.RoundAwayFromZero, Model.ActiveStoreScopeConfiguration)
+                                @Html.NopLabelFor(model => model.RoundAwayFromZero)
+                            </div>
+                            <div class="col-md-9">
+                                @Html.NopEditorFor(model => model.RoundAwayFromZero)
+                                @Html.ValidationMessageFor(model => model.RoundAwayFromZero)
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="panel panel-default advanced-setting">
+                    <div class="panel-body">
+
                         <div class="form-group advanced-setting">
                             <div class="col-md-3">
                                 @Html.OverrideStoreCheckboxFor(model => model.ExportImportProductAttributes_OverrideForStore, model => model.ExportImportProductAttributes, Model.ActiveStoreScopeConfiguration)
@@ -801,7 +836,7 @@
 
                 <div class="panel panel-default advanced-setting">
                     <div class="panel-body">
-                        
+
                         <div class="form-group advanced-setting">
                             <div class="col-md-3">
                                 @Html.OverrideStoreCheckboxFor(model => model.AllowProductSorting_OverrideForStore, model => model.AllowProductSorting, Model.ActiveStoreScopeConfiguration)
@@ -815,7 +850,7 @@
                         <div id="sortoptions-grid"></div>
 
                         <script>
-                            $(document).ready(function() {
+                            $(document).ready(function () {
                                 $("#sortoptions-grid").kendoGrid({
                                     dataSource: {
                                         type: "json",
@@ -846,12 +881,12 @@
                                                 }
                                             }
                                         },
-                                        requestEnd: function(e) {
+                                        requestEnd: function (e) {
                                             if (e.type == "update") {
                                                 this.read();
                                             }
                                         },
-                                        error: function(e) {
+                                        error: function (e) {
                                             display_kendoui_grid_error(e);
                                             // Cancel the changes
                                             this.cancelChanges();

--- a/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
+++ b/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
@@ -5053,19 +5053,19 @@
     <Value>Set rounding precision</Value>
   </LocaleResource>
   <LocaleResource Name="Admin.Configuration.Settings.Catalog.RoundingPrecision.Hint">
-    <Value>Set rounding precision for all calculations.</Value>
+    <Value>Set rounding precision for all calculations. Default should be 2.</Value>
   </LocaleResource>
   <LocaleResource Name="Admin.Configuration.Settings.Catalog.UseRoundingPrecisionForPriceDisplay">
     <Value>Use rounding precision for display</Value>
   </LocaleResource>
   <LocaleResource Name="Admin.Configuration.Settings.Catalog.UseRoundingPrecisionForPriceDisplay.Hint">
-    <Value>Use rounding precision for unit price display in all views.</Value>
+    <Value>Check to allow rounding precision for unit price display in all views.</Value>
   </LocaleResource>
   <LocaleResource Name="Admin.Configuration.Settings.Catalog.RoundAwayFromZero">
     <Value>Use away from zero rounding</Value>
   </LocaleResource>
   <LocaleResource Name="Admin.Configuration.Settings.Catalog.RoundAwayFromZero">
-    <Value>Use away from zero rounding for all rounding.</Value>
+    <Value>Check to use away from zero rounding for all rounding.</Value>
   </LocaleResource>
   <LocaleResource Name="Admin.Configuration.Settings.Catalog.ExportImportProductAttributes.Hint">
     <Value>Check if products should be exported/imported with product attributes.</Value>

--- a/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
+++ b/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
@@ -5064,7 +5064,7 @@
   <LocaleResource Name="Admin.Configuration.Settings.Catalog.RoundAwayFromZero">
     <Value>Use away from zero rounding</Value>
   </LocaleResource>
-  <LocaleResource Name="Admin.Configuration.Settings.Catalog.RoundAwayFromZero.Hint">
+  <LocaleResource Name="Admin.Configuration.Settings.Catalog.RoundAwayFromZero.Hint ">
     <Value>Check to use away from zero rounding instead of bankers rounding for all site rounding.</Value>
   </LocaleResource>
   <LocaleResource Name="Admin.Configuration.Settings.Catalog.ExportImportProductAttributes.Hint">

--- a/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
+++ b/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
@@ -5049,6 +5049,24 @@
   <LocaleResource Name="Admin.Configuration.Settings.Catalog.ExportImportProductAttributes">
     <Value>Export/Import products with attributes</Value>
   </LocaleResource>
+  <LocaleResource Name="Admin.Configuration.Settings.Catalog.RoundingPrecision">
+    <Value>Set rounding precision</Value>
+  </LocaleResource>
+  <LocaleResource Name="Admin.Configuration.Settings.Catalog.RoundingPrecision.Hint">
+    <Value>Set rounding precision for all calculations.</Value>
+  </LocaleResource>
+  <LocaleResource Name="Admin.Configuration.Settings.Catalog.UseRoundingPrecisionForPriceDisplay">
+    <Value>Use rounding precision for display</Value>
+  </LocaleResource>
+  <LocaleResource Name="Admin.Configuration.Settings.Catalog.UseRoundingPrecisionForPriceDisplay.Hint">
+    <Value>Use rounding precision for unit price display in all views.</Value>
+  </LocaleResource>
+  <LocaleResource Name="Admin.Configuration.Settings.Catalog.RoundAwayFromZero">
+    <Value>Use away from zero rounding</Value>
+  </LocaleResource>
+  <LocaleResource Name="Admin.Configuration.Settings.Catalog.RoundAwayFromZero">
+    <Value>Use away from zero rounding for all rounding.</Value>
+  </LocaleResource>
   <LocaleResource Name="Admin.Configuration.Settings.Catalog.ExportImportProductAttributes.Hint">
     <Value>Check if products should be exported/imported with product attributes.</Value>
   </LocaleResource>

--- a/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
+++ b/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
@@ -5053,19 +5053,19 @@
     <Value>Set rounding precision</Value>
   </LocaleResource>
   <LocaleResource Name="Admin.Configuration.Settings.Catalog.RoundingPrecision.Hint">
-    <Value>Set rounding precision for all calculations. Default should be 2.</Value>
+    <Value>Set rounding precision for all calculations. Default is 2.</Value>
   </LocaleResource>
   <LocaleResource Name="Admin.Configuration.Settings.Catalog.UseRoundingPrecisionForPriceDisplay">
     <Value>Use rounding precision for display</Value>
   </LocaleResource>
   <LocaleResource Name="Admin.Configuration.Settings.Catalog.UseRoundingPrecisionForPriceDisplay.Hint">
-    <Value>Check to allow rounding precision for unit price display in all views.</Value>
+    <Value>Check to allow rounding precision for unit price display in all views. Default is 2.</Value>
   </LocaleResource>
   <LocaleResource Name="Admin.Configuration.Settings.Catalog.RoundAwayFromZero">
     <Value>Use away from zero rounding</Value>
   </LocaleResource>
-  <LocaleResource Name="Admin.Configuration.Settings.Catalog.RoundAwayFromZero">
-    <Value>Check to use away from zero rounding for all rounding.</Value>
+  <LocaleResource Name="Admin.Configuration.Settings.Catalog.RoundAwayFromZero.Hint">
+    <Value>Check to use away from zero rounding instead of bankers rounding for all site rounding.</Value>
   </LocaleResource>
   <LocaleResource Name="Admin.Configuration.Settings.Catalog.ExportImportProductAttributes.Hint">
     <Value>Check if products should be exported/imported with product attributes.</Value>

--- a/src/Tests/Nop.Services.Tests/Catalog/PriceFormatterTests.cs
+++ b/src/Tests/Nop.Services.Tests/Catalog/PriceFormatterTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using Nop.Core;
 using Nop.Core.Caching;
 using Nop.Core.Data;
+using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Directory;
 using Nop.Core.Domain.Localization;
 using Nop.Core.Domain.Tax;
@@ -31,6 +32,7 @@ namespace Nop.Services.Tests.Catalog
         private ILocalizationService _localizationService;
         private TaxSettings _taxSettings;
         private IPriceFormatter _priceFormatter;
+        private CatalogSettings _catalogSettings;
         
         [SetUp]
         public new void SetUp()
@@ -74,13 +76,13 @@ namespace Nop.Services.Tests.Catalog
                 _currencySettings, pluginFinder, null);
 
             _taxSettings = new TaxSettings();
-
+            _catalogSettings = new CatalogSettings();
             _localizationService = MockRepository.GenerateMock<ILocalizationService>();
             _localizationService.Expect(x => x.GetResource("Products.InclTaxSuffix", 1, false)).Return("{0} incl tax");
             _localizationService.Expect(x => x.GetResource("Products.ExclTaxSuffix", 1, false)).Return("{0} excl tax");
             
             _priceFormatter = new PriceFormatter(_workContext, _currencyService,_localizationService, 
-                _taxSettings, _currencySettings);
+                _taxSettings, _currencySettings, _catalogSettings);
         }
 
         [Test]

--- a/src/Tests/Nop.Services.Tests/Orders/OrderProcessingServiceTests.cs
+++ b/src/Tests/Nop.Services.Tests/Orders/OrderProcessingServiceTests.cs
@@ -150,7 +150,7 @@ namespace Nop.Services.Tests.Orders
                 _storeContext,
                 _eventPublisher, 
                 _shoppingCartSettings,
-                cacheManager);
+                cacheManager, _catalogSettings);
             _shipmentService = MockRepository.GenerateMock<IShipmentService>();
             
 

--- a/src/Tests/Nop.Services.Tests/Orders/OrderTotalCalculationServiceTests.cs
+++ b/src/Tests/Nop.Services.Tests/Orders/OrderTotalCalculationServiceTests.cs
@@ -119,7 +119,7 @@ namespace Nop.Services.Tests.Orders
                 _storeContext,
                 _eventPublisher, 
                 _shoppingCartSettings,
-                cacheManager);
+                cacheManager, _catalogSettings);
             
 
             _paymentService = MockRepository.GenerateMock<IPaymentService>();

--- a/src/Tests/Nop.Services.Tests/Payments/PaymentServiceTests.cs
+++ b/src/Tests/Nop.Services.Tests/Payments/PaymentServiceTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Orders;
 using Nop.Core.Domain.Payments;
 using Nop.Core.Plugins;
@@ -16,6 +17,7 @@ namespace Nop.Services.Tests.Payments
     {
         private PaymentSettings _paymentSettings;
         private ShoppingCartSettings _shoppingCartSettings;
+        private CatalogSettings _catalogSettings;
         private ISettingService _settingService;
         private IPaymentService _paymentService;
         
@@ -29,9 +31,10 @@ namespace Nop.Services.Tests.Payments
             var pluginFinder = new PluginFinder();
 
             _shoppingCartSettings = new ShoppingCartSettings();
+            _catalogSettings = new CatalogSettings();
             _settingService = MockRepository.GenerateMock<ISettingService>();
 
-            _paymentService = new PaymentService(_paymentSettings, pluginFinder, _settingService, _shoppingCartSettings);
+            _paymentService = new PaymentService(_paymentSettings, pluginFinder, _settingService, _shoppingCartSettings, _catalogSettings);
         }
 
         [Test]

--- a/src/Tests/Nop.Services.Tests/Shipping/CalculateDimensionsTests.cs
+++ b/src/Tests/Nop.Services.Tests/Shipping/CalculateDimensionsTests.cs
@@ -39,6 +39,7 @@ namespace Nop.Services.Tests.Shipping
         private IProductService _productService;
         private Store _store;
         private IStoreContext _storeContext;
+        private CatalogSettings _catalogSettings;
 
         [SetUp]
         public new void SetUp()
@@ -67,7 +68,7 @@ namespace Nop.Services.Tests.Shipping
             _store = new Store { Id = 1 };
             _storeContext = MockRepository.GenerateMock<IStoreContext>();
             _storeContext.Expect(x => x.CurrentStore).Return(_store);
-
+            _catalogSettings = new CatalogSettings();
             _shoppingCartSettings = new ShoppingCartSettings();
             _shippingService = new ShippingService(_shippingMethodRepository,
                 _warehouseRepository,
@@ -83,7 +84,7 @@ namespace Nop.Services.Tests.Shipping
                 _storeContext,
                 _eventPublisher,
                 _shoppingCartSettings,
-                cacheManager);
+                cacheManager, _catalogSettings);
         }
 
         [Test]

--- a/src/Tests/Nop.Services.Tests/Shipping/ShippingServiceTests.cs
+++ b/src/Tests/Nop.Services.Tests/Shipping/ShippingServiceTests.cs
@@ -39,6 +39,7 @@ namespace Nop.Services.Tests.Shipping
         private IProductService _productService;
         private Store _store;
         private IStoreContext _storeContext;
+        private CatalogSettings _catalogSettings;
 
         [SetUp]
         public new void SetUp()
@@ -64,7 +65,7 @@ namespace Nop.Services.Tests.Shipping
             _localizationService = MockRepository.GenerateMock<ILocalizationService>();
             _addressService = MockRepository.GenerateMock<IAddressService>();
             _genericAttributeService = MockRepository.GenerateMock<IGenericAttributeService>();
-
+            _catalogSettings= new CatalogSettings();
             _store = new Store { Id = 1 };
             _storeContext = MockRepository.GenerateMock<IStoreContext>();
             _storeContext.Expect(x => x.CurrentStore).Return(_store);
@@ -84,7 +85,7 @@ namespace Nop.Services.Tests.Shipping
                 _storeContext,
                 _eventPublisher,
                 _shoppingCartSettings,
-                cacheManager);
+                cacheManager, _catalogSettings);
         }
 
         [Test]


### PR DESCRIPTION
Because RoundingHelper.RoundPrice handles all rounding, I would like to suggest adding the ability to configure some basic settings for how the rounding is handled.

The first option (RoundingPrecision) allows users to pass in the number of decimal places they would like to round to. Default would be 2. Right now there is no validation if a user enters a negative number. I could add it if suggested.

The second option (UseRoundingPrecisionForPriceDisplay) is would mostly be used by b2b implimentations where a buyer might want to see the entire price. In this case the same number of digits used for rounding would also be shown for the price on a product. It is disabled by default to use the standard 2 places.

The third option (RoundAwayFromZero ) just allows the admin to use this as a rounding options. While there has not been a lot of demand for this, it has come up.

Lastly, I am passing the Catalog Settings into the helper method so that the helper method does not have to resolve the settings. In most cases the settings were already loaded in the class where the helper method is being used. 

By allowing these features out of the box, it would make it easy for plugin developers to handle these cases without modifying core code or over-riding many services, especially since all of this logic passes through the single line of code in the RoundingHelper.