### PR TITLE
Many categories part 1 - Nop.Web top menu and navigation speedup

### DIFF
--- a/src/Libraries/Nop.Core/Domain/Common/CommonSettings.cs
+++ b/src/Libraries/Nop.Core/Domain/Common/CommonSettings.cs
@@ -115,5 +115,10 @@ namespace Nop.Core.Domain.Common
         /// Gets or sets a value indicating whether "accept terms of service" links should be open in popup window. If disabled, then they'll be open on a new page.
         /// </summary>
         public bool PopupForTermsOfServiceLinks { get; set; }
+
+        /// <summary>
+        /// Used for different approach when there are a lot of categories and/or manufacturers
+        /// </summary>
+        public bool LargeDatabase { get; set; }
     }
 }

--- a/src/Libraries/Nop.Services/Catalog/ICategoryService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ICategoryService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Nop.Core;
 using Nop.Core.Domain.Catalog;
+using Nop.Core.Domain.Seo;
 
 namespace Nop.Services.Catalog
 {
@@ -14,6 +15,12 @@ namespace Nop.Services.Catalog
         /// </summary>
         /// <param name="category">Category</param>
         void DeleteCategory(Category category);
+
+        List<Category> GetAllCategoriesInTopMenu();
+
+        List<Category> GetCategoriesForNavigation(int CategoryId);
+
+        List<UrlRecord> LoadLocalizedNamesAndSeNames(ref IList<Category> categories);
 
         /// <summary>
         /// Gets all categories

--- a/src/Libraries/Nop.Services/Catalog/IProductService.cs
+++ b/src/Libraries/Nop.Services/Catalog/IProductService.cs
@@ -228,7 +228,7 @@ namespace Nop.Services.Catalog
         /// <returns>Products</returns>
         IPagedList<Product> GetLowStockProducts(int vendorId = 0,
             int pageIndex = 0, int pageSize = int.MaxValue);
-
+        int GetLowStockProductsCount(int vendorId = 0);
         /// <summary>
         /// Get low stock product combinations
         /// </summary>
@@ -238,7 +238,7 @@ namespace Nop.Services.Catalog
         /// <returns>Product combinations</returns>
         IPagedList<ProductAttributeCombination> GetLowStockProductCombinations(int vendorId = 0,
             int pageIndex = 0, int pageSize = int.MaxValue);
-
+        int GetLowStockProductCombinationsCount(int vendorId = 0);
         /// <summary>
         /// Gets a product by SKU
         /// </summary>

--- a/src/Libraries/Nop.Services/Installation/CodeFirstInstallationService.cs
+++ b/src/Libraries/Nop.Services/Installation/CodeFirstInstallationService.cs
@@ -5891,7 +5891,8 @@ namespace Nop.Services.Installation
                 RenderXuaCompatible = false,
                 XuaCompatibleValue = "IE=edge",
                 BbcodeEditorOpenLinksInNewWindow = false,
-                PopupForTermsOfServiceLinks = true
+                PopupForTermsOfServiceLinks = true,
+                LargeDatabase = false
             });
 
             settingService.SaveSetting(new SeoSettings

--- a/src/NopCommerce.sln
+++ b/src/NopCommerce.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.16
+VisualStudioVersion = 15.0.27004.2009
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libraries", "Libraries", "{E4ACA93B-D3DE-4557-B069-F1DB42925A4B}"
 EndProject

--- a/src/Presentation/Nop.Web/Areas/Admin/Controllers/CategoryController.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Controllers/CategoryController.cs
@@ -28,6 +28,7 @@ using Nop.Web.Framework.Controllers;
 using Nop.Web.Framework.Kendoui;
 using Nop.Web.Framework.Mvc;
 using Nop.Web.Framework.Mvc.Filters;
+using Nop.Core.Domain.Common;
 
 namespace Nop.Web.Areas.Admin.Controllers
 {
@@ -57,6 +58,7 @@ namespace Nop.Web.Areas.Admin.Controllers
         private readonly IWorkContext _workContext;
         private readonly IImportManager _importManager;
         private readonly IStaticCacheManager _cacheManager;
+        private readonly CommonSettings _commonSettings;
         
         #endregion
         
@@ -81,7 +83,8 @@ namespace Nop.Web.Areas.Admin.Controllers
             CatalogSettings catalogSettings,
             IWorkContext workContext,
             IImportManager importManager, 
-            IStaticCacheManager cacheManager)
+            IStaticCacheManager cacheManager,
+            CommonSettings commonSettings)
         {
             this._categoryService = categoryService;
             this._categoryTemplateService = categoryTemplateService;
@@ -105,6 +108,7 @@ namespace Nop.Web.Areas.Admin.Controllers
             this._workContext = workContext;
             this._importManager = importManager;
             this._cacheManager = cacheManager;
+            this._commonSettings = commonSettings;
         }
         
         #endregion
@@ -158,14 +162,17 @@ namespace Nop.Web.Areas.Admin.Controllers
             if (model == null)
                 throw new ArgumentNullException(nameof(model));
 
-            model.AvailableCategories.Add(new SelectListItem
+            if (!_commonSettings.LargeDatabase)
             {
-                Text = _localizationService.GetResource("Admin.Catalog.Categories.Fields.Parent.None"),
-                Value = "0"
-            });
-            var categories = SelectListHelper.GetCategoryList(_categoryService, _cacheManager, true);
-            foreach (var c in categories)
-                model.AvailableCategories.Add(c);
+                model.AvailableCategories.Add(new SelectListItem
+                {
+                    Text = _localizationService.GetResource("Admin.Catalog.Categories.Fields.Parent.None"),
+                    Value = "0"
+                });
+                var categories = SelectListHelper.GetCategoryList(_categoryService, _cacheManager, true);
+                foreach (var c in categories)
+                    model.AvailableCategories.Add(c);
+            }
         }
 
         protected virtual void PrepareTemplatesModel(CategoryModel model)
@@ -702,11 +709,13 @@ namespace Nop.Web.Areas.Admin.Controllers
             
             var model = new CategoryModel.AddCategoryProductModel();
             //categories
-            model.AvailableCategories.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
-            var categories = SelectListHelper.GetCategoryList(_categoryService, _cacheManager, true);
-            foreach (var c in categories)
-                model.AvailableCategories.Add(c);
-
+            if (!_commonSettings.LargeDatabase)
+            {
+                model.AvailableCategories.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
+                var categories = SelectListHelper.GetCategoryList(_categoryService, _cacheManager, true);
+                foreach (var c in categories)
+                    model.AvailableCategories.Add(c);
+            }
             //manufacturers
             model.AvailableManufacturers.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
             var manufacturers = SelectListHelper.GetManufacturerList(_manufacturerService, _cacheManager, true);

--- a/src/Presentation/Nop.Web/Areas/Admin/Controllers/CustomerRoleController.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Controllers/CustomerRoleController.cs
@@ -22,6 +22,7 @@ using Nop.Services.Vendors;
 using Nop.Web.Framework.Controllers;
 using Nop.Web.Framework.Kendoui;
 using Nop.Web.Framework.Mvc.Filters;
+using Nop.Core.Domain.Common;
 
 namespace Nop.Web.Areas.Admin.Controllers
 {
@@ -41,6 +42,7 @@ namespace Nop.Web.Areas.Admin.Controllers
         private readonly IWorkContext _workContext;
 	    private readonly TaxSettings _taxSettings;
         private readonly IStaticCacheManager _cacheManager;
+        private readonly CommonSettings _commonSettings;
 
         #endregion
 
@@ -57,7 +59,8 @@ namespace Nop.Web.Areas.Admin.Controllers
             IVendorService vendorService,
             IWorkContext workContext,
             TaxSettings taxSettings,
-            IStaticCacheManager cacheManager)
+            IStaticCacheManager cacheManager,
+            CommonSettings commonSettings)
 		{
             this._customerService = customerService;
             this._localizationService = localizationService;
@@ -71,6 +74,7 @@ namespace Nop.Web.Areas.Admin.Controllers
             this._workContext = workContext;
 		    this._taxSettings = taxSettings;
             this._cacheManager = cacheManager;
+            this._commonSettings = commonSettings;
 		}
 
 		#endregion 
@@ -264,10 +268,13 @@ namespace Nop.Web.Areas.Admin.Controllers
             };
 
             //categories
-            model.AvailableCategories.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
-            var categories = SelectListHelper.GetCategoryList(_categoryService, _cacheManager, true);
-            foreach (var c in categories)
-                model.AvailableCategories.Add(c);
+            if (!_commonSettings.LargeDatabase)
+            {
+                model.AvailableCategories.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
+                var categories = SelectListHelper.GetCategoryList(_categoryService, _cacheManager, true);
+                foreach (var c in categories)
+                    model.AvailableCategories.Add(c);
+            }
 
             //manufacturers
             model.AvailableManufacturers.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });

