### PR TITLE
order for script tag helper

### DIFF
--- a/src/Presentation/Nop.Web.Framework/TagHelpers/Public/ScriptTagHelper.cs
+++ b/src/Presentation/Nop.Web.Framework/TagHelpers/Public/ScriptTagHelper.cs
@@ -16,6 +16,7 @@ namespace Nop.Web.Framework.TagHelpers.Public
     public class ScriptTagHelper : TagHelper
     {
         private const string LocationAttributeName = "asp-location";
+        private const string OrderAttributeName = "asp-order";
         private readonly IHtmlHelper _htmlHelper;
         private readonly IHttpContextAccessor _httpContextAccessor;
 
@@ -24,6 +25,12 @@ namespace Nop.Web.Framework.TagHelpers.Public
         /// </summary>
         [HtmlAttributeName(LocationAttributeName)]
         public ResourceLocation Location { set; get; }
+
+        /// <summary>
+        /// Indicates showing order of the script
+        /// </summary>
+        [HtmlAttributeName(OrderAttributeName)]
+        public int ScriptOrder { get; set; }
 
         /// <summary>
         /// ViewContext
@@ -82,7 +89,7 @@ namespace Nop.Web.Framework.TagHelpers.Public
                 if (!attribute.Name.StartsWith("asp-"))
                     scriptTag.Attributes.Add(attribute.Name, attribute.Value.ToString());
 
-            _htmlHelper.AddInlineScriptParts(Location, scriptTag.RenderHtmlContent());
+            _htmlHelper.AddInlineScriptParts(Location, scriptTag.RenderHtmlContent(), ScriptOrder);
 
             //generate nothing
             output.SuppressOutput();

--- a/src/Presentation/Nop.Web.Framework/UI/IPageHeadBuilder.cs
+++ b/src/Presentation/Nop.Web.Framework/UI/IPageHeadBuilder.cs
@@ -64,7 +64,7 @@ namespace Nop.Web.Framework.UI
         /// <param name="debugSrc">Script path (full debug version). If empty, then minified version will be used</param>
         /// <param name="excludeFromBundle">A value indicating whether to exclude this script from bundling</param>
         /// <param name="isAsync">A value indicating whether to add an attribute "async" or not for js files</param>
-        void AddScriptParts(ResourceLocation location, string src, string debugSrc, bool excludeFromBundle, bool isAsync);
+        void AddScriptParts(ResourceLocation location, string src, string debugSrc, bool excludeFromBundle, bool isAsync, int order = 0);
         /// <summary>
         /// Append script element
         /// </summary>
@@ -73,7 +73,7 @@ namespace Nop.Web.Framework.UI
         /// <param name="debugSrc">Script path (full debug version). If empty, then minified version will be used</param>
         /// <param name="excludeFromBundle">A value indicating whether to exclude this script from bundling</param>
         /// <param name="isAsync">A value indicating whether to add an attribute "async" or not for js files</param>
-        void AppendScriptParts(ResourceLocation location, string src, string debugSrc, bool excludeFromBundle, bool isAsync);
+        void AppendScriptParts(ResourceLocation location, string src, string debugSrc, bool excludeFromBundle, bool isAsync, int order = 0);
         /// <summary>
         /// Generate all script parts
         /// </summary>
@@ -88,13 +88,13 @@ namespace Nop.Web.Framework.UI
         /// </summary>
         /// <param name="location">A location of the script element</param>
         /// <param name="script">Script</param>
-        void AddInlineScriptParts(ResourceLocation location, string script);
+        void AddInlineScriptParts(ResourceLocation location, string script, int order = 0);
         /// <summary>
         /// Append inline script element
         /// </summary>
         /// <param name="location">A location of the script element</param>
         /// <param name="script">Script</param>
-        void AppendInlineScriptParts(ResourceLocation location, string script);
+        void AppendInlineScriptParts(ResourceLocation location, string script, int order = 0);
         /// <summary>
         /// Generate all inline script parts
         /// </summary>

--- a/src/Presentation/Nop.Web.Framework/UI/LayoutExtensions.cs
+++ b/src/Presentation/Nop.Web.Framework/UI/LayoutExtensions.cs
@@ -20,7 +20,7 @@ namespace Nop.Web.Framework.UI
         /// <param name="part">Title part</param>
         public static void AddTitleParts(this IHtmlHelper html, string part)
         {
-            var pageHeadBuilder  = EngineContext.Current.Resolve<IPageHeadBuilder>();
+            var pageHeadBuilder = EngineContext.Current.Resolve<IPageHeadBuilder>();
             pageHeadBuilder.AddTitleParts(part);
         }
         /// <summary>
@@ -30,7 +30,7 @@ namespace Nop.Web.Framework.UI
         /// <param name="part">Title part</param>
         public static void AppendTitleParts(this IHtmlHelper html, string part)
         {
-            var pageHeadBuilder  = EngineContext.Current.Resolve<IPageHeadBuilder>();
+            var pageHeadBuilder = EngineContext.Current.Resolve<IPageHeadBuilder>();
             pageHeadBuilder.AppendTitleParts(part);
         }
         /// <summary>
@@ -125,9 +125,9 @@ namespace Nop.Web.Framework.UI
         /// <param name="excludeFromBundle">A value indicating whether to exclude this script from bundling</param>
         /// <param name="isAsync">A value indicating whether to add an attribute "async" or not for js files</param>
         public static void AddScriptParts(this IHtmlHelper html, string src, string debugSrc = "",
-            bool excludeFromBundle = false, bool isAsync = false)
+            bool excludeFromBundle = false, bool isAsync = false, int order = 0)
         {
-            AddScriptParts(html, ResourceLocation.Head, src, debugSrc, excludeFromBundle, isAsync);
+            AddScriptParts(html, ResourceLocation.Head, src, debugSrc, excludeFromBundle, isAsync, order);
         }
         /// <summary>
         /// Add script element
