### PR TITLE
New feature for Adding minimum amount when applying tax on country & …

### DIFF
--- a/src/Plugins/Nop.Plugin.Tax.CountryStateZip/Controllers/TaxCountryStateZipController.cs
+++ b/src/Plugins/Nop.Plugin.Tax.CountryStateZip/Controllers/TaxCountryStateZipController.cs
@@ -103,6 +103,7 @@ namespace Nop.Plugin.Tax.CountryStateZip.Controllers
                         StateProvinceId = x.StateProvinceId,
                         Zip = x.Zip,
                         Percentage = x.Percentage,
+                        MinimumAmount = x.MinimumAmount
                     };
                     //store
                     var store = _storeService.GetStoreById(x.StoreId);
@@ -140,6 +141,7 @@ namespace Nop.Plugin.Tax.CountryStateZip.Controllers
             var taxRate = _taxRateService.GetTaxRateById(model.Id);
             taxRate.Zip = model.Zip == "*" ? null : model.Zip;
             taxRate.Percentage = model.Percentage;
+            taxRate.MinimumAmount = model.MinimumAmount;
             _taxRateService.UpdateTaxRate(taxRate);
 
             return new NullJsonResult();
@@ -173,7 +175,8 @@ namespace Nop.Plugin.Tax.CountryStateZip.Controllers
                 CountryId = model.AddCountryId,
                 StateProvinceId = model.AddStateProvinceId,
                 Zip = model.AddZip,
-                Percentage = model.AddPercentage
+                Percentage = model.AddPercentage,
+                MinimumAmount = model.AddMinimumAmount
             };
             _taxRateService.InsertTaxRate(taxRate);
 

--- a/src/Plugins/Nop.Plugin.Tax.CountryStateZip/Data/TaxRateMap.cs
+++ b/src/Plugins/Nop.Plugin.Tax.CountryStateZip/Data/TaxRateMap.cs
@@ -10,6 +10,7 @@ namespace Nop.Plugin.Tax.CountryStateZip.Data
             this.ToTable("TaxRate");
             this.HasKey(tr => tr.Id);
             this.Property(tr => tr.Percentage).HasPrecision(18, 4);
+            this.Property(tr => tr.MinimumAmount).HasPrecision(18, 4);
         }
     }
 }

--- a/src/Plugins/Nop.Plugin.Tax.CountryStateZip/Description.txt
+++ b/src/Plugins/Nop.Plugin.Tax.CountryStateZip/Description.txt
@@ -3,7 +3,7 @@ FriendlyName: Tax By Country & State & Zip
 SystemName: Tax.CountryStateZip
 Version: 1.42
 SupportedVersions: 3.80
-Author: nopCommerce team
+Author: nopCommerce team & jigarsangoi
 DisplayOrder: 1
 FileName: Nop.Plugin.Tax.CountryStateZip.dll
 Description: This plugin allow to configure taxe rates by coutries, states and zip codes

--- a/src/Plugins/Nop.Plugin.Tax.CountryStateZip/Domain/TaxRate.cs
+++ b/src/Plugins/Nop.Plugin.Tax.CountryStateZip/Domain/TaxRate.cs
@@ -36,5 +36,10 @@ namespace Nop.Plugin.Tax.CountryStateZip.Domain
         /// Gets or sets the percentage
         /// </summary>
         public decimal Percentage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum amount
+        /// </summary>
+        public decimal MinimumAmount { get; set; }
     }
 }

--- a/src/Plugins/Nop.Plugin.Tax.CountryStateZip/Infrastructure/Cache/TaxRateForCaching.cs
+++ b/src/Plugins/Nop.Plugin.Tax.CountryStateZip/Infrastructure/Cache/TaxRateForCaching.cs
@@ -12,5 +12,7 @@ namespace Nop.Plugin.Tax.CountryStateZip.Infrastructure.Cache
         public int StateProvinceId { get; set; }
         public string Zip { get; set; }
         public decimal Percentage { get; set; }
+
+        public decimal MinimumAmount { get; set; }
     }
 }

--- a/src/Plugins/Nop.Plugin.Tax.CountryStateZip/Models/TaxRateListModel.cs
+++ b/src/Plugins/Nop.Plugin.Tax.CountryStateZip/Models/TaxRateListModel.cs
@@ -36,6 +36,9 @@ namespace Nop.Plugin.Tax.CountryStateZip.Models
         public IList<SelectListItem> AvailableTaxCategories { get; set; }
 
         public IList<TaxRateModel> TaxRates { get; set; }
+
+        [NopResourceDisplayName("Plugins.Tax.CountryStateZip.Fields.MinimumAmount")]
+        public decimal AddMinimumAmount { get; set; }
         
     }
 }

--- a/src/Plugins/Nop.Plugin.Tax.CountryStateZip/Models/TaxRateModel.cs
+++ b/src/Plugins/Nop.Plugin.Tax.CountryStateZip/Models/TaxRateModel.cs
@@ -30,5 +30,8 @@ namespace Nop.Plugin.Tax.CountryStateZip.Models
 
         [NopResourceDisplayName("Plugins.Tax.CountryStateZip.Fields.Percentage")]
         public decimal Percentage { get; set; }
+
+        [NopResourceDisplayName("Plugins.Tax.CountryStateZip.Fields.MinimumAmount")]
+        public decimal MinimumAmount { get; set; }
     }
 }

--- a/src/Plugins/Nop.Plugin.Tax.CountryStateZip/Views/TaxCountryStateZip/Configure.cshtml
+++ b/src/Plugins/Nop.Plugin.Tax.CountryStateZip/Views/TaxCountryStateZip/Configure.cshtml
@@ -116,6 +116,19 @@
                                             });
                                 }
                             }, {
+                                field: "MinimumAmount",
+                                title: "@T("Plugins.Tax.CountryStateZip.Fields.MinimumAmount")",
+                                width: 100,
+                                editor: function (container, options) {
+                                    $('<input name="' + options.field + '"/>')
+                                            .appendTo(container)
+                                            .kendoNumericTextBox({
+                                                format: "{0:n2}",
+                                                decimals: 2
+                                            });
+                                }
+                            },
+                            {
                                 command: [{
                                     name: "edit",
                                     text: {
@@ -215,6 +228,15 @@
                     <div class="col-md-9">
                         @Html.NopEditorFor(model => model.AddPercentage)
                         @Html.ValidationMessageFor(model => model.AddPercentage)
+                    </div>
+                </div>
+                <div class="form-group">
+                    <div class="col-md-3">
+                        @Html.NopLabelFor(model => model.AddMinimumAmount):
+                    </div>
+                    <div class="col-md-9">
+                        @Html.EditorFor(model => model.AddMinimumAmount)
+                        @Html.ValidationMessageFor(model => model.AddMinimumAmount)
                     </div>
                 </div>
                 <div class="form-group">

--- a/upgradescripts/3.70-the next version/upgrade.sql
+++ b/upgradescripts/3.70-the next version/upgrade.sql
@@ -4931,3 +4931,10 @@ BEGIN
 	VALUES (N'producteditorsettings.specificationattributes', N'true', 0)
 END
 GO
+
+--default value for minimum amount
+Alter table TaxRate
+Add MinimumAmount decimal(18,4) null default 0
+Go
+
+Update TaxRate SET MinimumAMount = 0


### PR DESCRIPTION
New feature for Adding minimum amount when applying tax on country & state & zip

We are using Tax by country & state & zip. We have requirement when order total < 800 and shipping country USA, we dont want to apply tax. when amount > 800 we apply tax

I haven't done implementation for "develop" branch which you guys using for 3.90