### PR TITLE
[FEATURE] Optional encryption of settings.json to prevent exposing password as cleartext.

### DIFF
--- a/src/Libraries/Nop.Core/Data/DataSettings.cs
+++ b/src/Libraries/Nop.Core/Data/DataSettings.cs
@@ -1,5 +1,7 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Nop.Core.Data
 {
@@ -8,12 +10,14 @@ namespace Nop.Core.Data
     /// </summary>
     public partial class DataSettings
     {
+        protected ProtectedDataService ProtectedDataService = new ProtectedDataService();
+
         /// <summary>
         /// Ctor
         /// </summary>
         public DataSettings()
         {
-            RawDataSettings=new Dictionary<string, string>();
+            RawDataSettings = new Dictionary<string, string>();
         }
 
         /// <summary>
@@ -27,6 +31,11 @@ namespace Nop.Core.Data
         public string DataConnectionString { get; set; }
 
         /// <summary>
+        /// Should DataConnectionString be encrypted
+        /// </summary>
+        public bool EncryptStringSettings { get; set; }
+
+        /// <summary>
         /// Raw settings file
         /// </summary>
         public IDictionary<string, string> RawDataSettings { get; private set; }
@@ -37,7 +46,90 @@ namespace Nop.Core.Data
         /// <returns></returns>
         public bool IsValid()
         {
-            return !string.IsNullOrEmpty(this.DataProvider) && !string.IsNullOrEmpty(this.DataConnectionString);
+            return !String.IsNullOrEmpty(this.DataProvider) && !String.IsNullOrEmpty(this.DataConnectionString);
+        }
+
+        /// <summary>
+        /// Returns true if any STRING properties are in a decrypted state as determined by ProtectionDataService
+        /// </summary>
+        /// <returns></returns>
+        public bool HasAnyDecryptedDataSettings()
+        {
+            bool retVal = false;
+            PropertyInfo[] properties = this.GetType().GetProperties();
+
+            foreach (var property in properties)
+            {
+                if (property.PropertyType == typeof(string) && property.GetValue(this) != null && !ProtectedDataService.IsCipherText(property.GetValue(this).ToString()))
+                {
+                    retVal = true;
+                }
+            }
+            return retVal;
+        }
+
+        /// <summary>
+        /// Returns true if any STRING properties are in an encrypted state as determined by ProtectionDataService
+        /// </summary>
+        /// <returns></returns>
+        public bool HasAnyEncryptedDataSettings()
+        {
+            bool retVal = false;
+            PropertyInfo[] properties = this.GetType().GetProperties();
+
+            foreach (var property in properties)
+            {
+                if (property.PropertyType == typeof(string) && property.GetValue(this) != null && ProtectedDataService.IsCipherText(property.GetValue(this).ToString()))
+                {
+                    retVal = true;
+                }
+            }
+            return retVal;
+        }
+
+        /// <summary>
+        /// Decrypts all STRING PROPERTIES.  If already decrypted then they are unchanged.
+        /// </summary>
+        /// <returns></returns>
+        public void Decrypt()
+        {
+            PropertyInfo[] properties = this.GetType().GetProperties();
+
+            foreach (var property in properties)
+            {
+                if (property.PropertyType == typeof(string) && property.GetValue(this) != null && ProtectedDataService.IsCipherText(property.GetValue(this).ToString()))
+                {
+                    string clearText = ProtectedDataService.GetClearText(property.GetValue(this).ToString());
+                    property.SetValue(this, clearText);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Encrypts all STRING PROPERTIES.  If already encrypted then they are unchanged.
+        /// </summary>
+        /// <returns></returns>
+        public void Encrypt()
+        {
+            PropertyInfo[] properties = this.GetType().GetProperties();
+
+            foreach (var property in properties)
+            {
+                if (property.PropertyType == typeof(string) && property.GetValue(this) != null && !ProtectedDataService.IsCipherText(property.GetValue(this).ToString()))
+                {
+                    string cipherText = ProtectedDataService.GetCipherText(this.ProtectedDataService.GetCipherText(property.GetValue(this).ToString()));
+                    property.SetValue(this, cipherText);
+                }
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public DataSettings GetClone()
+        {
+            return JsonConvert.DeserializeObject<DataSettings>(JsonConvert.SerializeObject(this, Formatting.None));
         }
     }
 }

--- a/src/Libraries/Nop.Core/Data/ProtectedDataService.cs
+++ b/src/Libraries/Nop.Core/Data/ProtectedDataService.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Security.Cryptography;
+using System.Security.Principal;
+using System.Text;
+
+namespace Nop.Core.Data
+{
+    /// <summary>
+    /// Provides utility methods to allow easy encryption and description of small pieces of data with keys based on the user that the program is being run under.
+    /// </summary>
+    public class ProtectedDataService
+    {
+        protected const DataProtectionScope PROTECTION_SCOPE = DataProtectionScope.CurrentUser;  //This value determines if ProtectedData will happen at the user account level or machine level
+        private const string ENCRYPTION_PREFIX = "ENCRYPT::"; //This will be prepended to the beginning of every encrypted string so we can easily determine if it's encrypted or not.
+
+        /// <summary>
+        /// Returns the clear text version of ciphertext generated from this class.  When it receives a string without the correct prefix it will function as a null object and return the input parameter.
+        /// </summary>
+        /// <param name="cipherText">Text to be deciphered.  Should begin with ENCRYPTION_PREFIX value and be base64 encoded.</param>
+        /// <returns></returns>
+        public string GetClearText(string cipherText)
+        {
+            if (!IsCipherText(cipherText))
+                return cipherText;
+            var decodedCipherText = System.Convert.FromBase64String(cipherText.Substring(ENCRYPTION_PREFIX.Length));
+            return Encoding.UTF8.GetString(ProtectedData.Unprotect(decodedCipherText, GetEntropy(), PROTECTION_SCOPE));
+        }
+
+        /// <summary>
+        /// Returns ciphertext that is base64 encoded and prefixed with the ENCRYPTION_PREFIX value.
+        /// </summary>
+        /// <param name="clearText">Plain text string to be encrypted.</param>
+        /// <returns></returns>
+        public string GetCipherText(string clearText)
+        {
+            if (IsCipherText(clearText))
+                return clearText;
+            byte[] clearTextBytes = Encoding.UTF8.GetBytes(clearText);
+            var unencodedCipherText = ProtectedData.Protect(clearTextBytes, GetEntropy(), PROTECTION_SCOPE);
+            var encodedCipherText = System.Convert.ToBase64String(unencodedCipherText);
+            return PrefixSettingWithEncryptionFlag(encodedCipherText);
+        }
+
+        /// <summary>
+        /// Helper method that checks to see if a string starts with ENCRYPTION_PREFIX value
+        /// </summary>
+        /// <param name="value">text to check.</param>
+        /// <returns></returns>
+        public bool IsCipherText(string value)
+        {
+            return value.StartsWith(ENCRYPTION_PREFIX);
+        }
+
+        /// <summary>
+        /// Returns entropy that is required for ProtectedData to work.  The entropy is non-changing based on the user the code is running under.
+        /// </summary>
+        /// <returns></returns>
+        protected byte[] GetEntropy()
+        {   //TODO: This may not be the best way to create repeatable, secure entropy.
+            byte[] entropy = Encoding.ASCII.GetBytes(WindowsIdentity.GetCurrent().Name);
+            Array.Resize(ref entropy, 16);
+            return entropy;
+        }
+
+        /// <summary>
+        /// Helper method that returns a string prefixed with the value of ENCRYPTION_PREFIX
+        /// </summary>
+        /// <param name="cipherText">ciper text that needs to have prefix attached to denote that it is cipher text.</param>
+        /// <returns></returns>
+        protected string PrefixSettingWithEncryptionFlag(string cipherText)
+        {
+            return $"{ENCRYPTION_PREFIX}{cipherText}";
+        }
+    }
+}


### PR DESCRIPTION
This feature addresses the narrow scope security case where misconfigured IIS allows for the downloading of settings.txt or settings.json.  

In the current codebase these files store database passwords and user accounts in as unencrypted clear text.  

This feature uses dotNet's ProtectedData API (scoped to the account the application is running under) to encrypt the values found in the dataSettings.json file so that in the event the file is exposed the sensitive information isn't available in clear text.