@@ -139,10 +139,10 @@ namespace Nop.Web.Framework.UI
         /// <param name="excludeFromBundle">A value indicating whether to exclude this script from bundling</param>
         /// <param name="isAsync">A value indicating whether to add an attribute "async" or not for js files</param>
         public static void AddScriptParts(this IHtmlHelper html, ResourceLocation location,
-            string src, string debugSrc = "", bool excludeFromBundle = false, bool isAsync = false)
+            string src, string debugSrc = "", bool excludeFromBundle = false, bool isAsync = false, int order = 0)
         {
             var pageHeadBuilder = EngineContext.Current.Resolve<IPageHeadBuilder>();
-            pageHeadBuilder.AddScriptParts(location, src, debugSrc, excludeFromBundle, isAsync);
+            pageHeadBuilder.AddScriptParts(location, src, debugSrc, excludeFromBundle, isAsync, order);
         }
         /// <summary>
         /// Append script element
@@ -153,9 +153,9 @@ namespace Nop.Web.Framework.UI
         /// <param name="excludeFromBundle">A value indicating whether to exclude this script from bundling</param>
         /// <param name="isAsync">A value indicating whether to add an attribute "async" or not for js files</param>
         public static void AppendScriptParts(this IHtmlHelper html, string src, string debugSrc = "",
-            bool excludeFromBundle = false, bool isAsync = false)
+            bool excludeFromBundle = false, bool isAsync = false, int order = 0)
         {
-            AppendScriptParts(html, ResourceLocation.Head, src, debugSrc, excludeFromBundle, isAsync);
+            AppendScriptParts(html, ResourceLocation.Head, src, debugSrc, excludeFromBundle, isAsync, order);
         }
         /// <summary>
         /// Append script element
@@ -167,10 +167,10 @@ namespace Nop.Web.Framework.UI
         /// <param name="excludeFromBundle">A value indicating whether to exclude this script from bundling</param>
         /// <param name="isAsync">A value indicating whether to add an attribute "async" or not for js files</param>
         public static void AppendScriptParts(this IHtmlHelper html, ResourceLocation location,
-            string src, string debugSrc = "", bool excludeFromBundle = false, bool isAsync = false)
+            string src, string debugSrc = "", bool excludeFromBundle = false, bool isAsync = false, int order = 0)
         {
             var pageHeadBuilder = EngineContext.Current.Resolve<IPageHeadBuilder>();
-            pageHeadBuilder.AppendScriptParts(location, src, debugSrc, excludeFromBundle, isAsync);
+            pageHeadBuilder.AppendScriptParts(location, src, debugSrc, excludeFromBundle, isAsync, order);
         }
         /// <summary>
         /// Generate all script parts
@@ -196,10 +196,10 @@ namespace Nop.Web.Framework.UI
         /// <param name="html">HTML helper</param>
         /// <param name="location">A location of the script element</param>
         /// <param name="script">Script</param>