--- a/src/Presentation/Nop.Web/Areas/Admin/Controllers/DiscountController.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Controllers/DiscountController.cs
@@ -27,6 +27,7 @@ using Nop.Web.Framework.Extensions;
 using Nop.Web.Framework.Kendoui;
 using Nop.Web.Framework.Mvc;
 using Nop.Web.Framework.Mvc.Filters;
+using Nop.Core.Domain.Common;
 
 namespace Nop.Web.Areas.Admin.Controllers
 {
@@ -52,6 +53,7 @@ namespace Nop.Web.Areas.Admin.Controllers
         private readonly IOrderService _orderService;
         private readonly IPriceFormatter _priceFormatter;
         private readonly IStaticCacheManager _cacheManager;
+        private readonly CommonSettings _commonSettings;
 
         #endregion
 
@@ -74,7 +76,8 @@ namespace Nop.Web.Areas.Admin.Controllers
             IVendorService vendorService,
             IOrderService orderService,
             IPriceFormatter priceFormatter,
-            IStaticCacheManager cacheManager)
+            IStaticCacheManager cacheManager,
+            CommonSettings commonSettings)
         {
             this._discountService = discountService;
             this._localizationService = localizationService;
@@ -94,6 +97,7 @@ namespace Nop.Web.Areas.Admin.Controllers
             this._orderService = orderService;
             this._priceFormatter = priceFormatter;
             this._cacheManager = cacheManager;
+            this._commonSettings = commonSettings;
         }
 
         #endregion
@@ -604,10 +608,13 @@ namespace Nop.Web.Areas.Admin.Controllers
 
             var model = new DiscountModel.AddProductToDiscountModel();
             //categories
-            model.AvailableCategories.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
-            var categories = SelectListHelper.GetCategoryList(_categoryService, _cacheManager, true);
-            foreach (var c in categories)
-                model.AvailableCategories.Add(c);
+            if (!_commonSettings.LargeDatabase)
+            {
+                model.AvailableCategories.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
+                var categories = SelectListHelper.GetCategoryList(_categoryService, _cacheManager, true);
+                foreach (var c in categories)
+                    model.AvailableCategories.Add(c);
+            }
 
             //manufacturers
             model.AvailableManufacturers.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });

--- a/src/Presentation/Nop.Web/Areas/Admin/Controllers/ManufacturerController.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Controllers/ManufacturerController.cs
@@ -28,6 +28,7 @@ using Nop.Web.Framework.Controllers;
 using Nop.Web.Framework.Kendoui;
 using Nop.Web.Framework.Mvc;
 using Nop.Web.Framework.Mvc.Filters;
+using Nop.Core.Domain.Common;
 
 namespace Nop.Web.Areas.Admin.Controllers
 {
@@ -57,6 +58,7 @@ namespace Nop.Web.Areas.Admin.Controllers
         private readonly IWorkContext _workContext;
         private readonly IImportManager _importManager;
         private readonly IStaticCacheManager _cacheManager;
+        private readonly CommonSettings _commonSettings;
 
         #endregion
 
@@ -83,7 +85,8 @@ namespace Nop.Web.Areas.Admin.Controllers
             CatalogSettings catalogSettings,
             IWorkContext workContext,
             IImportManager importManager, 
-            IStaticCacheManager cacheManager)
+            IStaticCacheManager cacheManager,
+            CommonSettings commonSettings)
         {
             this._categoryService = categoryService;
             this._manufacturerTemplateService = manufacturerTemplateService;
@@ -107,6 +110,7 @@ namespace Nop.Web.Areas.Admin.Controllers
             this._workContext = workContext;
             this._importManager = importManager;
             this._cacheManager = cacheManager;
+            this._commonSettings = commonSettings;
         }
 
         #endregion
@@ -683,10 +687,13 @@ namespace Nop.Web.Areas.Admin.Controllers
 
             var model = new ManufacturerModel.AddManufacturerProductModel();
             //categories
-            model.AvailableCategories.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
-            var categories = SelectListHelper.GetCategoryList(_categoryService, _cacheManager, true);
-            foreach (var c in categories)
-                model.AvailableCategories.Add(c);
+            if (!_commonSettings.LargeDatabase)
+            {
+                model.AvailableCategories.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
+                var categories = SelectListHelper.GetCategoryList(_categoryService, _cacheManager, true);
+                foreach (var c in categories)
+                    model.AvailableCategories.Add(c);
+            }
 
             //manufacturers
             model.AvailableManufacturers.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });

--- a/src/Presentation/Nop.Web/Areas/Admin/Controllers/OrderController.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Controllers/OrderController.cs
@@ -96,6 +96,7 @@ namespace Nop.Web.Areas.Admin.Controllers
 	    private readonly IPictureService _pictureService;
         private readonly ICustomerActivityService _customerActivityService;
 	    private readonly IStaticCacheManager _cacheManager;
+        private readonly CommonSettings _commonSettings;
 
         private readonly OrderSettings _orderSettings;
         private readonly CurrencySettings _currencySettings;
@@ -155,7 +156,8 @@ namespace Nop.Web.Areas.Admin.Controllers
             TaxSettings taxSettings,
             MeasureSettings measureSettings,
             AddressSettings addressSettings,
-            ShippingSettings shippingSettings)
+            ShippingSettings shippingSettings,
+            CommonSettings commonSettings)
 		{
             this._orderService = orderService;
             this._orderReportService = orderReportService;
@@ -205,6 +207,7 @@ namespace Nop.Web.Areas.Admin.Controllers
             this._measureSettings = measureSettings;
             this._addressSettings = addressSettings;
             this._shippingSettings = shippingSettings;
+            this._commonSettings = commonSettings;
 		}
         
         #endregion
@@ -2608,10 +2611,13 @@ namespace Nop.Web.Areas.Admin.Controllers
                 OrderId = orderId
             };
             //categories
-            model.AvailableCategories.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
-            var categories = SelectListHelper.GetCategoryList(_categoryService, _cacheManager, true);
-            foreach (var c in categories)
-                model.AvailableCategories.Add(c);
+            if (!_commonSettings.LargeDatabase)
+            {
+                model.AvailableCategories.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
+                var categories = SelectListHelper.GetCategoryList(_categoryService, _cacheManager, true);
+                foreach (var c in categories)
+                    model.AvailableCategories.Add(c);
+            }
 
             //manufacturers
             model.AvailableManufacturers.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
@@ -3964,10 +3970,13 @@ namespace Nop.Web.Areas.Admin.Controllers
             model.AvailablePaymentStatuses.Insert(0, new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
 
             //categories
-            model.AvailableCategories.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
-            var categories = SelectListHelper.GetCategoryList(_categoryService, _cacheManager, true);
-            foreach (var c in categories)
-                model.AvailableCategories.Add(c);
+            if (!_commonSettings.LargeDatabase)
+            {
+                model.AvailableCategories.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
+                var categories = SelectListHelper.GetCategoryList(_categoryService, _cacheManager, true);
+                foreach (var c in categories)
+                    model.AvailableCategories.Add(c);
+            }
 
             //manufacturers
             model.AvailableManufacturers.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
@@ -4058,10 +4067,13 @@ namespace Nop.Web.Areas.Admin.Controllers
             };
 
             //categories
-            model.AvailableCategories.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
-            var categories = SelectListHelper.GetCategoryList(_categoryService, _cacheManager, true);
-            foreach (var c in categories)
-                model.AvailableCategories.Add(c);
+            if (!_commonSettings.LargeDatabase)
+            {
+                model.AvailableCategories.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
+                var categories = SelectListHelper.GetCategoryList(_categoryService, _cacheManager, true);
+                foreach (var c in categories)
+                    model.AvailableCategories.Add(c);
+            }
 
             //manufacturers
             model.AvailableManufacturers.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });

--- a/src/Presentation/Nop.Web/Areas/Admin/Controllers/PluginController.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Controllers/PluginController.cs
@@ -31,6 +31,7 @@ using Nop.Web.Areas.Admin.Extensions;
 using Nop.Web.Areas.Admin.Models.Plugins;
 using Nop.Web.Framework.Controllers;
 using Nop.Web.Framework.Kendoui;
