### PR TITLE
Admin section links for help and public store link is opened in new tab

### DIFF
--- a/src/Presentation/Nop.Web.Framework/Menu/SiteMapNode.cs
+++ b/src/Presentation/Nop.Web.Framework/Menu/SiteMapNode.cs
@@ -59,5 +59,10 @@ namespace Nop.Web.Framework.Menu
         /// Gets or sets the item is visible
         /// </summary>
         public bool Visible { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to open url in new tab (window) or not
+        /// </summary>
+        public bool OpenUrlInNewTab { get; set; }
     }
 }

--- a/src/Presentation/Nop.Web.Framework/Menu/XmlSiteMap.cs
+++ b/src/Presentation/Nop.Web.Framework/Menu/XmlSiteMap.cs
@@ -110,6 +110,18 @@ namespace Nop.Web.Framework.Menu
             {
                 siteMapNode.Visible = true;
             }
+
+            // Open URL in new tab
+            var openUrlInNewTabValue = GetStringValueFromAttribute(xmlNode, "OpenUrlInNewTab");
+            bool booleanResult;
+            if (!string.IsNullOrWhiteSpace(openUrlInNewTabValue) && bool.TryParse(openUrlInNewTabValue, out booleanResult))
+            {
+                siteMapNode.OpenUrlInNewTab = booleanResult;
+            }
+            else
+            {
+                siteMapNode.OpenUrlInNewTab = false;
+            }
         }
 
         private static string GetStringValueFromAttribute(XmlNode node, string attributeName)

--- a/src/Presentation/Nop.Web.Framework/Menu/XmlSiteMap.cs
+++ b/src/Presentation/Nop.Web.Framework/Menu/XmlSiteMap.cs
@@ -118,10 +118,6 @@ namespace Nop.Web.Framework.Menu
             {
                 siteMapNode.OpenUrlInNewTab = booleanResult;
             }
-            else
-            {
-                siteMapNode.OpenUrlInNewTab = false;
-            }
         }
 
         private static string GetStringValueFromAttribute(XmlNode node, string attributeName)

--- a/src/Presentation/Nop.Web/Administration/Views/Shared/Menu.cshtml
+++ b/src/Presentation/Nop.Web/Administration/Views/Shared/Menu.cshtml
@@ -26,7 +26,7 @@
     if (!String.IsNullOrEmpty(url))
     {
         <li @(isActive ? Html.Raw("class=\"active current-active-item\"") : null)>
-            <a href="@url" class="menu-item-link" @(item.OpenUrlInNewTab ? Html.Raw("target=\"_blank\"") : null)>
+            <a href="@url" class="menu-item-link"@(item.OpenUrlInNewTab ? Html.Raw(" target=\"_blank\"") : null)>
                 @if (!String.IsNullOrEmpty(item.IconClass))
                 {
                     <text>

--- a/src/Presentation/Nop.Web/Administration/Views/Shared/Menu.cshtml
+++ b/src/Presentation/Nop.Web/Administration/Views/Shared/Menu.cshtml
@@ -26,7 +26,7 @@
     if (!String.IsNullOrEmpty(url))
     {
         <li @(isActive ? Html.Raw("class=\"active current-active-item\"") : null)>
-            <a href="@url" class="menu-item-link">
+            <a href="@url" class="menu-item-link" @(item.OpenUrlInNewTab ? Html.Raw("target=\"_blank\"") : null)>
                 @if (!String.IsNullOrEmpty(item.IconClass))
                 {
                     <text>

--- a/src/Presentation/Nop.Web/Administration/Views/Shared/_AdminLayout.cshtml
+++ b/src/Presentation/Nop.Web/Administration/Views/Shared/_AdminLayout.cshtml
@@ -142,7 +142,7 @@
                                     @Html.Widget("admin_header_middle", area: "Admin")
                                 </li>
                                 <li>
-                                    <a href="@Url.Action("Index", "Home", new {area = ""})">
+                                    <a href="@Url.Action("Index", "Home", new {area = ""})" target="_blank">
                                         @T("Admin.Header.PublicStore")
                                     </a>
                                 </li>

--- a/src/Presentation/Nop.Web/Administration/Views/Shared/_AdminLayout.cshtml
+++ b/src/Presentation/Nop.Web/Administration/Views/Shared/_AdminLayout.cshtml
@@ -142,7 +142,7 @@
                                     @Html.Widget("admin_header_middle", area: "Admin")
                                 </li>
                                 <li>
-                                    <a href="@Url.Action("Index", "Home", new {area = ""})" target="_blank">
+                                    <a href="@Url.Action("Index", "Home", new {area = ""})">
                                         @T("Admin.Header.PublicStore")
                                     </a>
                                 </li>

--- a/src/Presentation/Nop.Web/Administration/sitemap.config
+++ b/src/Presentation/Nop.Web/Administration/sitemap.config
@@ -121,9 +121,9 @@
       </siteMapNode>
     </siteMapNode>
     <siteMapNode SystemName="Help" nopResource="Admin.Help" IconClass="fa-question-circle">
-      <siteMapNode SystemName="Help topics" nopResource="Admin.Help.Topics" url="http://docs.nopcommerce.com/display/nc/nopCommerce+Documentation?utm_source=admin-panel&amp;utm_medium=menu&amp;utm_campaign=admin-panel"  IconClass="fa-dot-circle-o"/>
-      <siteMapNode SystemName="Community forums" nopResource="Admin.Help.Forums" url="http://www.nopcommerce.com/boards/?utm_source=admin-panel&amp;utm_medium=menu&amp;utm_campaign=admin-panel"  IconClass="fa-dot-circle-o"/>
-      <siteMapNode SystemName="Premium support services" nopResource="Admin.Help.SupportServices" url="http://www.nopcommerce.com/p/541/nopcommerce-premium-support-services.aspx?utm_source=admin-panel&amp;utm_medium=menu&amp;utm_campaign=admin-panel"  IconClass="fa-dot-circle-o"/>
+      <siteMapNode SystemName="Help topics" nopResource="Admin.Help.Topics" url="http://docs.nopcommerce.com/display/nc/nopCommerce+Documentation?utm_source=admin-panel&amp;utm_medium=menu&amp;utm_campaign=admin-panel"  IconClass="fa-dot-circle-o" OpenUrlInNewTab="true"/>
+      <siteMapNode SystemName="Community forums" nopResource="Admin.Help.Forums" url="http://www.nopcommerce.com/boards/?utm_source=admin-panel&amp;utm_medium=menu&amp;utm_campaign=admin-panel"  IconClass="fa-dot-circle-o" OpenUrlInNewTab="true"/>
+      <siteMapNode SystemName="Premium support services" nopResource="Admin.Help.SupportServices" url="http://www.nopcommerce.com/p/541/nopcommerce-premium-support-services.aspx?utm_source=admin-panel&amp;utm_medium=menu&amp;utm_campaign=admin-panel"  IconClass="fa-dot-circle-o" OpenUrlInNewTab="true"/>
     </siteMapNode>
     <siteMapNode SystemName="Third party plugins" nopResource="Admin.Plugins" IconClass="fa-bars" />
   </siteMapNode>


### PR DESCRIPTION
#2022  A new field called OpenUrlInNewTab is added in SiteMapNode.cs file which allows to configure particular url to open in new tab through sitemap.config file. @AndreiMaz please review.