### PR TITLE
Thumbnails table reference

### DIFF
--- a/src/Libraries/Nop.Core/Domain/Media/Thumbnail.cs
+++ b/src/Libraries/Nop.Core/Domain/Media/Thumbnail.cs
@@ -1,0 +1,9 @@
+﻿namespace Nop.Core.Domain.Media
+{
+    public partial class Thumbnail : BaseEntity
+    {
+        public int PictureId { get; set; }
+        public int ThumbSize { get; set; }
+        public string FileName { get; set; }
+    }
+}

--- a/src/Libraries/Nop.Data/Mapping/Media/ThumbnailMap.cs
+++ b/src/Libraries/Nop.Data/Mapping/Media/ThumbnailMap.cs
@@ -1,0 +1,16 @@
+﻿using Nop.Core.Domain.Media;
+
+namespace Nop.Data.Mapping.Media
+{
+    public partial class ThumbnailMap : NopEntityTypeConfiguration<Thumbnail>
+    {
+        public ThumbnailMap()
+        {
+            this.ToTable("Thumb_Mapping");
+            this.HasKey(p => p.Id);
+            this.Property(p => p.PictureId);
+            this.Property(p => p.ThumbSize);
+            this.Property(p => p.FileName);
+        }
+    }
+}

--- a/src/Libraries/Nop.Services/Media/AzurePictureService.cs
+++ b/src/Libraries/Nop.Services/Media/AzurePictureService.cs
@@ -76,7 +76,8 @@ namespace Nop.Services.Media
             MediaSettings mediaSettings,
             NopConfig config,
             IDataProvider dataProvider,
-            IHostingEnvironment hostingEnvironment)
+            IHostingEnvironment hostingEnvironment,
+            IRepository<Thumbnail> thumbRepository)
             : base(pictureRepository,
                 productPictureRepository,
                 settingService,
@@ -86,7 +87,7 @@ namespace Nop.Services.Media
                 eventPublisher,
                 mediaSettings,
                 dataProvider,
-                hostingEnvironment)
+                hostingEnvironment, thumbRepository)
         {
             this._cacheManager = cacheManager;
             this._mediaSettings = mediaSettings;
@@ -134,9 +135,9 @@ namespace Nop.Services.Media
         /// Delete picture thumbs
         /// </summary>
         /// <param name="picture">Picture</param>
-        protected override async void DeletePictureThumbs(Picture picture)
+        protected override async void DeletePictureThumbs(int PictureId)
         {
-            await DeletePictureThumbsAsync(picture);
+            await DeletePictureThumbsAsync(PictureId);
         }
 
         /// <summary>
@@ -187,10 +188,10 @@ namespace Nop.Services.Media
         /// Initiates an asynchronous operation to delete picture thumbs
         /// </summary>
         /// <param name="picture">Picture</param>
-        protected virtual async Task DeletePictureThumbsAsync(Picture picture)
+        protected virtual async Task DeletePictureThumbsAsync(int PictureId)
         {
             //create a string containing the blob name prefix
-            var prefix = $"{picture.Id:0000000}";
+            var prefix = $"{PictureId:0000000}";
 
             BlobContinuationToken continuationToken = null;
             do

--- a/src/Libraries/Nop.Services/Media/IPictureService.cs
+++ b/src/Libraries/Nop.Services/Media/IPictureService.cs
@@ -160,5 +160,14 @@ namespace Nop.Services.Media
         /// <param name="picturesIds">Pictures Ids</param>
         /// <returns></returns>
         IDictionary<int, string> GetPicturesHash(int [] picturesIds);
+
+        #region Thumbnail
+        List<Thumbnail> GetThumbnails(int PictureId);
+        List<string> GetThumbnailsFileNames(int PictureId);
+        void DeleteThumbnailsFromMap(int PictureId);
+        void InsertThumbnail(Thumbnail thumb);
+        void DeleteThumbnail(int ThumbnailId);
+        #endregion
+
     }
 }


### PR DESCRIPTION
This is an ultra fast way to get thumbnails urls.
We add table that contains pictures ids and their thumbnail file names.
This way we easily generate urls without accessing file system. We easily delete thumbnails without searching files using wildcards on file system (that is terribly slow when there are a lot of thumbnails and killing hdd).

Code to generate table:
```
SET ANSI_NULLS ON
GO

SET QUOTED_IDENTIFIER ON
GO

CREATE TABLE [dbo].[Thumb_Mapping](
	[Id] [int] IDENTITY(1,1) NOT NULL,
	[PictureId] [int] NOT NULL,
	[ThumbSize] [int] NOT NULL,
	[FileName] [varchar](max) NOT NULL,
 CONSTRAINT [PK_Thumb_Mapping] PRIMARY KEY CLUSTERED 
(
	[Id] ASC
)WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
GO
```

We also need to create non clustered non unique index for PictureId with included column ThumbSize.