### PR TITLE
Allowing unicode characters in picture file names

### DIFF
--- a/src/Libraries/Nop.Services/Media/PictureService.cs
+++ b/src/Libraries/Nop.Services/Media/PictureService.cs
@@ -362,7 +362,7 @@ namespace Nop.Services.Media
         /// <returns>Result</returns>
         public virtual string GetPictureSeName(string name)
         {
-            return SeoExtensions.GetSeName(name, true, false);
+            return SeoExtensions.GetSeName(name, true, true);
         }
 
         /// <summary>


### PR DESCRIPTION
Image file name is one of the factors of image SEO improvements. Currently picture files get the product name which is good for site admins who enter product names in english. But for languages which use unicode characters for product names, picture file names changes to "-". So what you got is some meaning less file names both to search engines and humans. This update corrects this functionality.