+using Nop.Core.Domain.Common;
 
 namespace Nop.Web.Areas.Admin.Controllers
 {
@@ -55,6 +56,7 @@ namespace Nop.Web.Areas.Admin.Controllers
         private readonly ICustomerService _customerService;
         private readonly IUploadService _uploadService;
         private readonly IEventPublisher _eventPublisher;
+        private readonly CommonSettings _commonSettings;
 
         #endregion
 
@@ -76,7 +78,8 @@ namespace Nop.Web.Areas.Admin.Controllers
             ICustomerActivityService customerActivityService,
             ICustomerService customerService,
             IUploadService uploadService,
-            IEventPublisher eventPublisher)
+            IEventPublisher eventPublisher,
+            CommonSettings commonSettings)
         {
             this._pluginFinder = pluginFinder;
             this._officialFeedManager = officialFeedManager;
@@ -95,6 +98,7 @@ namespace Nop.Web.Areas.Admin.Controllers
             this._customerService = customerService;
             this._uploadService = uploadService;
             this._eventPublisher = eventPublisher;
+            this._commonSettings = commonSettings;
         }
 
 		#endregion 
@@ -667,10 +671,13 @@ namespace Nop.Web.Areas.Admin.Controllers
             }
 
             //categories
-            var categories = _officialFeedManager.GetCategories();
-            model.AvailableCategories.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
-            foreach (var category in categories)
-                model.AvailableCategories.Add(new SelectListItem { Text = GetCategoryBreadCrumbName(category, categories), Value = category.Id.ToString() });
+            if (!_commonSettings.LargeDatabase)
+            {
+                var categories = _officialFeedManager.GetCategories();
+                model.AvailableCategories.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
+                foreach (var category in categories)
+                    model.AvailableCategories.Add(new SelectListItem { Text = GetCategoryBreadCrumbName(category, categories), Value = category.Id.ToString() });
+            }
             //prices
             model.AvailablePrices.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Common.All"), Value = "0" });
             model.AvailablePrices.Add(new SelectListItem { Text = _localizationService.GetResource("Admin.Configuration.Plugins.OfficialFeed.Price.Free"), Value = "10" });

--- a/src/Presentation/Nop.Web/Areas/Admin/Models/Catalog/ProductModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Models/Catalog/ProductModel.cs
@@ -381,6 +381,9 @@ namespace Nop.Web.Areas.Admin.Models.Catalog
         public IList<int> SelectedCategoryIds { get; set; }
         public IList<SelectListItem> AvailableCategories { get; set; }
 
+        [NopResourceDisplayName("Admin.Catalog.Products.Fields.CategoriesToAdd")]
+        public string CategoriesToAdd { get; set; }
+
         //manufacturers
         [NopResourceDisplayName("Admin.Catalog.Products.Fields.Manufacturers")]
         public IList<int> SelectedManufacturerIds { get; set; }

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Category/ProductAddPopup.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Category/ProductAddPopup.cshtml
@@ -45,12 +45,19 @@
                                         <nop-editor asp-for="SearchProductName" />
                                     </div>
                                 </div>
