### PR TITLE
Set Default Scheme so HttpContext.User gets set

### DIFF
--- a/src/Libraries/Nop.Services/Authentication/AuthenticationMiddleware.cs
+++ b/src/Libraries/Nop.Services/Authentication/AuthenticationMiddleware.cs
@@ -9,6 +9,10 @@ namespace Nop.Services.Authentication
     /// <summary>
     /// Represents middleware that enables authentication
     /// </summary>
+    /// <remarks>
+    /// Based on Microsoft.AspNetCore.Authentication.AuthenticationMiddleware,
+    /// with error handling added.
+    /// </remarks>
     public class AuthenticationMiddleware
     {
         #region Fields

--- a/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -189,8 +189,7 @@ namespace Nop.Web.Framework.Infrastructure.Extensions
             //set default authentication schemes
             var authenticationBuilder = services.AddAuthentication(options =>
             {
-                options.DefaultChallengeScheme = NopCookieAuthenticationDefaults.AuthenticationScheme;
-                options.DefaultSignInScheme = NopCookieAuthenticationDefaults.ExternalAuthenticationScheme;
+                options.DefaultScheme = NopCookieAuthenticationDefaults.AuthenticationScheme;
             });
 
             //add main cookie authentication


### PR DESCRIPTION
`HttpContext.User` is not being set to the current user because the default scheme branch of [`AuthenticationMiddleware`](https://github.com/nopSolutions/nopCommerce/blob/dae3e4dfe5178443153d11368c4c44931d96e432/src/Libraries/Nop.Services/Authentication/AuthenticationMiddleware.cs#L71) isn't entered. It also works to set [`options.DefaultAuthenticateScheme`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.authenticationoptions.defaultauthenticatescheme), but as far as I can tell `AuthenticationScheme` is the only scheme that's actually used.

`ExternalAuthenticationScheme` was introduced in 11c5ba948971419e51928512af30d0969cbda377, where its only other use is [`SignOutFromExternalAuthenticationAttribute`](https://github.com/MarryMyCity/nopCommerce/blob/fe1ef86688f49d159510d64d790da8ecf7f54738/src/Presentation/Nop.Web.Framework/Mvc/Filters/SignOutFromExternalAuthenticationAttribute.cs), which is [applied to `BaseController`](https://github.com/MarryMyCity/nopCommerce/blob/8315c57d48a2e04b6449009f60f3d049f6a67a7f/src/Presentation/Nop.Web.Framework/Controllers/BaseController.cs#L32). Does this code only exist for legacy reasons?