### PR TITLE
Add external identificators for products load

### DIFF
--- a/src/Libraries/Nop.Core/Domain/Catalog/Category.cs
+++ b/src/Libraries/Nop.Core/Domain/Catalog/Category.cs
@@ -128,5 +128,15 @@ namespace Nop.Core.Domain.Catalog
             get { return _appliedDiscounts ?? (_appliedDiscounts = new List<Discount>()); }
             protected set { _appliedDiscounts = value; }
         }
+
+        /// <summary>
+        /// Used to identify products supplier
+        /// </summary>
+        public int? ExternalType { get; set; }
+        
+        /// <summary>
+        /// Used to identify category in products supplier price list
+        /// </summary>
+        public long? ExternalId { get; set; }
     }
 }

--- a/src/Libraries/Nop.Core/Domain/Catalog/Manufacturer.cs
+++ b/src/Libraries/Nop.Core/Domain/Catalog/Manufacturer.cs
@@ -113,5 +113,15 @@ namespace Nop.Core.Domain.Catalog
             get { return _appliedDiscounts ?? (_appliedDiscounts = new List<Discount>()); }
             protected set { _appliedDiscounts = value; }
         }
+
+        /// <summary>
+        /// Used to identify products supplier
+        /// </summary>
+        public int? ExternalType { get; set; }
+
+        /// <summary>
+        /// Used to identify manufacturer in products supplier price list
+        /// </summary>
+        public long? ExternalId { get; set; }
     }
 }

--- a/src/Libraries/Nop.Core/Domain/Catalog/Product.cs
+++ b/src/Libraries/Nop.Core/Domain/Catalog/Product.cs
@@ -771,5 +771,15 @@ namespace Nop.Core.Domain.Catalog
             get { return _productWarehouseInventory ?? (_productWarehouseInventory = new List<ProductWarehouseInventory>()); }
             protected set { _productWarehouseInventory = value; }
         }
+
+        /// <summary>
+        /// Used to identify products supplier
+        /// </summary>
+        public int? ExternalType { get; set; }
+
+        /// <summary>
+        /// Used to identify product in supplier price list
+        /// </summary>
+        public long? ExternalId { get; set; }
     }
 }


### PR DESCRIPTION
We often need to load products automatically from external sources and update them (from product suppliers). To identify that product is loaded from external supplier and update it we need two references for it. One to identify supplier (I use ExternalType for it) and one to identify product in supplier price list (or on the web page). Also we need same identificators for manufacturer and for categories (to copy supplier manufacturers and categories list). Then they can be used to automatically copy products to shop published categories and etc. I suggest we add such identificators to original database. Maybe with different names. But I think name should start from "External" for easy remembering.