### PR TITLE
(Issue) Top cart icon not updating when initialing adding items to it

### DIFF
--- a/src/Presentation/Nop.Web/wwwroot/js/public.ajaxcart.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/public.ajaxcart.js
@@ -78,6 +78,7 @@ var AjaxCart = {
     success_process: function (response) {
         if (response.updatetopcartsectionhtml) {
             $(AjaxCart.topcartselector).html(response.updatetopcartsectionhtml);
+			$(AjaxCart.topcartselector).removeClass("hidden");
         }
         if (response.updatetopwishlistsectionhtml) {
             $(AjaxCart.topwishlistselector).html(response.updatetopwishlistsectionhtml);


### PR DESCRIPTION
This was an issue I encountered when adding an item to the cart for the first time (empty cart); the top cart icon in the menu did not update until the page was refreshed, after that the number of items in the cart would show and increase when other items were added.

I discovered that the cshtml page checks if items are in the cart and applies a 'hidden' css class if they are none on initial page load, and when adding items to the bag it does not reload the page so it does not remove the 'hidden' class.

The solution was to remove the css class from the element after an update is applied to the element

I couldn't see any bugs relating to this within the issue list, but since we added this change in it has fixed the problem for us, so I thought I'd put in a pull request with the fix into the main nopcommerce branch.