### PR TITLE
Product editor settings dialog checkbox check status problem

### DIFF
--- a/src/Presentation/Nop.Web/Administration/Views/Product/_ProductEditorSettingsModal.cshtml
+++ b/src/Presentation/Nop.Web/Administration/Views/Product/_ProductEditorSettingsModal.cshtml
@@ -761,17 +761,23 @@
                 }
                 <script>
                     $(document).ready(function () {
-                        $('input[type=checkbox].select-all-fields').each(function (index, value) {
-                            if ($('input[type=checkbox]:checked', $(this).closest('.panel')).length > 0) {
-                                $(this).attr('checked', true);
-                            }
+                        updateAllFieldsCheckbox();
+                        $('#productsettings-window input[type=checkbox]').not('.select-all-fields').on('click', function () {
+                            updateAllFieldsCheckbox();
                         });
-
 
                         $('input[type=checkbox].select-all-fields').on('click', function () {
                             $('input[type=checkbox]', $(this).closest('.panel')).attr('checked', $(this).is(':checked'));
                         });
                     });
+
+                    function updateAllFieldsCheckbox() {
+                        $('input[type=checkbox].select-all-fields').each(function (index, value) {
+                            var numChkBoxes = $('input[type=checkbox]', $(this).closest('.panel')).not('.select-all-fields').length;
+                            var numChkBoxesChecked = $('input[type=checkbox]:checked', $(this).closest('.panel')).not('.select-all-fields').length;
+                            $(this).attr('checked', numChkBoxes == numChkBoxesChecked && numChkBoxes > 0);
+                        });
+                    }
                 </script>
             </div>
         </div>

--- a/src/Presentation/Nop.Web/Controllers/CommonController.cs
+++ b/src/Presentation/Nop.Web/Controllers/CommonController.cs
@@ -331,7 +331,7 @@ namespace Nop.Web.Controllers
             };
 
             if (model.AvailableCurrencies.Count == 1)
-                Content("");
+                return Content("");
 
             return PartialView(model);
         }

--- a/src/Presentation/Nop.Web/Controllers/CommonController.cs
+++ b/src/Presentation/Nop.Web/Controllers/CommonController.cs
@@ -257,7 +257,7 @@ namespace Nop.Web.Controllers
             };
 
             if (model.AvailableLanguages.Count == 1)
-                Content("");
+                return Content("");
 
             return PartialView(model);
         }


### PR DESCRIPTION
In product edit page, \Presentation\Nop.Web\Administration\Views\Product\_ProductEditorSettingsModal.cshtml
I think the current logic is wrong:, and current logic is :

`
                        $('input[type=checkbox].select-all-fields').each(function (index, value) {
                            if ($('input[type=checkbox]:checked', $(this).closest('.panel')).length > 0) {
                                $(this).attr('checked', true);
                            }
                        });
`

for example, "Advanced product types " category has 4 options, if "Is gift card
" is checked, "Advanced product types " will be checked according current logic.

"Advanced product types " should be checked when all options checked.

Advanced product types 
- Is gift card
- Downloadable product
- Recurring product
- Is rental