### PR TITLE
window.load even has been deprecated in jQuery 1.8 and removed in 3.0

### DIFF
--- a/src/Plugins/Nop.Plugin.Widgets.NivoSlider/Views/PublicInfo.cshtml
+++ b/src/Plugins/Nop.Plugin.Widgets.NivoSlider/Views/PublicInfo.cshtml
@@ -68,7 +68,7 @@
 </div>
 
 <script type="text/javascript">
-    $(window).load(function () {
+    $(window).on("load", function () {
         $('#nivo-slider').nivoSlider();
     });
 </script>


### PR DESCRIPTION
I found out that Nivo Slider plugin raised JavaScript error when I was developing a theme using jQuery 3 and Foundation framework.  The error was caused by the fact that .load event has been deprecated and removed: https://api.jquery.com/load-event/