### PR TITLE
Feature #2200 - Log should save URL "as is" (do not lowercase)

### DIFF
--- a/src/Libraries/Nop.Core/IWebHelper.cs
+++ b/src/Libraries/Nop.Core/IWebHelper.cs
@@ -32,8 +32,9 @@ namespace Nop.Core
         /// </summary>
         /// <param name="includeQueryString">Value indicating whether to include query strings</param>
         /// <param name="useSsl">Value indicating whether to get SSL secured page URL</param>
+        /// <param name="ignoreCase">Value indicating whether the page URL should be lowercase or not</param>
         /// <returns>Page URL</returns>
-        string GetThisPageUrl(bool includeQueryString, bool useSsl);
+        string GetThisPageUrl(bool includeQueryString, bool useSsl, bool ignoreCase = true);
 
         /// <summary>
         /// Gets a value indicating whether current connection is secured

--- a/src/Libraries/Nop.Core/WebHelper.cs
+++ b/src/Libraries/Nop.Core/WebHelper.cs
@@ -151,8 +151,9 @@ namespace Nop.Core
         /// </summary>
         /// <param name="includeQueryString">Value indicating whether to include query strings</param>
         /// <param name="useSsl">Value indicating whether to get SSL secured page URL</param>
+        /// <param name="ignoreCase">Value indicating whether the page URL should be lowercase or not</param>
         /// <returns>Page URL</returns>
-        public virtual string GetThisPageUrl(bool includeQueryString, bool useSsl)
+        public virtual string GetThisPageUrl(bool includeQueryString, bool useSsl, bool ignoreCase = true)
         {
             if (!IsRequestAvailable())
                 return string.Empty;
@@ -164,7 +165,10 @@ namespace Nop.Core
             var url = string.Format("{0}{1}{2}", host, _httpContextAccessor.HttpContext.Request.Path,
                 includeQueryString ? _httpContextAccessor.HttpContext.Request.QueryString.Value : string.Empty);
 
-            return url.ToLowerInvariant();
+            if (ignoreCase)
+                return url.ToLowerInvariant();
+
+            return url;
         }
 
         /// <summary>

--- a/src/Libraries/Nop.Services/Logging/DefaultLogger.cs
+++ b/src/Libraries/Nop.Services/Logging/DefaultLogger.cs
@@ -228,7 +228,7 @@ namespace Nop.Services.Logging
                 FullMessage = fullMessage,
                 IpAddress = _webHelper.GetCurrentIpAddress(),
                 Customer = customer,
-                PageUrl = _webHelper.GetThisPageUrl(true),
+                PageUrl = _webHelper.GetThisPageUrl(true, _webHelper.IsCurrentConnectionSecured(), false),
                 ReferrerUrl = _webHelper.GetUrlReferrer(),
                 CreatedOnUtc = DateTime.UtcNow
             };


### PR DESCRIPTION
Created a new default parameter in the method IWebHelper.GetThisPageUrl to return the page URL "as-is", without lowercase.

We now have the following scenario in IWebHelper:
GetThisPageUrl (bool includeQueryString)
GetThisPageUrl (bool includeQueryString, bool useSsl, bool ignoreCase = true)

Adjust DefaultLogger.InsertLog to use new parameter, passing value "false":
_webHelper.GetThisPageUrl(true, _webHelper.IsCurrentConnectionSecured(), false)