### PR TITLE
Avoid calculating tax rate when it is not necessary

### DIFF
--- a/src/Libraries/Nop.Services/Tax/TaxService.cs
+++ b/src/Libraries/Nop.Services/Tax/TaxService.cs
@@ -413,6 +413,9 @@ namespace Nop.Services.Tax
             decimal price, bool includingTax, Customer customer,
             bool priceIncludesTax, out decimal taxRate)
         {
+            bool isTaxable = false;
+            taxRate = decimal.Zero;
+
             //no need to calculate tax rate if passed "price" is 0
             if (price == decimal.Zero)
             {
@@ -420,12 +423,10 @@ namespace Nop.Services.Tax
                 return taxRate;
             }
 
-
-            bool isTaxable;
-            GetTaxRate(product, taxCategoryId, customer, price, out taxRate, out isTaxable);
-
             if (priceIncludesTax)
             {
+                GetTaxRate(product, taxCategoryId, customer, price, out taxRate, out isTaxable);
+
                 //"price" already includes tax
                 if (includingTax)
                 {
@@ -448,6 +449,7 @@ namespace Nop.Services.Tax
                 //"price" doesn't include tax
                 if (includingTax)
                 {
+                    GetTaxRate(product, taxCategoryId, customer, price, out taxRate, out isTaxable);
                     //we should calculate price WITH tax
                     //do it only when price is taxable
                     if (isTaxable)


### PR DESCRIPTION
Background. A client is using a tax calculation plugin that is a little resource intensive. The product catalog is configured not to include tax in the product price but the way 'GetProductPrice' is currently implemented it still calculates the tax rate for every product on the page and then discards the result. This is adding about ~2000 milliseconds to my client's product catalog page. This is a simple change that just avoids calculating the tax rate if it is not necessary.