### PR TITLE
fix IsFullTextSupported error

### DIFF
--- a/src/Presentation/Nop.Web/App_Data/Install/SqlServer.StoredProcedures.sql
+++ b/src/Presentation/Nop.Web/App_Data/Install/SqlServer.StoredProcedures.sql
@@ -743,7 +743,7 @@ BEGIN
 		ELSE 0
 		END
 	ELSE 0
-	END')
+	END Value')
 END
 GO
 


### PR DESCRIPTION
fix IsFullTextSupported error(The required column  'Value' was not present in the results of a 'FromSql' operation.).