### PR TITLE
Add In-Memory Scheduled Task Lock

### DIFF
--- a/src/Libraries/Nop.Core/Caching/ILocker.cs
+++ b/src/Libraries/Nop.Core/Caching/ILocker.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Nop.Core.Caching
+{
+    public interface ILocker
+    {
+        /// <summary>
+        /// Perform some action with exclusive lock
+        /// </summary>
+        /// <param name="resource">The key we are locking on</param>
+        /// <param name="expirationTime">The time after which the lock will automatically be expired</param>
+        /// <param name="action">Action to be performed with locking</param>
+        /// <returns>True if lock was acquired and action was performed; otherwise false</returns>
+        bool PerformActionWithLock(string resource, TimeSpan expirationTime, Action action);
+    }
+}

--- a/src/Libraries/Nop.Core/Caching/IRedisConnectionWrapper.cs
+++ b/src/Libraries/Nop.Core/Caching/IRedisConnectionWrapper.cs
@@ -34,14 +34,5 @@ namespace Nop.Core.Caching
         /// </summary>
         /// <param name="db">Database number; pass null to use the default value</param>
         void FlushDatabase(int? db = null);
-
-        /// <summary>
-        /// Perform some action with Redis distributed lock
-        /// </summary>
-        /// <param name="resource">The thing we are locking on</param>
-        /// <param name="expirationTime">The time after which the lock will automatically be expired by Redis</param>
-        /// <param name="action">Action to be performed with locking</param>
-        /// <returns>True if lock was acquired and action was performed; otherwise false</returns>
-        bool PerformActionWithLock(string resource, TimeSpan expirationTime, Action action);
     }
 }

--- a/src/Libraries/Nop.Core/Caching/MemoryCacheManager.cs
+++ b/src/Libraries/Nop.Core/Caching/MemoryCacheManager.cs
@@ -58,7 +58,17 @@ namespace Nop.Core.Caching
         /// </summary>
         /// <param name="cacheTime">Cache time in minutes</param>
         /// <returns></returns>
+        [Obsolete]
         protected MemoryCacheEntryOptions GetMemoryCacheEntryOptions(int cacheTime)
+        {
+            return GetMemoryCacheEntryOptions(TimeSpan.FromMinutes(cacheTime));
+        }
+
+        /// <summary>
+        /// Create entry options to item of memory cache
+        /// </summary>
+        /// <param name="cacheTime">Cache time</param>
+        protected MemoryCacheEntryOptions GetMemoryCacheEntryOptions(TimeSpan cacheTime)
         {
             var options = new MemoryCacheEntryOptions()
                 // add cancellation token for clear cache
@@ -67,7 +77,7 @@ namespace Nop.Core.Caching
                 .RegisterPostEvictionCallback(PostEviction);
 
             //set cache time
-            options.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(cacheTime);
+            options.AbsoluteExpirationRelativeToNow = cacheTime;
 
             return options;
         }
@@ -162,7 +172,7 @@ namespace Nop.Core.Caching
         {
             if (data != null)
             {
-                _cache.Set(AddKey(key), data, GetMemoryCacheEntryOptions(cacheTime));
+                _cache.Set(AddKey(key), data, GetMemoryCacheEntryOptions(TimeSpan.FromMinutes(cacheTime)));
             }
         }
 

--- a/src/Libraries/Nop.Core/Caching/MemoryCacheManager.cs
+++ b/src/Libraries/Nop.Core/Caching/MemoryCacheManager.cs
@@ -54,17 +54,6 @@ namespace Nop.Core.Caching
         #region Utilities
 
         /// <summary>
-        /// Create entry options to item of memory cache 
-        /// </summary>
-        /// <param name="cacheTime">Cache time in minutes</param>
-        /// <returns></returns>
-        [Obsolete]
-        protected MemoryCacheEntryOptions GetMemoryCacheEntryOptions(int cacheTime)
-        {
-            return GetMemoryCacheEntryOptions(TimeSpan.FromMinutes(cacheTime));
-        }
-
-        /// <summary>
         /// Create entry options to item of memory cache
         /// </summary>
         /// <param name="cacheTime">Cache time</param>

--- a/src/Libraries/Nop.Core/Caching/RedisConnectionWrapper.cs
+++ b/src/Libraries/Nop.Core/Caching/RedisConnectionWrapper.cs
@@ -11,7 +11,7 @@ namespace Nop.Core.Caching
     /// <summary>
     /// Represents Redis connection wrapper implementation
     /// </summary>
