### PR TITLE
Campaigns - make urls absolute

### DIFF
--- a/src/Presentation/Nop.Web/Areas/Admin/Controllers/CampaignController.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Controllers/CampaignController.cs
@@ -310,6 +310,12 @@ namespace Nop.Web.Areas.Admin.Controllers
 
             return View(model);
 		}
+        private string MakeImagesPathsAbsolute(string body, int storeid)
+        {
+            if (storeid == 0) storeid = 1;
+            var store = _storeService.GetStoreById(storeid);
+            return body.Replace("src=\"/", "src=\"" + store.Url);
+        }
 
         [HttpPost,ActionName("Edit")]
         [FormValueRequired("send-test-email")]
@@ -322,7 +328,9 @@ namespace Nop.Web.Areas.Admin.Controllers
             if (campaign == null)
                 //No campaign found with the specified id
                 return RedirectToAction("List");
-            
+
+            campaign.Body = MakeImagesPathsAbsolute(campaign.Body, campaign.StoreId);
+
             model.AllowedTokens = string.Join(", ", _messageTokenProvider.GetListOfCampaignAllowedTokens());
             //stores
             PrepareStoresModel(model);
@@ -378,6 +386,8 @@ namespace Nop.Web.Areas.Admin.Controllers
             if (campaign == null)
                 //No campaign found with the specified id
                 return RedirectToAction("List");
+
+            campaign.Body = MakeImagesPathsAbsolute(campaign.Body, campaign.StoreId);
 
             model.AllowedTokens = string.Join(", ", _messageTokenProvider.GetListOfCampaignAllowedTokens());
             //stores


### PR DESCRIPTION
This issue existed in v3.8. Looks like it is still in v4.0.
When we send campaign emails with images their urls are relative (do not contain reference to domain). This way customer do not see images in emails.
These changes urls to full in send test email and in send mass email.