### PR TITLE
#3086 Replace js "Confirm" to Nop-action-confirmation window for Admi…

### DIFF
--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/AddShipment.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/AddShipment.cshtml
@@ -31,6 +31,8 @@
                 <i class="fa fa-floppy-o"></i>
                 @T("Admin.Common.SaveContinue")
             </button>
+            <nop-action-confirmation asp-button-id="shipment-save" asp-action="AddShipment" asp-additional-confirm='@T("Admin.Orders.Shipments.Products.Warehouse.QuantityNotEnough")' />
+            <nop-action-confirmation asp-button-id="shipment-save-continue" asp-additional-confirm='@T("Admin.Orders.Shipments.Products.Warehouse.QuantityNotEnough")'/>
             @await Component.InvokeAsync("AdminWidget", new { widgetZone = AdminWidgetZones.OrderShipmentAddButtons })
         </div>
     </div>
@@ -62,15 +64,15 @@
                     {
                         <script>
                             $(document).ready(function() {
-                                $('#shipment-save').click(function() {
-                                    return validateWarehouseAvailability();
+                                $("#shipment-save-action-confirmation-submit-button").bind("click", function () {
+                                    return validateWarehouseAvailability("save");
                                 });
-                                $('#shipment-save-continue').click(function() {
-                                    return validateWarehouseAvailability();
+                                $("#shipment-save-continue-action-confirmation-submit-button").bind("click", function () {
+                                    return validateWarehouseAvailability("continue");
                                 });
                             });
 
-                            function validateWarehouseAvailability() {
+                            function validateWarehouseAvailability(saveOrContinue) {
                                 @{
                                     var sb = new StringBuilder();
                                     for (var i = 0; i <= itemsFromMultipleWarehouses.Count - 1; i++)
@@ -85,7 +87,12 @@
                                 }
                                 var valid = @(Html.Raw(sb.ToString()));
                                 if (!valid) {
-                                    return confirm('@T("Admin.Orders.Shipments.Products.Warehouse.QuantityNotEnough")');
+                                    if (saveOrContinue === "save") {
+                                        $('#shipment-save-action-confirmation').modal('toggle');
+                                    }
+                                    if (saveOrContinue === "continue") {
+                                        $('#shipment-save-continue-action-confirmation').modal('toggle');
+                                    }
                                 }
                                 return true;
                             }

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/AddShipment.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/AddShipment.cshtml
@@ -31,8 +31,8 @@
                 <i class="fa fa-floppy-o"></i>
                 @T("Admin.Common.SaveContinue")
             </button>
-            <nop-action-confirmation asp-button-id="shipment-save" asp-additional-confirm='@T("Admin.Orders.Shipments.Products.Warehouse.QuantityNotEnough")' />
-            <nop-action-confirmation asp-button-id="shipment-save-continue" asp-additional-confirm='@T("Admin.Orders.Shipments.Products.Warehouse.QuantityNotEnough")'/>
+            <nop-action-confirmation asp-button-id="shipment-save" asp-additional-confirm="Admin.Orders.Shipments.Products.Warehouse.QuantityNotEnough" />
+            <nop-action-confirmation asp-button-id="shipment-save-continue" asp-additional-confirm="Admin.Orders.Shipments.Products.Warehouse.QuantityNotEnough"/>
             @await Component.InvokeAsync("AdminWidget", new { widgetZone = AdminWidgetZones.OrderShipmentAddButtons })
         </div>
     </div>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/AddShipment.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/AddShipment.cshtml
@@ -31,7 +31,7 @@
                 <i class="fa fa-floppy-o"></i>
                 @T("Admin.Common.SaveContinue")
             </button>
-            <nop-action-confirmation asp-button-id="shipment-save" asp-action="AddShipment" asp-additional-confirm='@T("Admin.Orders.Shipments.Products.Warehouse.QuantityNotEnough")' />
+            <nop-action-confirmation asp-button-id="shipment-save" asp-additional-confirm='@T("Admin.Orders.Shipments.Products.Warehouse.QuantityNotEnough")' />
             <nop-action-confirmation asp-button-id="shipment-save-continue" asp-additional-confirm='@T("Admin.Orders.Shipments.Products.Warehouse.QuantityNotEnough")'/>
             @await Component.InvokeAsync("AdminWidget", new { widgetZone = AdminWidgetZones.OrderShipmentAddButtons })
         </div>
@@ -60,54 +60,71 @@
                             </div>
                         </div>
                     </div>
-                    @if (itemsFromMultipleWarehouses.Any())
-                    {
-                        <script>
-                            $(document).ready(function() {
-                                $("#shipment-save-action-confirmation-submit-button").bind("click", function () {
-                                    return validateWarehouseAvailability("save");
-                                });
-                                $("#shipment-save-continue-action-confirmation-submit-button").bind("click", function () {
-                                    return validateWarehouseAvailability("continue");
-                                });
-                            });
+                    <script>
+                        $(document).ready(function () {
+                            $("#shipment-save").bind("focus", function () {
+                                if (validateWarehouseAvailability("save")) {
+                                    $("#shipment-save-action-confirmation").remove();
+                                    $(this).attr("name", "save").attr("type", "submit");
+                                }
+                            }).bind("click", function () {
+                                return validateWarehouseAvailability("save");
+                            });;
 
-                            function validateWarehouseAvailability(saveOrContinue) {
-                                @{
-                                    var sb = new StringBuilder();
-                                    for (var i = 0; i <= itemsFromMultipleWarehouses.Count - 1; i++)
+                            $("#shipment-save-continue").bind("focus", function () {
+                                if (validateWarehouseAvailability("continue")) {
+                                    $("#shipment-save-continue-action-confirmation").remove();
+                                    $(this).attr("name", "save-continue").attr("type", "submit");
+                                }
+                            }).bind("click", function () {
+                                return validateWarehouseAvailability("continue");
+                            });;
+                        });
+
+                        function validateWarehouseAvailability(action) {
+                            @{
+                                var sb = new StringBuilder();
+                                var count = itemsFromMultipleWarehouses.Count;
+                                if (count == 0)
+                                {
+                                    sb.Append("true");
+                                }
+                                else
+                                {
+                                    for (var i = 0; i <= count - 1; i++)
                                     {
                                         var item = itemsFromMultipleWarehouses[i];
                                         sb.AppendFormat("validateAvailableQuantity('{0}')", item.OrderItemId);
-                                        if (i != itemsFromMultipleWarehouses.Count - 1)
+                                        if (i != count - 1)
                                         {
                                             sb.Append(" && ");
                                         }
                                     }
                                 }
-                                var valid = @(Html.Raw(sb.ToString()));
-                                if (!valid) {
-                                    if (saveOrContinue === "save") {
-                                        $('#shipment-save-action-confirmation').modal('toggle');
-                                    }
-                                    if (saveOrContinue === "continue") {
-                                        $('#shipment-save-continue-action-confirmation').modal('toggle');
-                                    }
+                            }
+                            var valid = @(Html.Raw(sb.ToString()));
+                            if (!valid) {
+                                if (action === "save") {
+                                    $('#shipment-save-action-confirmation').modal('toggle');
                                 }
-                                return true;
+                                if (action === "continue") {
+                                    $('#shipment-save-continue-action-confirmation').modal('toggle');
+                                }
+                                return false;
                             }
+                            return true;
+                        }
 
-                            function validateAvailableQuantity(orderItemId) {
-                                var enteredValue = parseInt($('#qtyToAdd' + orderItemId).val(), 10);
-                                if (enteredValue <= 0)
-                                    return true;
-                                var reservedValue = parseInt($('#warehouse_' + orderItemId).find(':selected').data('reserved-qty'), 10);
-                                var plannedValue = parseInt($('#warehouse_' + orderItemId).find(':selected').data('planned-qty'), 10);
-                                var availableToAdd = reservedValue - plannedValue;
-                                return enteredValue <= availableToAdd;
-                            }
-                        </script>
-                    }
+                        function validateAvailableQuantity(orderItemId) {
+                            var enteredValue = parseInt($('#qtyToAdd' + orderItemId).val(), 10);
+                            if (enteredValue <= 0)
+                                return true;
+                            var reservedValue = parseInt($('#warehouse_' + orderItemId).find(':selected').data('reserved-qty'), 10);
+                            var plannedValue = parseInt($('#warehouse_' + orderItemId).find(':selected').data('planned-qty'), 10);
+                            var availableToAdd = reservedValue - plannedValue;
+                            return enteredValue <= availableToAdd;
+                        }
+                    </script>
                 </div>
 
                 <div class="panel panel-default">


### PR DESCRIPTION
@DmitriyKulagin  Please review and let me know your thought on "3" as follows. 

There are a couple of questions here:

1. Does this confirmation window look OK? It came from "Admin.Orders.Shipments.Products.Warehouse.QuantityNotEnough" and confirmation text has to come from localized resource as it is specifically for warehouse quantity computation. So I'd need to pass it into asp-additional-confirm.

2. Since we have both button trigger confirmation, I had to pass a button value to confirmation method in order to to differentiate between Save button and SaveAndContinue button, otherwise the confirmation windows would open twice.

3. The confirmation should only appear if meets warehouse quantity condition. Now that we have "<nop-action-confirmation asp-button-id="shipment-save">" in place and it causes the confirmation window to open all the time even if there is no warehouse selected. I thought a couple of ways doing this, like having a hidden button to act as a save button or adding an if condition to warp <nop-action-confirmation> it out. I would like to hear your suggestions so I can move toward the right direction.  

![image](https://user-images.githubusercontent.com/18490641/42516232-322b9184-8423-11e8-829b-ffd622b5b0aa.png)