-    public class RedisConnectionWrapper : IRedisConnectionWrapper
+    public class RedisConnectionWrapper : IRedisConnectionWrapper, ILocker
     {
         #region Fields
 

--- a/src/Libraries/Nop.Services/Tasks/Task.cs
+++ b/src/Libraries/Nop.Services/Tasks/Task.cs
@@ -139,7 +139,7 @@ namespace Nop.Services.Tasks
                     var expirationInSeconds = ScheduleTask.Seconds <= 300 ? ScheduleTask.Seconds - 1 : 300;
 
                     //execute task with lock
-                    var redisWrapper = EngineContext.Current.Resolve<IRedisConnectionWrapper>();
+                    var redisWrapper = EngineContext.Current.Resolve<ILocker>();
                     redisWrapper.PerformActionWithLock(ScheduleTask.Type, TimeSpan.FromSeconds(expirationInSeconds), ExecuteTask);
                 }
                 else

--- a/src/Libraries/Nop.Services/Tasks/Task.cs
+++ b/src/Libraries/Nop.Services/Tasks/Task.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using Nop.Core.Caching;
-using Nop.Core.Configuration;
 using Nop.Core.Domain.Tasks;
 using Nop.Core.Infrastructure;
 using Nop.Services.Logging;
@@ -132,20 +131,13 @@ namespace Nop.Services.Tasks
 
             try
             {
-                var nopConfig = EngineContext.Current.Resolve<NopConfig>();
-                if (nopConfig.RedisCachingEnabled)
-                {
-                    //get expiration time
-                    var expirationInSeconds = ScheduleTask.Seconds <= 300 ? ScheduleTask.Seconds - 1 : 300;
+                //get expiration time
+                var expirationInSeconds = Math.Min(ScheduleTask.Seconds, 300) - 1;
+                var expiration = TimeSpan.FromSeconds(expirationInSeconds);
 
-                    //execute task with lock
-                    var redisWrapper = EngineContext.Current.Resolve<ILocker>();
-                    redisWrapper.PerformActionWithLock(ScheduleTask.Type, TimeSpan.FromSeconds(expirationInSeconds), ExecuteTask);
-                }
-                else
-                {
-                    ExecuteTask();
-                }
+                //execute task with lock
+                var locker = EngineContext.Current.Resolve<ILocker>();
+                locker.PerformActionWithLock(ScheduleTask.Type, expiration, ExecuteTask);
             }
             catch (Exception exc)
             {

--- a/src/Presentation/Nop.Web.Framework/Infrastructure/DependencyRegistrar.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/DependencyRegistrar.cs
@@ -113,7 +113,12 @@ namespace Nop.Web.Framework.Infrastructure
                 builder.RegisterType<RedisCacheManager>().As<IStaticCacheManager>().InstancePerLifetimeScope();
             }
             else
-                builder.RegisterType<MemoryCacheManager>().As<IStaticCacheManager>().SingleInstance();
+            {
+                builder.RegisterType<MemoryCacheManager>()
+                    .As<ILocker>()
+                    .As<IStaticCacheManager>()
+                    .SingleInstance();
+            }
 
             //work context
             builder.RegisterType<WebWorkContext>().As<IWorkContext>().InstancePerLifetimeScope();

--- a/src/Presentation/Nop.Web.Framework/Infrastructure/DependencyRegistrar.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/DependencyRegistrar.cs
@@ -106,7 +106,10 @@ namespace Nop.Web.Framework.Infrastructure
             //static cache manager
             if (config.RedisCachingEnabled)
             {
-                builder.RegisterType<RedisConnectionWrapper>().As<IRedisConnectionWrapper>().SingleInstance();
+                builder.RegisterType<RedisConnectionWrapper>()
+                    .As<ILocker>()
+                    .As<IRedisConnectionWrapper>()
+                    .SingleInstance();
                 builder.RegisterType<RedisCacheManager>().As<IStaticCacheManager>().InstancePerLifetimeScope();
             }
             else


### PR DESCRIPTION
Closes #2930 

Rather than leave Redis-specific lock code, I introduced an `ILocker` interface with an in-memory implementation.

cc @skoshelev @AndreiMaz 