### PR TITLE
#2463 Custom label tag helper is added

### DIFF
--- a/src/Presentation/Nop.Web.Framework/TagHelpers/Public/LabelTagHelper.cs
+++ b/src/Presentation/Nop.Web.Framework/TagHelpers/Public/LabelTagHelper.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using System.Threading.Tasks;
+
+namespace Nop.Web.Framework.TagHelpers.Public
+{
+    [HtmlTargetElement("label",Attributes =ForAttributeName)]
+    public class LabelTagHelper : Microsoft.AspNetCore.Mvc.TagHelpers.LabelTagHelper
+    {
+        private const string ForAttributeName = "asp-for";
+
+        public LabelTagHelper(IHtmlGenerator generator) : base(generator)
+        {
+        }
+
+        public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+        {
+            await base.ProcessAsync(context, output);
+
+            output.Content.Append(":");
+        }
+    }
+}


### PR DESCRIPTION
- A custom label tag helper is added to render colon after a local in public area #2463 
- For this purpose a new file called **LabelTagHelper.cs** is added in Nop.Web.Framework project.

@AndreiMaz and @mariannk please review the pull request