-                                <div class="form-group" @(Model.AvailableCategories.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>
+                                <div class="form-group">
                                     <div class="col-sm-5">
                                         <nop-label asp-for="SearchCategoryId" />
                                     </div>
                                     <div class="col-sm-7">
-                                        <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                        @if (!Model.AvailableCategories.SelectionIsNotPossible())
+                                        {
+                                            <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                        }
+                                        else
+                                        {
+                                            <nop-editor asp-for="SearchCategoryId" />
+                                        }
                                     </div>
                                 </div>
                                 <div class="form-group" @(Model.AvailableVendors.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Category/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Category/_CreateOrUpdate.Info.cshtml
@@ -88,7 +88,14 @@
                     <nop-label asp-for="ParentCategoryId" />
                 </div>
                 <div class="col-md-9">
+                    @if (!Model.AvailableCategories.SelectionIsNotPossible())
+                    {
                     <nop-select asp-for="ParentCategoryId" asp-items="Model.AvailableCategories" />
+                    }
+                    else
+                    {
+                    <nop-editor asp-for="ParentCategoryId" />
+                    }
                     <span asp-validation-for="ParentCategoryId"></span>
                 </div>
             </div>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/CustomerRole/AssociateProductToCustomerRolePopup.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/CustomerRole/AssociateProductToCustomerRolePopup.cshtml
@@ -51,12 +51,19 @@
                                         <nop-editor asp-for="SearchProductName" />
                                     </div>
                                 </div>
-                                <div class="form-group" @(Model.AvailableCategories.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>
+                                <div class="form-group">
                                     <div class="col-sm-5">
                                         <nop-label asp-for="SearchCategoryId" />
                                     </div>
                                     <div class="col-sm-7">
-                                        <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                        @if (!Model.AvailableCategories.SelectionIsNotPossible())
+                                        {
+                                            <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                        }
+                                        else
+                                        {
+                                            <nop-editor asp-for="SearchCategoryId" />
+                                        }
                                     </div>
                                 </div>
                                 <div class="form-group" @(Model.AvailableVendors.SelectionIsNotPossible() || Model.IsLoggedInAsVendor ? Html.Raw("style='display: none;'") : null)>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Discount/ProductAddPopup.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Discount/ProductAddPopup.cshtml
@@ -47,12 +47,19 @@
                                         <nop-editor asp-for="SearchProductName" />
                                     </div>
                                 </div>
-                                <div class="form-group" @(Model.AvailableCategories.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>
+                                <div class="form-group">
                                     <div class="col-sm-5">
                                         <nop-label asp-for="SearchCategoryId" />
                                     </div>
                                     <div class="col-sm-7">
-                                        <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                        @if (!Model.AvailableCategories.SelectionIsNotPossible())
+                                        {
+                                            <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                        }
+                                        else
+                                        {
+                                            <nop-editor asp-for="SearchCategoryId" />
+                                        }
                                     </div>
                                 </div>
                                 <div class="form-group" @(Model.AvailableVendors.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Manufacturer/ProductAddPopup.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Manufacturer/ProductAddPopup.cshtml
@@ -47,12 +47,19 @@
                                         <nop-editor asp-for="SearchProductName" />
                                     </div>
                                 </div>
-                                <div class="form-group" @(Model.AvailableCategories.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>
+                                <div class="form-group">
                                     <div class="col-sm-5">
                                         <nop-label asp-for="SearchCategoryId" />
                                     </div>
                                     <div class="col-sm-7">
-                                        <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                        @if (!Model.AvailableCategories.SelectionIsNotPossible())
+                                        {
+                                            <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                        }
+                                        else
+                                        {
+                                            <nop-editor asp-for="SearchCategoryId" />
+                                        }
                                     </div>
                                 </div>
                                 <div class="form-group" @(Model.AvailableVendors.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/AddProductToOrder.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/AddProductToOrder.cshtml
@@ -40,12 +40,19 @@
                                     <nop-editor asp-for="SearchProductName" />
                                 </div>
                             </div>
-                            <div class="form-group" @(Model.AvailableCategories.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>
+                            <div class="form-group">
                                 <div class="col-md-4">
                                     <nop-label asp-for="SearchCategoryId" />
                                 </div>
                                 <div class="col-md-8">
-                                    <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                    @if (!Model.AvailableCategories.SelectionIsNotPossible())
+                                    {
+                                        <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                    }
+                                    else
+                                    {
+                                        <nop-editor asp-for="SearchCategoryId" />
+                                    }
                                 </div>
                             </div>
                             <div class="form-group" @(Model.AvailableManufacturers.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/BestsellersReport.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/BestsellersReport.cshtml
@@ -75,7 +75,14 @@
                                     <nop-label asp-for="CategoryId" />
                                 </div>
                                 <div class="col-md-8">
-                                    <nop-select asp-for="CategoryId" asp-items="Model.AvailableCategories" />
+                                    @if (!Model.AvailableCategories.SelectionIsNotPossible())
+                                    {
+                                        <nop-select asp-for="CategoryId" asp-items="Model.AvailableCategories" />
+                                    }
+                                    else
+                                    {
+                                        <nop-editor asp-for="CategoryId" />
+                                    }
                                 </div>
                             </div>
                             <div class="form-group">

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/NeverSoldReport.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/NeverSoldReport.cshtml
@@ -28,12 +28,19 @@
                 <div class="panel-body">
                     <div class="row">
                         <div class="col-md-5">
-                            <div class="form-group" @(Model.AvailableCategories.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>
+                            <div class="form-group">
                                 <div class="col-md-4">
                                     <nop-label asp-for="SearchCategoryId" />
                                 </div>
                                 <div class="col-md-8">
-                                    <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                    @if (!Model.AvailableCategories.SelectionIsNotPossible())
+                                    {
+                                        <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                    }
+                                    else
+                                    {
+                                        <nop-editor asp-for="SearchCategoryId" />
+                                    }
                                 </div>
                             </div>
                             <div class="form-group" @(Model.AvailableManufacturers.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Plugin/OfficialFeed.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Plugin/OfficialFeed.cshtml
@@ -48,7 +48,14 @@
                                     <nop-label asp-for="SearchCategoryId" />
                                 </div>
                                 <div class="col-md-8">
-                                    <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                    @if (!Model.AvailableCategories.SelectionIsNotPossible())
+                                    {
+                                        <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                    }
+                                    else
+                                    {
+                                        <nop-editor asp-for="SearchCategoryId" />
+                                    }
                                 </div>
                             </div>
                             <div class="form-group">

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/AssociateProductToAttributeValuePopup.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/AssociateProductToAttributeValuePopup.cshtml
@@ -50,12 +50,19 @@
                                         <nop-editor asp-for="SearchProductName" />
                                     </div>
                                 </div>
-                                <div class="form-group" @(Model.AvailableCategories.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>
+                                <div class="form-group">
                                     <div class="col-sm-5">
                                         <nop-label asp-for="SearchCategoryId" />
                                     </div>
                                     <div class="col-sm-7">
-                                        <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                        @if (!Model.AvailableCategories.SelectionIsNotPossible())
+                                        {
+                                            <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                        }
+                                        else
+                                        {
+                                            <nop-editor asp-for="SearchCategoryId" />
+                                        }
                                     </div>
                                 </div>
                                 <div class="form-group" @(Model.AvailableVendors.SelectionIsNotPossible() || Model.IsLoggedInAsVendor ? Html.Raw("style='display: none;'") : null)>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/AssociatedProductAddPopup.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/AssociatedProductAddPopup.cshtml
@@ -47,12 +47,19 @@
                                         <nop-editor asp-for="SearchProductName" />
                                     </div>
                                 </div>
-                                <div class="form-group" @(Model.AvailableCategories.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>
+                                <div class="form-group">
                                     <div class="col-sm-5">
                                         <nop-label asp-for="SearchCategoryId" />
                                     </div>
                                     <div class="col-sm-7">
-                                        <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                        @if (!Model.AvailableCategories.SelectionIsNotPossible())
+                                        {
+                                            <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                        }
+                                        else
+                                        {
+                                            <nop-editor asp-for="SearchCategoryId" />
+                                        }
                                     </div>
                                 </div>
                                 <div class="form-group" @(Model.AvailableVendors.SelectionIsNotPossible() || Model.IsLoggedInAsVendor ? Html.Raw("style='display: none;'") : null)>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/BulkEdit.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/BulkEdit.cshtml
@@ -37,12 +37,19 @@
                                             <nop-editor asp-for="SearchProductName" />
                                         </div>
                                     </div>
-                                    <div class="form-group" @(Model.AvailableCategories.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>
+                                    <div class="form-group">
                                         <div class="col-md-4">
                                             <nop-label asp-for="SearchCategoryId" />
                                         </div>
                                         <div class="col-md-8">
-                                            <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                            @if (!Model.AvailableCategories.SelectionIsNotPossible())
+                                            {
+                                                <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                            }
+                                            else
+                                            {
+                                                <nop-editor asp-for="SearchCategoryId" />
+                                            }
                                         </div>
                                     </div>
                                     <div class="form-group" @(Model.AvailableManufacturers.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/CrossSellProductAddPopup.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/CrossSellProductAddPopup.cshtml
@@ -47,12 +47,19 @@
                                         <nop-editor asp-for="SearchProductName" />
                                     </div>
                                 </div>
-                                <div class="form-group" @(Model.AvailableCategories.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>
+                                <div class="form-group">
                                     <div class="col-sm-5">
                                         <nop-label asp-for="SearchCategoryId" />
                                     </div>
                                     <div class="col-sm-7">
-                                        <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                        @if (!Model.AvailableCategories.SelectionIsNotPossible())
+                                        {
+                                            <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                        }
+                                        else
+                                        {
+                                            <nop-editor asp-for="SearchCategoryId" />
+                                        }
                                     </div>
                                 </div>
                                 <div class="form-group" @(Model.AvailableVendors.SelectionIsNotPossible() || Model.IsLoggedInAsVendor ? Html.Raw("style='display: none;'") : null)>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/List.cshtml
@@ -96,15 +96,22 @@
                                         <nop-editor asp-for="SearchProductName" />
                                     </div>
                                 </div>
-                                <div class="form-group" @(Model.AvailableCategories.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>
+                                <div class="form-group">
                                     <div class="col-md-4">
                                         <nop-label asp-for="SearchCategoryId" />
                                     </div>
                                     <div class="col-md-8">
+                                        @if (!Model.AvailableCategories.SelectionIsNotPossible())
+                                        {
                                         <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                        }
+                                        else
+                                        {
+                                        <nop-editor asp-for="SearchCategoryId"/>
+                                        }
                                     </div>
                                 </div>
-                                <div class="form-group" @(Model.AvailableCategories.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>
+                                <div class="form-group">
                                     <div class="col-md-4">
                                         <nop-label asp-for="SearchIncludeSubCategories" />
                                     </div>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/RelatedProductAddPopup.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/RelatedProductAddPopup.cshtml
@@ -47,12 +47,19 @@
                                         <nop-editor asp-for="SearchProductName" />
                                     </div>
                                 </div>
-                                <div class="form-group" @(Model.AvailableCategories.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>
+                                <div class="form-group">
                                     <div class="col-sm-5">
                                         <nop-label asp-for="SearchCategoryId" />
                                     </div>
                                     <div class="col-sm-7">
-                                        <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                        @if (!Model.AvailableCategories.SelectionIsNotPossible())
+                                        {
+                                            <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                        }
+                                        else
+                                        {
+                                            <nop-editor asp-for="SearchCategoryId" />
+                                        }
                                     </div>
                                 </div>
                                 <div class="form-group" @(Model.AvailableVendors.SelectionIsNotPossible() || Model.IsLoggedInAsVendor ? Html.Raw("style='display: none;'") : null)>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/RequiredProductAddPopup.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/RequiredProductAddPopup.cshtml
@@ -36,12 +36,19 @@
                                     <nop-editor asp-for="SearchProductName" />
                                 </div>
                             </div>
-                            <div class="form-group" @(Model.AvailableCategories.SelectionIsNotPossible() ? Html.Raw("style=\"display:none\"") : null)>
+                            <div class="form-group">
                                 <div class="col-sm-5">
                                     <nop-label asp-for="SearchCategoryId" />
                                 </div>
                                 <div class="col-sm-7">
-                                    <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                    @if (!Model.AvailableCategories.SelectionIsNotPossible())
+                                    {
+                                        <nop-select asp-for="SearchCategoryId" asp-items="Model.AvailableCategories" />
+                                    }
+                                    else
+                                    {
+                                        <nop-editor asp-for="SearchCategoryId" />
+                                    }
                                 </div>
                             </div>
                             <div class="form-group" @(Model.AvailableVendors.SelectionIsNotPossible() || Model.IsLoggedInAsVendor ? Html.Raw("style='display: none;'") : null)>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.Info.cshtml
@@ -460,7 +460,7 @@
 
 <div class="raw clearfix">
     <div class="@(Model.ProductEditorSettingsModel.OneColumnProductPage ? "col-md-12" : "col-md-7")">
-        <div class="panel-group">            
+        <div class="panel-group">
             @await Component.InvokeAsync("AdminWidget", new { widgetZone = "admin_product_details_info_column_left_top", additionalData = Model.Id })
             <div class="panel panel-default">
                 <div class="panel-heading">
@@ -546,7 +546,7 @@
                                 <span asp-validation-for="@Model.Locales[item].FullDescription"></span>
                             </div>
                         </div>
-                        
+
                         <input type="hidden" asp-for="@Model.Locales[item].LanguageId" />
                     </div>
                             ,@<div>
@@ -581,103 +581,103 @@
                             ))
                     <div class="form-group">
                         <div class="col-md-3">
-							<nop-label asp-for="Sku" />
+                            <nop-label asp-for="Sku" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="Sku" />
-							<span asp-validation-for="Sku"></span>
+                            <nop-editor asp-for="Sku" />
+                            <span asp-validation-for="Sku"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.Published ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="Published" />
+                            <nop-label asp-for="Published" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="Published" />
-							<span asp-validation-for="Published"></span>
+                            <nop-editor asp-for="Published" />
+                            <span asp-validation-for="Published"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.ProductTags ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="ProductTags" />
+                            <nop-label asp-for="ProductTags" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="ProductTags" />
-							<span asp-validation-for="ProductTags"></span>
+                            <nop-editor asp-for="ProductTags" />
+                            <span asp-validation-for="ProductTags"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.GTIN ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="Gtin" />
+                            <nop-label asp-for="Gtin" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="Gtin" />
-							<span asp-validation-for="Gtin"></span>
+                            <nop-editor asp-for="Gtin" />
+                            <span asp-validation-for="Gtin"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.ManufacturerPartNumber ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="ManufacturerPartNumber" />
+                            <nop-label asp-for="ManufacturerPartNumber" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="ManufacturerPartNumber" />
-							<span asp-validation-for="ManufacturerPartNumber"></span>
+                            <nop-editor asp-for="ManufacturerPartNumber" />
+                            <span asp-validation-for="ManufacturerPartNumber"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.ShowOnHomePage ? null : "advanced-setting")" @(Model.IsLoggedInAsVendor ? Html.Raw("style='display: none;'") : null)>
                         <div class="col-md-3">
-							<nop-label asp-for="ShowOnHomePage" />
+                            <nop-label asp-for="ShowOnHomePage" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="ShowOnHomePage" />
-							<span asp-validation-for="ShowOnHomePage"></span>
+                            <nop-editor asp-for="ShowOnHomePage" />
+                            <span asp-validation-for="ShowOnHomePage"></span>
                         </div>
                     </div>
                     <nop-nested-setting asp-for="ShowOnHomePage">
                         <div class="form-group @(Model.ProductEditorSettingsModel.DisplayOrder ? null : "advanced-setting")" id="pnlDisplayOrder" @(Model.IsLoggedInAsVendor ? Html.Raw("style='display: none;'") : null)>
-                        <div class="col-md-3">
-							<nop-label asp-for="DisplayOrder" />
+                            <div class="col-md-3">
+                                <nop-label asp-for="DisplayOrder" />
+                            </div>
+                            <div class="col-md-9">
+                                <nop-editor asp-for="DisplayOrder" />
+                                <span asp-validation-for="DisplayOrder"></span>
+                            </div>
                         </div>
-                        <div class="col-md-9">
-							<nop-editor asp-for="DisplayOrder" />
-							<span asp-validation-for="DisplayOrder"></span>
-                        </div>
-                    </div>
                     </nop-nested-setting>
                     <div class="form-group @(Model.ProductEditorSettingsModel.AllowCustomerReviews ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="AllowCustomerReviews" />
+                            <nop-label asp-for="AllowCustomerReviews" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="AllowCustomerReviews" />
-							<span asp-validation-for="AllowCustomerReviews"></span>
+                            <nop-editor asp-for="AllowCustomerReviews" />
+                            <span asp-validation-for="AllowCustomerReviews"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.AvailableStartDate ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="AvailableStartDateTimeUtc" />
+                            <nop-label asp-for="AvailableStartDateTimeUtc" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="AvailableStartDateTimeUtc" />
-							<span asp-validation-for="AvailableStartDateTimeUtc"></span>
+                            <nop-editor asp-for="AvailableStartDateTimeUtc" />
+                            <span asp-validation-for="AvailableStartDateTimeUtc"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.AvailableEndDate ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="AvailableEndDateTimeUtc" />
+                            <nop-label asp-for="AvailableEndDateTimeUtc" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="AvailableEndDateTimeUtc" />
-							<span asp-validation-for="AvailableEndDateTimeUtc"></span>
+                            <nop-editor asp-for="AvailableEndDateTimeUtc" />
+                            <span asp-validation-for="AvailableEndDateTimeUtc"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.MarkAsNew ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="MarkAsNew" />
+                            <nop-label asp-for="MarkAsNew" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="MarkAsNew" />
-							<span asp-validation-for="MarkAsNew"></span>
+                            <nop-editor asp-for="MarkAsNew" />
+                            <span asp-validation-for="MarkAsNew"></span>
                         </div>
                     </div>
                     <nop-nested-setting asp-for="MarkAsNew">
@@ -702,18 +702,18 @@
                     </nop-nested-setting>
                     <div class="form-group @(Model.ProductEditorSettingsModel.AdminComment ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="AdminComment" />
+                            <nop-label asp-for="AdminComment" />
                         </div>
                         <div class="col-md-9">
-							<nop-textarea asp-for="AdminComment" />
-							<span asp-validation-for="AdminComment"></span>
+                            <nop-textarea asp-for="AdminComment" />
+                            <span asp-validation-for="AdminComment"></span>
                         </div>
                     </div>
                     @if (Model.CreatedOn.HasValue)
                     {
                         <div class="form-group @(Model.ProductEditorSettingsModel.CreatedOn ? null : "advanced-setting")">
                             <div class="col-md-3">
-								<nop-label asp-for="CreatedOn" />
+                                <nop-label asp-for="CreatedOn" />
                             </div>
                             <div class="col-md-9">
                                 <div class="form-text-row">@Model.CreatedOn.Value.ToString("F")</div>
@@ -724,7 +724,7 @@
                     {
                         <div class="form-group @(Model.ProductEditorSettingsModel.UpdatedOn ? null : "advanced-setting")">
                             <div class="col-md-3">
-								<nop-label asp-for="UpdatedOn" />
+                                <nop-label asp-for="UpdatedOn" />
                             </div>
                             <div class="col-md-9">
                                 <div class="form-text-row">@Model.UpdatedOn.Value.ToString("F")</div>
@@ -740,11 +740,11 @@
                 <div class="panel-body">
                     <div class="form-group">
                         <div class="col-md-3">
-							<nop-label asp-for="IsGiftCard" />
+                            <nop-label asp-for="IsGiftCard" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="IsGiftCard" />
-							<span asp-validation-for="IsGiftCard"></span>
+                            <nop-editor asp-for="IsGiftCard" />
+                            <span asp-validation-for="IsGiftCard"></span>
                         </div>
                     </div>
                     <nop-nested-setting asp-for="IsGiftCard">
@@ -776,11 +776,11 @@
                 <div class="panel-body">
                     <div class="form-group">
                         <div class="col-md-3">
-							<nop-label asp-for="IsDownload" />
+                            <nop-label asp-for="IsDownload" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="IsDownload" />
-							<span asp-validation-for="IsDownload"></span>
+                            <nop-editor asp-for="IsDownload" />
+                            <span asp-validation-for="IsDownload"></span>
                         </div>
                     </div>
                     <nop-nested-setting asp-for="IsDownload">
@@ -877,11 +877,11 @@
                 <div class="panel-body">
                     <div class="form-group">
                         <div class="col-md-3">
-							<nop-label asp-for="IsRecurring" />
+                            <nop-label asp-for="IsRecurring" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="IsRecurring" />
-							<span asp-validation-for="IsRecurring"></span>
+                            <nop-editor asp-for="IsRecurring" />
+                            <span asp-validation-for="IsRecurring"></span>
                         </div>
                     </div>
                     <nop-nested-setting asp-for="IsRecurring">
@@ -912,7 +912,7 @@
                                 <span asp-validation-for="RecurringTotalCycles"></span>
                             </div>
                         </div>
-                    </nop-nested-setting>                    
+                    </nop-nested-setting>
                 </div>
             </div>
             <div class="panel panel-default @(Model.ProductEditorSettingsModel.IsRental ? null : "advanced-setting")" id="group-rental">
@@ -922,11 +922,11 @@
                 <div class="panel-body">
                     <div class="form-group">
                         <div class="col-md-3">
-							<nop-label asp-for="IsRental" />
+                            <nop-label asp-for="IsRental" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="IsRental" />
-							<span asp-validation-for="IsRental"></span>
+                            <nop-editor asp-for="IsRental" />
+                            <span asp-validation-for="IsRental"></span>
                         </div>
                     </div>
                     <nop-nested-setting asp-for="IsRental">
@@ -958,56 +958,56 @@
                 <div class="panel-body">
                     <div class="form-group">
                         <div class="col-md-3">
-							<nop-label asp-for="Price" />
+                            <nop-label asp-for="Price" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="Price" asp-postfix="@Model.PrimaryStoreCurrencyCode" />
-							<span asp-validation-for="Price"></span>
+                            <nop-editor asp-for="Price" asp-postfix="@Model.PrimaryStoreCurrencyCode" />
+                            <span asp-validation-for="Price"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.OldPrice ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="OldPrice" />
+                            <nop-label asp-for="OldPrice" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="OldPrice" asp-postfix="@Model.PrimaryStoreCurrencyCode" />
-							<span asp-validation-for="OldPrice"></span>
+                            <nop-editor asp-for="OldPrice" asp-postfix="@Model.PrimaryStoreCurrencyCode" />
+                            <span asp-validation-for="OldPrice"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.ProductCost ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="ProductCost" />
+                            <nop-label asp-for="ProductCost" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="ProductCost" asp-postfix="@Model.PrimaryStoreCurrencyCode" />
-							<span asp-validation-for="ProductCost"></span>
+                            <nop-editor asp-for="ProductCost" asp-postfix="@Model.PrimaryStoreCurrencyCode" />
+                            <span asp-validation-for="ProductCost"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.DisableBuyButton ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="DisableBuyButton" />
+                            <nop-label asp-for="DisableBuyButton" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="DisableBuyButton" />
-							<span asp-validation-for="DisableBuyButton"></span>
+                            <nop-editor asp-for="DisableBuyButton" />
+                            <span asp-validation-for="DisableBuyButton"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.DisableWishlistButton ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="DisableWishlistButton" />
+                            <nop-label asp-for="DisableWishlistButton" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="DisableWishlistButton" />
-							<span asp-validation-for="DisableWishlistButton"></span>
+                            <nop-editor asp-for="DisableWishlistButton" />
+                            <span asp-validation-for="DisableWishlistButton"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.AvailableForPreOrder ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="AvailableForPreOrder" />
+                            <nop-label asp-for="AvailableForPreOrder" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="AvailableForPreOrder" />
-							<span asp-validation-for="AvailableForPreOrder"></span>
+                            <nop-editor asp-for="AvailableForPreOrder" />
+                            <span asp-validation-for="AvailableForPreOrder"></span>
                         </div>
                     </div>
                     <nop-nested-setting asp-for="AvailableForPreOrder">
@@ -1023,20 +1023,20 @@
                     </nop-nested-setting>
                     <div class="form-group @(Model.ProductEditorSettingsModel.CallForPrice ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="CallForPrice" />
+                            <nop-label asp-for="CallForPrice" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="CallForPrice" />
-							<span asp-validation-for="CallForPrice"></span>
+                            <nop-editor asp-for="CallForPrice" />
+                            <span asp-validation-for="CallForPrice"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.CustomerEntersPrice ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="CustomerEntersPrice" />
+                            <nop-label asp-for="CustomerEntersPrice" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="CustomerEntersPrice" />
-							<span asp-validation-for="CustomerEntersPrice"></span>
+                            <nop-editor asp-for="CustomerEntersPrice" />
+                            <span asp-validation-for="CustomerEntersPrice"></span>
                         </div>
                     </div>
                     <nop-nested-setting asp-for="CustomerEntersPrice">
@@ -1061,11 +1061,11 @@
                     </nop-nested-setting>
                     <div class="form-group @(Model.ProductEditorSettingsModel.PAngV ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="BasepriceEnabled" />
+                            <nop-label asp-for="BasepriceEnabled" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="BasepriceEnabled" />
-							<span asp-validation-for="BasepriceEnabled"></span>
+                            <nop-editor asp-for="BasepriceEnabled" />
+                            <span asp-validation-for="BasepriceEnabled"></span>
                         </div>
                     </div>
                     <nop-nested-setting asp-for="BasepriceEnabled">
@@ -1108,10 +1108,10 @@
                     </nop-nested-setting>
                     <div class="form-group @(Model.ProductEditorSettingsModel.Discounts ? null : "advanced-setting")">
                         <div class="col-md-3">
-							<nop-label asp-for="SelectedDiscountIds" />
+                            <nop-label asp-for="SelectedDiscountIds" />
                         </div>
                         <div class="col-md-9">
-							<nop-select asp-for="SelectedDiscountIds" asp-items="Model.AvailableDiscounts" asp-multiple="true"/>
+                            <nop-select asp-for="SelectedDiscountIds" asp-items="Model.AvailableDiscounts" asp-multiple="true" />
                             <script type="text/javascript">
                                 $(document).ready(function() {
                                     var discountsIdsInput = $('#@Html.IdFor(model => model.SelectedDiscountIds)').data("kendoMultiSelect");
@@ -1137,29 +1137,29 @@
                     </div>
                     <div class="form-group">
                         <div class="col-md-3">
-							<nop-label asp-for="IsTaxExempt" />
+                            <nop-label asp-for="IsTaxExempt" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="IsTaxExempt" />
-							<span asp-validation-for="IsTaxExempt"></span>
+                            <nop-editor asp-for="IsTaxExempt" />
+                            <span asp-validation-for="IsTaxExempt"></span>
                         </div>
                     </div>
                     <div class="form-group" id="pnlTaxCategory">
                         <div class="col-md-3">
-							<nop-label asp-for="TaxCategoryId" />
+                            <nop-label asp-for="TaxCategoryId" />
                         </div>
                         <div class="col-md-9">
-							<nop-select asp-for="TaxCategoryId" asp-items="Model.AvailableTaxCategories" />
-							<span asp-validation-for="TaxCategoryId"></span>
+                            <nop-select asp-for="TaxCategoryId" asp-items="Model.AvailableTaxCategories" />
+                            <span asp-validation-for="TaxCategoryId"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.TelecommunicationsBroadcastingElectronicServices ? null : "advanced-setting")" id="pnlIsTelecommunicationsOrBroadcastingOrElectronicServices">
                         <div class="col-md-3">
-							<nop-label asp-for="IsTelecommunicationsOrBroadcastingOrElectronicServices" />
+                            <nop-label asp-for="IsTelecommunicationsOrBroadcastingOrElectronicServices" />
                         </div>
                         <div class="col-md-9">
-							<nop-editor asp-for="IsTelecommunicationsOrBroadcastingOrElectronicServices" />
-							<span asp-validation-for="IsTelecommunicationsOrBroadcastingOrElectronicServices"></span>
+                            <nop-editor asp-for="IsTelecommunicationsOrBroadcastingOrElectronicServices" />
+                            <span asp-validation-for="IsTelecommunicationsOrBroadcastingOrElectronicServices"></span>
                         </div>
                     </div>
                 </div>
@@ -1283,8 +1283,8 @@
                         </button>
                         <input type="submit" id="btnRefreshTierPrices" style="display: none" />
                         <script type="text/javascript">
-                            $(document).ready(function() {
-                                $('#btnRefreshTierPrices').click(function() {
+                            $(document).ready(function () {
+                                $('#btnRefreshTierPrices').click(function () {
                                     $("#tierprices-grid").data('kendoGrid').dataSource.read();
                                     //return false to don't reload a page
                                     return false;
@@ -1431,8 +1431,8 @@
                         </button>
                         <input type="submit" id="btnRefreshAssociatedProducts" style="display: none" />
                         <script type="text/javascript">
-                            $(document).ready(function() {
-                                $('#btnRefreshAssociatedProducts').click(function() {
+                            $(document).ready(function () {
+                                $('#btnRefreshAssociatedProducts').click(function () {
                                     //refresh grid
                                     var grid = $("#associatedproducts-grid").data('kendoGrid');
                                     grid.dataSource.read();
@@ -1458,39 +1458,39 @@
                 <div class="panel-body">
                     <div class="form-group">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="ManageInventoryMethodId" />
+                            <nop-label asp-for="ManageInventoryMethodId" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-select asp-for="ManageInventoryMethodId" asp-items="@(((ManageInventoryMethod)Model.ManageInventoryMethodId).ToSelectList())" />
-							<span asp-validation-for="ManageInventoryMethodId"></span>
+                            <nop-select asp-for="ManageInventoryMethodId" asp-items="@(((ManageInventoryMethod)Model.ManageInventoryMethodId).ToSelectList())" />
+                            <span asp-validation-for="ManageInventoryMethodId"></span>
                         </div>
                     </div>
                     <div class="form-group" id="pnlStockQuantity">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="StockQuantity" />
+                            <nop-label asp-for="StockQuantity" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-editor asp-for="StockQuantity" />
-							<input type="hidden" asp-for="LastStockQuantity" />
-							<span asp-validation-for="StockQuantity"></span>
+                            <nop-editor asp-for="StockQuantity" />
+                            <input type="hidden" asp-for="LastStockQuantity" />
+                            <span asp-validation-for="StockQuantity"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.Warehouse ? null : "advanced-setting")" id="pnlWarehouse">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="WarehouseId" />
+                            <nop-label asp-for="WarehouseId" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-select asp-for="WarehouseId" asp-items="Model.AvailableWarehouses" />
-							<span asp-validation-for="WarehouseId"></span>
+                            <nop-select asp-for="WarehouseId" asp-items="Model.AvailableWarehouses" />
+                            <span asp-validation-for="WarehouseId"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.UseMultipleWarehouses ? null : "advanced-setting")" id="pnlUseMultipleWarehouses">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="UseMultipleWarehouses" />
+                            <nop-label asp-for="UseMultipleWarehouses" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-editor asp-for="UseMultipleWarehouses" />
-							<span asp-validation-for="UseMultipleWarehouses"></span>
+                            <nop-editor asp-for="UseMultipleWarehouses" />
+                            <span asp-validation-for="UseMultipleWarehouses"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.UseMultipleWarehouses ? null : "advanced-setting")" id="pnlMultipleWarehouses">
@@ -1576,119 +1576,119 @@
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.DisplayStockAvailability ? null : "advanced-setting")" id="pnlDisplayStockAvailability">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="DisplayStockAvailability" />
+                            <nop-label asp-for="DisplayStockAvailability" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-editor asp-for="DisplayStockAvailability" />
-							<span asp-validation-for="DisplayStockAvailability"></span>
+                            <nop-editor asp-for="DisplayStockAvailability" />
+                            <span asp-validation-for="DisplayStockAvailability"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.DisplayStockQuantity ? null : "advanced-setting")" id="pnlDisplayStockQuantity">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="DisplayStockQuantity" />
+                            <nop-label asp-for="DisplayStockQuantity" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-editor asp-for="DisplayStockQuantity" />
-							<span asp-validation-for="DisplayStockQuantity"></span>
+                            <nop-editor asp-for="DisplayStockQuantity" />
+                            <span asp-validation-for="DisplayStockQuantity"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.MinimumStockQuantity ? null : "advanced-setting")" id="pnlMinStockQuantity">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="MinStockQuantity" />
+                            <nop-label asp-for="MinStockQuantity" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-editor asp-for="MinStockQuantity" />
-							<span asp-validation-for="MinStockQuantity"></span>
+                            <nop-editor asp-for="MinStockQuantity" />
+                            <span asp-validation-for="MinStockQuantity"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.LowStockActivity ? null : "advanced-setting")" id="pnlLowStockActivity">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="LowStockActivityId" />
+                            <nop-label asp-for="LowStockActivityId" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-select asp-for="LowStockActivityId" asp-items="@(((LowStockActivity)Model.LowStockActivityId).ToSelectList())" />
-							<span asp-validation-for="LowStockActivityId"></span>
+                            <nop-select asp-for="LowStockActivityId" asp-items="@(((LowStockActivity)Model.LowStockActivityId).ToSelectList())" />
+                            <span asp-validation-for="LowStockActivityId"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.NotifyAdminForQuantityBelow ? null : "advanced-setting")" id="pnlNotifyForQuantityBelow">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="NotifyAdminForQuantityBelow" />
+                            <nop-label asp-for="NotifyAdminForQuantityBelow" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-editor asp-for="NotifyAdminForQuantityBelow" />
-							<span asp-validation-for="NotifyAdminForQuantityBelow"></span>
+                            <nop-editor asp-for="NotifyAdminForQuantityBelow" />
+                            <span asp-validation-for="NotifyAdminForQuantityBelow"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.Backorders ? null : "advanced-setting")" id="pnlBackorders">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="BackorderModeId" />
+                            <nop-label asp-for="BackorderModeId" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-select asp-for="BackorderModeId" asp-items="@(((BackorderMode)Model.BackorderModeId).ToSelectList())" />
-							<span asp-validation-for="BackorderModeId"></span>
+                            <nop-select asp-for="BackorderModeId" asp-items="@(((BackorderMode)Model.BackorderModeId).ToSelectList())" />
+                            <span asp-validation-for="BackorderModeId"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.AllowBackInStockSubscriptions ? null : "advanced-setting")" id="pnlAllowBackInStockSubscriptions">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="AllowBackInStockSubscriptions" />
+                            <nop-label asp-for="AllowBackInStockSubscriptions" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-editor asp-for="AllowBackInStockSubscriptions" />
-							<span asp-validation-for="AllowBackInStockSubscriptions"></span>
+                            <nop-editor asp-for="AllowBackInStockSubscriptions" />
+                            <span asp-validation-for="AllowBackInStockSubscriptions"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.ProductAvailabilityRange ? null : "advanced-setting")" id="pnlProductAvailabilityRange">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="ProductAvailabilityRangeId" />
+                            <nop-label asp-for="ProductAvailabilityRangeId" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-select asp-for="ProductAvailabilityRangeId" asp-items="Model.AvailableProductAvailabilityRanges" />
-							<span asp-validation-for="ProductAvailabilityRangeId"></span>
+                            <nop-select asp-for="ProductAvailabilityRangeId" asp-items="Model.AvailableProductAvailabilityRanges" />
+                            <span asp-validation-for="ProductAvailabilityRangeId"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.MinimumCartQuantity ? null : "advanced-setting")">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="OrderMinimumQuantity" />
+                            <nop-label asp-for="OrderMinimumQuantity" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-editor asp-for="OrderMinimumQuantity" />
-							<span asp-validation-for="OrderMinimumQuantity"></span>
+                            <nop-editor asp-for="OrderMinimumQuantity" />
+                            <span asp-validation-for="OrderMinimumQuantity"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.MaximumCartQuantity ? null : "advanced-setting")">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="OrderMaximumQuantity" />
+                            <nop-label asp-for="OrderMaximumQuantity" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-editor asp-for="OrderMaximumQuantity" />
-							<span asp-validation-for="OrderMaximumQuantity"></span>
+                            <nop-editor asp-for="OrderMaximumQuantity" />
+                            <span asp-validation-for="OrderMaximumQuantity"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.AllowedQuantities ? null : "advanced-setting")">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="AllowedQuantities" />
+                            <nop-label asp-for="AllowedQuantities" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-editor asp-for="AllowedQuantities" />
-							<span asp-validation-for="AllowedQuantities"></span>
+                            <nop-editor asp-for="AllowedQuantities" />
+                            <span asp-validation-for="AllowedQuantities"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.AllowAddingOnlyExistingAttributeCombinations ? null : "advanced-setting")" id="pnlAllowAddingOnlyExistingAttributeCombinations">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="AllowAddingOnlyExistingAttributeCombinations" />
+                            <nop-label asp-for="AllowAddingOnlyExistingAttributeCombinations" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-editor asp-for="AllowAddingOnlyExistingAttributeCombinations" />
-							<span asp-validation-for="AllowAddingOnlyExistingAttributeCombinations"></span>
+                            <nop-editor asp-for="AllowAddingOnlyExistingAttributeCombinations" />
+                            <span asp-validation-for="AllowAddingOnlyExistingAttributeCombinations"></span>
                         </div>
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.NotReturnable ? null : "advanced-setting")">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="NotReturnable" />
+                            <nop-label asp-for="NotReturnable" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-editor asp-for="NotReturnable" />
-							<span asp-validation-for="NotReturnable"></span>
+                            <nop-editor asp-for="NotReturnable" />
+                            <span asp-validation-for="NotReturnable"></span>
                         </div>
                     </div>
                 </div>
@@ -1700,11 +1700,11 @@
                 <div class="panel-body">
                     <div class="form-group">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="IsShipEnabled" />
+                            <nop-label asp-for="IsShipEnabled" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-editor asp-for="IsShipEnabled" />
-							<span asp-validation-for="IsShipEnabled"></span>
+                            <nop-editor asp-for="IsShipEnabled" />
+                            <span asp-validation-for="IsShipEnabled"></span>
                         </div>
                     </div>
                     <nop-nested-setting asp-for="IsShipEnabled">
@@ -1790,10 +1790,10 @@
                 <div class="panel-body">
                     <div class="form-group">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="SelectedCategoryIds" />
+                            <nop-label asp-for="SelectedCategoryIds" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-select asp-for="SelectedCategoryIds" asp-items="Model.AvailableCategories" asp-multiple="true" />
+                            <nop-select asp-for="SelectedCategoryIds" asp-items="Model.AvailableCategories" asp-multiple="true" />
                             <script type="text/javascript">
                                 $(document).ready(function() {
                                     var categoryIdsInput = $('#@Html.IdFor(model => model.SelectedCategoryIds)').data("kendoMultiSelect");
@@ -1817,12 +1817,26 @@
                             </script>
                         </div>
                     </div>
+                    @if (Model.CategoriesToAdd == "+")
+                    {
+                        Model.CategoriesToAdd = "";
+                        <div class="panel-body">
+                            <div class="form-group">
+                                <div class="@leftColumnClass">
+                                    <nop-label asp-for="CategoriesToAdd" />
+                                </div>
+                                <div class="@rightColumnClass">
+                                    <nop-editor asp-for="CategoriesToAdd" />
+                                </div>
+                            </div>
+                        </div>
+                    }
                     <div class="form-group @(Model.ProductEditorSettingsModel.Manufacturers ? null : "advanced-setting")">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="SelectedManufacturerIds" />
+                            <nop-label asp-for="SelectedManufacturerIds" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-select asp-for="SelectedManufacturerIds" asp-items="Model.AvailableManufacturers" asp-multiple="true" />
+                            <nop-select asp-for="SelectedManufacturerIds" asp-items="Model.AvailableManufacturers" asp-multiple="true" />
                             <script type="text/javascript">
                                 $(document).ready(function() {
                                     var manufacturersIdsInput = $('#@Html.IdFor(model => model.SelectedManufacturerIds)').data("kendoMultiSelect");
@@ -1848,10 +1862,10 @@
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.Stores ? null : "advanced-setting")">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="SelectedStoreIds" />
+                            <nop-label asp-for="SelectedStoreIds" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-select asp-for="SelectedStoreIds" asp-items="Model.AvailableStores" asp-multiple="true" />
+                            <nop-select asp-for="SelectedStoreIds" asp-items="Model.AvailableStores" asp-multiple="true" />
                             <script type="text/javascript">
                                 $(document).ready(function() {
                                     var storesIdsInput = $('#@Html.IdFor(model => model.SelectedStoreIds)').data("kendoMultiSelect");
@@ -1877,11 +1891,11 @@
                     </div>
                     <div class="form-group @(Model.ProductEditorSettingsModel.Vendor ? null : "advanced-setting")" @(Model.IsLoggedInAsVendor ? Html.Raw("style='display: none;'") : null)>
                         <div class="@leftColumnClass">
-							<nop-label asp-for="VendorId" />
+                            <nop-label asp-for="VendorId" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-select asp-for="VendorId" asp-items="Model.AvailableVendors" />
-							<span asp-validation-for="VendorId"></span>
+                            <nop-select asp-for="VendorId" asp-items="Model.AvailableVendors" />
+                            <span asp-validation-for="VendorId"></span>
                         </div>
                     </div>
                 </div>
@@ -1893,10 +1907,10 @@
                 <div class="panel-body">
                     <div class="form-group">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="SelectedCustomerRoleIds" />
+                            <nop-label asp-for="SelectedCustomerRoleIds" />
                         </div>
                         <div class="@rightColumnClass">
-							<nop-select asp-for="SelectedCustomerRoleIds" asp-items="Model.AvailableCustomerRoles" asp-multiple="true" />
+                            <nop-select asp-for="SelectedCustomerRoleIds" asp-items="Model.AvailableCustomerRoles" asp-multiple="true" />
                             <script type="text/javascript">
                                 $(document).ready(function() {
                                     var rolesIdsInput = $('#@Html.IdFor(model => model.SelectedCustomerRoleIds)').data("kendoMultiSelect");
@@ -1929,7 +1943,7 @@
                 <div class="panel-body">
                     <div class="form-group">
                         <div class="@leftColumnClass">
-							<nop-label asp-for="RequireOtherProducts" />
+                            <nop-label asp-for="RequireOtherProducts" />
                         </div>
                         <div class="@rightColumnClass">
                             <nop-editor asp-for="RequireOtherProducts" />
@@ -2096,8 +2110,8 @@
                         </button>
                         <input type="submit" id="btnRefreshRelatedProducts" style="display: none" />
                         <script type="text/javascript">
-                            $(document).ready(function() {
-                                $('#btnRefreshRelatedProducts').click(function() {
+                            $(document).ready(function () {
+                                $('#btnRefreshRelatedProducts').click(function () {
                                     //refresh grid
                                     var grid = $("#relatedproducts-grid").data('kendoGrid');
                                     grid.dataSource.read();
@@ -2201,8 +2215,8 @@
                         </button>
                         <input type="submit" id="btnRefreshCrossSellProducts" style="display: none" />
                         <script type="text/javascript">
-                            $(document).ready(function() {
-                                $('#btnRefreshCrossSellProducts').click(function() {
+                            $(document).ready(function () {
+                                $('#btnRefreshCrossSellProducts').click(function () {
                                     //refresh grid
                                     var grid = $("#crosssellproducts-grid").data('kendoGrid');
                                     grid.dataSource.read();
@@ -2221,7 +2235,7 @@
                     </div>
                 }
             </div>
-            @await Component.InvokeAsync("AdminWidget", new { widgetZone = "admin_product_details_info_column_right_bottom", additionalData = Model.Id })        
+            @await Component.InvokeAsync("AdminWidget", new { widgetZone = "admin_product_details_info_column_right_bottom", additionalData = Model.Id })
         </div>
     </div>
 </div>

--- a/src/Presentation/Nop.Web/Factories/ICatalogModelFactory.cs
+++ b/src/Presentation/Nop.Web/Factories/ICatalogModelFactory.cs
@@ -2,6 +2,7 @@
 using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Vendors;
 using Nop.Web.Models.Catalog;
+using Nop.Core.Domain.Seo;
 
 namespace Nop.Web.Factories
 {
@@ -88,7 +89,7 @@ namespace Nop.Web.Factories
         /// <param name="allCategories">All available categories; pass null to load them internally</param>
         /// <returns>List of category (simple) models</returns>
         List<CategorySimpleModel> PrepareCategorySimpleModels(int rootCategoryId,
-            bool loadSubCategories = true, IList<Category> allCategories = null);
+            bool loadSubCategories = true, IList<Category> allCategories = null, IList<UrlRecord> slugs = null, bool topmenu = false, bool navigation = false);
 
         #endregion
 

--- a/src/Presentation/Nop.Web/Infrastructure/Cache/ModelCacheEventConsumer.cs
+++ b/src/Presentation/Nop.Web/Infrastructure/Cache/ModelCacheEventConsumer.cs
@@ -215,6 +215,17 @@ namespace Nop.Web.Infrastructure.Cache
         public const string CATEGORY_ALL_PATTERN_KEY = "Nop.pres.category.all";
 
         /// <summary>
+        /// Key for list of CategorySimpleModel caching for top menu
+        /// </summary>
+        /// <remarks>
+        /// {0} : language id
+        /// {1} : comma separated list of customer roles
+        /// {2} : current store ID
+        /// </remarks>
+        public const string CATEGORY_TOP_MENU_MODEL_KEY = "Nop.pres.category.topmenu-{0}-{1}-{2}";
+        public const string CATEGORY_TOP_MENU_PATTERN_KEY = "Nop.pres.category.topmenu";
+
+        /// <summary>
         /// Key for caching
         /// </summary>
         /// <remarks>

--- a/src/Presentation/Nop.Web/Views/Catalog/Search.cshtml
+++ b/src/Presentation/Nop.Web/Views/Catalog/Search.cshtml
@@ -45,12 +45,13 @@
                         <div class="advanced-search" id="advanced-search-block">
                             @if (Model.AvailableCategories.Count > 0)
                             {
+
                                 <div class="inputs">
                                     <label asp-for="cid">@T("Search.Category"):</label>
                                     <select asp-for="cid" asp-items="Model.AvailableCategories"></select>
                                 </div>
                                 <div class="inputs reversed">
-                                    <input asp-for="isc"/>
+                                    <input asp-for="isc" />
                                     <label asp-for="isc">@T("Search.IncludeSubCategories")</label>
                                 </div>
                             }


### PR DESCRIPTION
Description:
1. We add setting for LargeDatabase.
2. We make different approach for top menu load and navigation load.
For top menu only included in top menu categories are loaded and cached separately.
For navigation load only categories that are needed for tree generation are loaded. And they are not cached (maybe we should also add child categories to selected one to also display them in the tree - for easier navigation).
During first execution of recursive proc we also load all slugs and all localized names for all categories that will be used later (using 2 sql requests).
In total this makes only few requests to database instead of some requests per loaded category.
Top menu is cached anyway so LargeDatabase setting is not used for it.
LargeDatabase setting is used for navigation part. If it is true then new approach is used. If it is false then  it loads all categories as before and cache them and cache used.

Part 2 description:
In Admin area by default all categories are loaded for views for user to be able to select category. It very long too load and prepare if there are a lot of categories and also even if they are cached, then their list will be sent to user with each request. Also mobile devices will just die because of such huge lists. So based on LargeDatabase switch I stop populating AvailableCategories variable and if it its count == 0 then in views we show only editor where user can insert category id. Its everywhere except product add/update where we need extra field to be able to add new categories. There comma separated ids list is used. Also part 2 contains fix for common statistics mentioned here: https://github.com/nopSolutions/nopCommerce/issues/2744
And also categories population is removed from search part because its used in products search in the public store and again its not possible for user to wait their population. Category search is hidden there because customers can't know category ids to search by id.