-        public static void AddInlineScriptParts(this IHtmlHelper html, ResourceLocation location, string script)
+        public static void AddInlineScriptParts(this IHtmlHelper html, ResourceLocation location, string script, int order = 0)
         {
             var pageHeadBuilder = EngineContext.Current.Resolve<IPageHeadBuilder>();
-            pageHeadBuilder.AddInlineScriptParts(location, script);
+            pageHeadBuilder.AddInlineScriptParts(location, script, order);
         }
         /// <summary>
         /// Append inline script element
@@ -207,10 +207,10 @@ namespace Nop.Web.Framework.UI
         /// <param name="html">HTML helper</param>
         /// <param name="location">A location of the script element</param>
         /// <param name="script">Script</param>
-        public static void AppendInlineScriptParts(this IHtmlHelper html, ResourceLocation location, string script)
+        public static void AppendInlineScriptParts(this IHtmlHelper html, ResourceLocation location, string script, int order = 0)
         {
             var pageHeadBuilder = EngineContext.Current.Resolve<IPageHeadBuilder>();
-            pageHeadBuilder.AppendInlineScriptParts(location, script);
+            pageHeadBuilder.AppendInlineScriptParts(location, script, order);
         }
         /// <summary>
         /// Generate all inline script parts
@@ -244,7 +244,7 @@ namespace Nop.Web.Framework.UI
         /// <param name="src">Script path (minified version)</param>
         /// <param name="debugSrc">Script path (full debug version). If empty, then minified version will be used</param>
         /// <param name="excludeFromBundle">A value indicating whether to exclude this script from bundling</param>
-        public static void AddCssFileParts(this IHtmlHelper html, ResourceLocation location, 
+        public static void AddCssFileParts(this IHtmlHelper html, ResourceLocation location,
             string src, string debugSrc = "", bool excludeFromBundle = false)
         {
             var pageHeadBuilder = EngineContext.Current.Resolve<IPageHeadBuilder>();
@@ -269,7 +269,7 @@ namespace Nop.Web.Framework.UI
         /// <param name="src">Script path (minified version)</param>
         /// <param name="debugSrc">Script path (full debug version). If empty, then minified version will be used</param>
         /// <param name="excludeFromBundle">A value indicating whether to exclude this script from bundling</param>
-        public static void AppendCssFileParts(this IHtmlHelper html, ResourceLocation location, 
+        public static void AppendCssFileParts(this IHtmlHelper html, ResourceLocation location,
             string src, string debugSrc = "", bool excludeFromBundle = false)
         {
             var pageHeadBuilder = EngineContext.Current.Resolve<IPageHeadBuilder>();

--- a/src/Presentation/Nop.Web.Framework/UI/PageHeadBuilder.cs
+++ b/src/Presentation/Nop.Web.Framework/UI/PageHeadBuilder.cs
@@ -848,14 +848,32 @@ namespace Nop.Web.Framework.UI
         /// </summary>
         private class ScriptInlineReference : IEquatable<ScriptInlineReference>
         {
+            /// <summary>
+            /// Inline script
+            /// </summary>
             public string InlineScript { get; set; }
+
+            /// <summary>
+            /// Showing order for inline script
+            /// </summary>
             public int Order { get; set; }
+
+            /// <summary>
+            /// Equals
+            /// </summary>
+            /// <param name="item">Other item</param>
+            /// <returns>Result</returns>
             public bool Equals(ScriptInlineReference item)
             {
                 if (item == null)
                     return false;
                 return this.InlineScript.Equals(item.InlineScript) && this.Order.Equals(item.Order);
             }
+
+            /// <summary>
+            /// Get hash code
+            /// </summary>
+            /// <returns></returns>
             public override int GetHashCode()
             {
                 return InlineScript == null ? 0 : base.GetHashCode();


### PR DESCRIPTION
hi guys.
i have added Show Order to script tag helper so some one may need to load scripts in an order.

in some cases you may want to load some scripts before another and each tag may be requested from any parts of the page.
for example you may want to load jquery or it's plugins before another scripts.
also it works for both Script files and inline scripts.
i hope it will be usefull.
examples:
`
Html.AppendScriptParts(ResourceLocation.Footer, "~/js/public.common.js", order:"1");
`
or
`
<script src="~/js/admin.common.js" asp-location="Footer" asp-order="2"></script>
`