### PR TITLE
Fixing the bug: "Notify for qty below" setting in product details doesn't work

### DIFF
--- a/src/Libraries/Nop.Services/Catalog/ProductService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ProductService.cs
@@ -865,7 +865,7 @@ namespace Nop.Services.Catalog
             //filter by products with stock quantity less than the minimum
             query = query.Where(product =>
                 (product.UseMultipleWarehouses ? product.ProductWarehouseInventory.Sum(pwi => pwi.StockQuantity - pwi.ReservedQuantity)
-                    : product.StockQuantity) <= product.MinStockQuantity);
+                    : product.StockQuantity) <= product.NotifyAdminForQuantityBelow);
 
             //ignore deleted products
             query = query.Where(product => !product.Deleted);
@@ -920,7 +920,7 @@ namespace Nop.Services.Catalog
             var combinations = products.SelectMany(product => product.ProductAttributeCombinations);
 
             //filter by combinations with stock quantity less than the minimum
-            combinations = combinations.Where(combination => combination.StockQuantity <= 0);
+            combinations = combinations.Where(combination => combination.StockQuantity <= combination.NotifyAdminForQuantityBelow);
 
             combinations = combinations.OrderBy(combination => combination.ProductId).ThenBy(combination => combination.Id);
 


### PR DESCRIPTION
The "Notify for qty below" setting in product details doesn't work. It doesn't notify the store owner for stock quantities below the specified value. This is because wrong values are used in queries instead of using "Notify for qty below" setting.
Queries get corrected to use the "Notify for qty below" setting (NotifyAdminForQuantityBelow) for filtering the result sets.
Please refer to issue #3353 for more information.