### PR TITLE
ModifyQueryString and RemoveQueryString methods were failing in unit tests

### DIFF
--- a/src/Tests/Nop.Core.Tests/WebHelperTests.cs
+++ b/src/Tests/Nop.Core.Tests/WebHelperTests.cs
@@ -82,7 +82,7 @@ namespace Nop.Core.Tests
         public void Can_remove_queryString_should_ignore_input_parameter_case()
         {
             _webHelper.RemoveQueryString("http://www.example.com/?param1=value1&parAm2=value2", "paRAm1")
-                .ShouldEqual("http://www.example.com/?param2=value2");
+                .ShouldEqual("http://www.example.com/?parAm2=value2");
         }
 
         [Test]
@@ -103,14 +103,14 @@ namespace Nop.Core.Tests
         public void Can_modify_queryString_with_anchor()
         {
             _webHelper.ModifyQueryString("http://www.example.com/?param1=value1&param2=value2", "param1=value3", "Test")
-                .ShouldEqual("http://www.example.com/?param1=value3&param2=value2#test");
+                .ShouldEqual("http://www.example.com/?param1=value3&param2=value2#Test");
         }
 
         [Test]
         public void Can_modify_queryString_new_anchor_should_remove_previous_one()
         {
             _webHelper.ModifyQueryString("http://www.example.com/?param1=value1&param2=value2#test1", "param1=value3", "Test2")
-                .ShouldEqual("http://www.example.com/?param1=value3&param2=value2#test2");
+                .ShouldEqual("http://www.example.com/?param1=value3&param2=value2#Test2");
         }
     }
 

--- a/src/Tests/Nop.Core.Tests/WebHelperTests.cs
+++ b/src/Tests/Nop.Core.Tests/WebHelperTests.cs
@@ -79,13 +79,6 @@ namespace Nop.Core.Tests
         }
 
         [Test]
-        public void Can_remove_queryString_should_ignore_input_parameter_case()
-        {
-            _webHelper.RemoveQueryString("http://www.example.com/?param1=value1&parAm2=value2", "paRAm1")
-                .ShouldEqual("http://www.example.com/?parAm2=value2");
-        }
-
-        [Test]
         public void Can_modify_queryString()
         {
             //first param (?)


### PR DESCRIPTION
I don't think RemoveQueryString and ModifyQueryString should change anchor to lowercase, but some tests were failing because they were expecting anchor in lowercase. 