### PR TITLE
Product Attribute Combination Pictures: Each product (item for sale i…

### DIFF
--- a/src/Libraries/Nop.Core/Domain/Catalog/ProductAttributeCombination.cs
+++ b/src/Libraries/Nop.Core/Domain/Catalog/ProductAttributeCombination.cs
@@ -6,6 +6,11 @@ namespace Nop.Core.Domain.Catalog
     public partial class ProductAttributeCombination : BaseEntity
     {
         /// <summary>
+        /// Gets or sets the picture identifier
+        /// </summary>
+        public int PictureId { get; set; }
+
+        /// <summary>
         /// Gets or sets the product identifier
         /// </summary>
         public int ProductId { get; set; }

--- a/src/Libraries/Nop.Services/Media/Extensions.cs
+++ b/src/Libraries/Nop.Services/Media/Extensions.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Media;
 using Nop.Services.Catalog;
+using System.Collections.Generic;
 
 namespace Nop.Services.Media
 {
@@ -60,15 +61,25 @@ namespace Nop.Services.Media
 
             Picture picture = null;
 
-            //first, let's see whether we have some attribute values with custom pictures
-            var attributeValues = productAttributeParser.ParseProductAttributeValues(attributesXml);
-            foreach (var attributeValue in attributeValues)
+            // SEQ: Really first, lets get the COMBO
+            ProductAttributeCombination pac = productAttributeParser.FindProductAttributeCombination(product, attributesXml, true);
+            if (pac != null)
             {
-                var attributePicture = pictureService.GetPictureById(attributeValue.PictureId);
-                if (attributePicture != null)
+                picture = pictureService.GetPictureById(pac.PictureId);
+            }
+
+            //first, let's see whether we have some attribute values with custom pictures
+            if (picture == null)
+            {
+                var attributeValues = productAttributeParser.ParseProductAttributeValues(attributesXml);
+                foreach (var attributeValue in attributeValues)
                 {
-                    picture = attributePicture;
-                    break;
+                    var attributePicture = pictureService.GetPictureById(attributeValue.PictureId);
+                    if (attributePicture != null)
+                    {
+                        picture = attributePicture;
+                        break;
+                    }
                 }
             }
 

--- a/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
+++ b/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
@@ -3150,6 +3150,9 @@
   <LocaleResource Name="Admin.Catalog.Products.Fields.StockQuantity">
     <Value>Stock quantity</Value>
   </LocaleResource>
+  <LocaleResource Name="Admin.Catalog.Products.Fields.PictureId">
+    <Value>Picture ID</Value>
+  </LocaleResource>
   <LocaleResource Name="Admin.Catalog.Products.Fields.StockQuantity.Hint">
     <Value>The current stock quantity of this product.</Value>
   </LocaleResource>
@@ -3380,6 +3383,9 @@
   </LocaleResource>
   <LocaleResource Name="Admin.Catalog.Products.ProductAttributes.AttributeCombinations.Fields.Attributes">
     <Value>Attributes</Value>
+  </LocaleResource>
+  <LocaleResource Name="Admin.Catalog.Products.ProductAttributes.AttributeCombinations.Fields.ProductId">
+    <Value>Product Id</Value>
   </LocaleResource>
   <LocaleResource Name="Admin.Catalog.Products.ProductAttributes.AttributeCombinations.Fields.GTIN">
     <Value>GTIN</Value>

--- a/src/Presentation/Nop.Web/Areas/Admin/Controllers/ProductController.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Controllers/ProductController.cs
@@ -4383,8 +4383,17 @@ namespace Nop.Web.Areas.Admin.Controllers
             var combinationsModel = combinations
                 .Select(x =>
                 {
+                    var url = "blank";
+                    var picture = _pictureService.GetPictureById(x.PictureId);
+                    if (picture != null)
+                    {
+                        url = _pictureService.GetPictureUrl(picture);
+                    }
+
                     var pacModel = new ProductModel.ProductAttributeCombinationModel
                     {
+                        PictureId = x.PictureId,
+                        PictureUrl = url,
                         Id = x.Id,
                         ProductId = x.ProductId,
                         AttributesXml = _productAttributeFormatter.FormatAttributes(x.Product, x.AttributesXml, _workContext.CurrentCustomer, "<br />", true, true, true, false),
@@ -4439,6 +4448,7 @@ namespace Nop.Web.Areas.Admin.Controllers
 
             var previousSrockQuantity = combination.StockQuantity;
 
+            combination.PictureId = model.PictureId;
             combination.StockQuantity = model.StockQuantity;
             combination.AllowOutOfStockOrders = model.AllowOutOfStockOrders;
             combination.Sku = model.Sku;
@@ -4671,6 +4681,7 @@ namespace Nop.Web.Areas.Admin.Controllers
                 //save combination
                 var combination = new ProductAttributeCombination
                 {
+                    PictureId = model.PictureId,
                     ProductId = product.Id,
                     AttributesXml = attributesXml,
                     StockQuantity = model.StockQuantity,
@@ -4730,6 +4741,7 @@ namespace Nop.Web.Areas.Admin.Controllers
                 //save combination
                 var combination = new ProductAttributeCombination
                 {
+                    PictureId = 0,
                     ProductId = product.Id,
                     AttributesXml = attributesXml,
                     StockQuantity = 0,

--- a/src/Presentation/Nop.Web/Areas/Admin/Models/Catalog/AddProductAttributeCombinationModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Models/Catalog/AddProductAttributeCombinationModel.cs
@@ -12,6 +12,12 @@ namespace Nop.Web.Areas.Admin.Models.Catalog
         //MVC is suppressing further validation if the IFormCollection is passed to a controller method. That's why we add to the model
         public IFormCollection Form { get; set; }
 
+        [NopResourceDisplayName("Admin.Catalog.Products.ProductAttributes.AttributeCombinations.Fields.PictureId")]
+        public int PictureId { get; set; }
+
+        [NopResourceDisplayName("Admin.Catalog.Products.ProductAttributes.AttributeCombinations.Fields.Id")]
+        public int Id { get; set; }
+
         public AddProductAttributeCombinationModel()
         {
             ProductAttributes = new List<ProductAttributeModel>();
@@ -44,6 +50,7 @@ namespace Nop.Web.Areas.Admin.Models.Catalog
 
         public IList<string> Warnings { get; set; }
 
+        [NopResourceDisplayName("Admin.Catalog.Products.ProductAttributes.AttributeCombinations.Fields.ProductId")]
         public int ProductId { get; set; }
 
         #region Nested classes

--- a/src/Presentation/Nop.Web/Areas/Admin/Models/Catalog/ProductModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Models/Catalog/ProductModel.cs
@@ -890,7 +890,12 @@ namespace Nop.Web.Areas.Admin.Models.Catalog
 
         public partial class ProductAttributeCombinationModel : BaseNopEntityModel
         {
+            public string PictureUrl { get; set; }
+
             public int ProductId { get; set; }
+
+            [NopResourceDisplayName("Admin.Catalog.Products.ProductAttributes.AttributeCombinations.Fields.PictureId")]
+            public int PictureId { get; set; }
 
             [NopResourceDisplayName("Admin.Catalog.Products.ProductAttributes.AttributeCombinations.Fields.Attributes")]
             public string AttributesXml { get; set; }

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.ProductAttributes.Combinations.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.ProductAttributes.Combinations.cshtml
@@ -42,6 +42,7 @@
                                 id: "Id",
                                 fields: {
                                     //ProductId: { editable: false, type: "number" },
+                                    PictureId: { editable: false, type: "number"},
                                     AttributesXml: { editable: false, type: "string" },
                                     Warnings: { editable: false, type: "string" },
                                     StockQuantity: { editable: true, type: "number" },
@@ -83,6 +84,21 @@
                     scrollable: false,
                     columns: [
                         {
+                            field: "Id",
+                            title: "@T("Admin.Catalog.Products.ProductAttributes.AttributeCombinations.Fields.Id")",
+                            width: 100,
+                            //integer format
+                            format: "{0:0}"
+                        }, {
+                            field: "PictureUrl",
+                            title: "@T("Admin.Catalog.Products.ProductAttributes.AttributeCombinations.Fields.PictureId")",
+                            template: '<a href="#=PictureUrl#" target="_blank"><img alt="#=PictureId#" src="#=PictureUrl#" width="150" /></a>',
+                            editor: attPictureEditor,
+                            width: 250,
+                            id: '#=PictureId#',
+                            // <nop-editor asp-for="AddPictureModel.PictureId" />
+                            //Integer format - format: "{0:0}"
+                        }, {
                             field: "AttributesXml",
                             title: "@T("Admin.Catalog.Products.ProductAttributes.AttributeCombinations.Fields.Attributes")",
                             width: 400,
@@ -154,7 +170,25 @@
 
         <input type="submit" id="btnRefreshCombinations" style="display: none" />
         <script type="text/javascript">
-            $(document).ready(function() {
+           function attPictureEditor(container, options) {
+                $('<div id="#' + options.model.Id + '">...</div>')
+                    .appendTo(container).fineUploader({
+                    template: 'qq-template-gallery',
+                    request: { endpoint: '@(Url.Content("~/Admin/Picture/AsyncUpload"))' },
+                    multiple: false
+                }).on("complete", function(event, id, name, responseJSON, xhr) {
+                    if (responseJSON.success) {
+                        options.model.PictureId = responseJSON.pictureId;
+                        options.model.PictureUrl = responseJSON.imageUrl;
+                        options.model.dirty = true;
+                        $('#' + options.model.Id).html("<a href=" + responseJSON.imageUrl +
+                            "target=\"_blank\"><img alt=\"" + responseJSON.pictureId +
+                            "\" src=\"" + responseJSON.imageUrl + "\" width=\"150\"/></a>");
+                    }
+                });
+            }
+
+            $(document).ready(function () {
                 //refresh button
                 $('#btnRefreshCombinations').click(function() {
                     //refresh grid
@@ -164,13 +198,12 @@
                     //return false to don't reload a page
                     return false;
                 });
-                
+
                 //generate combinations
                 $('#btnGenerateAllCombinations').click(function() {
                     if (confirm('@T("Admin.Common.AreYouSure")')) {
 
                         var postData = {
-
                         };
                         addAntiForgeryToken(postData);
 
@@ -192,6 +225,8 @@
                     }
                     return false;
                 });
+
+
             });
         </script>
     </div>
@@ -203,3 +238,48 @@
     </div>
 </div>
 @await Component.InvokeAsync("AdminWidget", new { widgetZone = "admin_product_details_product_attributes_combinations_bottom", additionalData = Model })
+
+@using Nop.Core;
+@using Nop.Services.Media
+@using Nop.Web.Framework.UI;
+
+@inject IPictureService pictureService
+
+@{
+    Html.AddCssFileParts("~/lib/fineuploader/fineuploader-4.2.2.min.css");
+    Html.AddScriptParts("~/lib/fineuploader/jquery.fineuploader-4.2.2.min.js");
+    
+    var random = CommonHelper.GenerateRandomInteger();
+    var clientId = "picture" + random;
+}
+
+<script type="text/template" id="qq-template-gallery">
+    <div class="qq-uploader-selector qq-uploader">
+        <div class="qq-upload-drop-area-selector qq-upload-drop-area" qq-hide-dropzone>
+            <span>@T("Common.FileUploader.DropFiles")</span>
+        </div>
+        <div class="qq-upload-button-selector qq-upload-button">
+            <div>@T("Common.FileUploader.Upload")</div>
+        </div>
+        <span class="qq-drop-processing-selector qq-drop-processing">
+            <span>@T("Common.FileUploader.Processing")</span>
+            <span class="qq-drop-processing-spinner-selector qq-drop-processing-spinner"></span>
+        </span>
+        <ul class="qq-upload-list-selector qq-upload-list">
+            <li>
+                <div class="qq-progress-bar-container-selector">
+                    <div class="qq-progress-bar-selector qq-progress-bar"></div>
+                </div>
+                <span class="qq-upload-spinner-selector qq-upload-spinner"></span>
+                <span class="qq-edit-filename-icon-selector qq-edit-filename-icon"></span>
+                <span class="qq-upload-file-selector qq-upload-file"></span>
+                <input class="qq-edit-filename-selector qq-edit-filename" tabindex="0" type="text">
+                <span class="qq-upload-size-selector qq-upload-size"></span>
+                <a class="qq-upload-cancel-selector qq-upload-cancel" href="#">@T("Common.FileUploader.Cancel")</a>
+                <a class="qq-upload-retry-selector qq-upload-retry" href="#">@T("Common.FileUploader.Retry")</a>
+                <a class="qq-upload-delete-selector qq-upload-delete" href="#">@T("Common.FileUploader.Delete")</a>
+                <span class="qq-upload-status-text-selector qq-upload-status-text"></span>
+            </li>
+        </ul>
+    </div>
+</script>

--- a/upgradescripts/4.00-4.10 (under development)/upgrade.sql
+++ b/upgradescripts/4.00-4.10 (under development)/upgrade.sql
@@ -1,5 +1,10 @@
 ﻿--upgrade scripts from nopCommerce 4.00 to 4.10
 
+-- Product Attribute Combination PictureId
+ALTER TABLE ProductAttributeCombination
+ADD PictureId int not null default(0);
+GO
+
 --new locale resources
 declare @resources xml
 --a resource will be deleted if its value is empty


### PR DESCRIPTION
…n the store e.g. Sunglasses) had its own picture, however, each product attribute combination (any possible combination of attributes that the product may have e.g. Frame & Lens Color –> Metal & Blue) would be forced to share the products default image. There are Attribute Images in NopCommerce, but they do not cater for the full permutation. For example, above you could see the different Sunglasses Frames, but each with only one lens color; or each lens color but with only one frame.

We have added a Picture per Product Attribute Combination on the Admin Side, and made the Store Front show this combination if selected (otherwise it defaults back to the previous logic), as well as in the Order List and Shopping Cart.