### PR TITLE
Fixed cache key typo in nivo slider plugin.

### DIFF
--- a/src/Plugins/Nop.Plugin.Widgets.NivoSlider/Infrastructure/Cache/ModelCacheEventConsumer.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.NivoSlider/Infrastructure/Cache/ModelCacheEventConsumer.cs
@@ -1,7 +1,6 @@
 ﻿using Nop.Core.Caching;
 using Nop.Core.Domain.Configuration;
 using Nop.Core.Events;
-using Nop.Core.Infrastructure;
 using Nop.Services.Events;
 
 namespace Nop.Plugin.Widgets.NivoSlider.Infrastructure.Cache
@@ -9,7 +8,7 @@ namespace Nop.Plugin.Widgets.NivoSlider.Infrastructure.Cache
     /// <summary>
     /// Model cache event consumer (used for caching of presentation layer models)
     /// </summary>
-    public partial class ModelCacheEventConsumer: 
+    public partial class ModelCacheEventConsumer :
         IConsumer<EntityInserted<Setting>>,
         IConsumer<EntityUpdated<Setting>>,
         IConsumer<EntityDeleted<Setting>>
@@ -20,16 +19,16 @@ namespace Nop.Plugin.Widgets.NivoSlider.Infrastructure.Cache
         /// <remarks>
         /// {0} : picture id
         /// </remarks>
-        public const string PICTURE_URL_MODEL_KEY = "Nop.plugins.widgets.nivosrlider.pictureurl-{0}";
-        public const string PICTURE_URL_PATTERN_KEY = "Nop.plugins.widgets.nivosrlider";
-        
+        public const string PICTURE_URL_MODEL_KEY = "Nop.plugins.widgets.nivoslider.pictureurl-{0}";
+        public const string PICTURE_URL_PATTERN_KEY = "Nop.plugins.widgets.nivoslider";
+
         private readonly IStaticCacheManager _cacheManager;
-        
+
         public ModelCacheEventConsumer(IStaticCacheManager cacheManager)
         {
             this._cacheManager = cacheManager;
         }
-        
+
         public void HandleEvent(EntityInserted<Setting> eventMessage)
         {
             _cacheManager.RemoveByPattern(PICTURE_URL_PATTERN_KEY);


### PR DESCRIPTION
#2397 Fixed cache key typo (nivosrlider -> nivoslider) in nivoslider plugin. Also removed the unused using statement **Nop.Core.Infrastructure**.
@AndreiMaz and @mariannk please review the pull request.