### PR TITLE
Add a formatting correction to _FilterSpecsBox.cshtml

### DIFF
--- a/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
+++ b/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
@@ -15307,7 +15307,7 @@
     <Value>Remove Filter</Value>
   </LocaleResource>
   <LocaleResource Name="Filtering.SpecificationFilter.Separator">
-    <Value>or </Value>
+    <Value>or</Value>
   </LocaleResource>
   <LocaleResource Name="Footer.CustomerService">
     <Value>Customer service</Value>

--- a/src/Presentation/Nop.Web/Views/Catalog/_FilterSpecsBox.cshtml
+++ b/src/Presentation/Nop.Web/Views/Catalog/_FilterSpecsBox.cshtml
@@ -56,7 +56,7 @@
                             <li class="item">
                                 <strong>@group.First().SpecificationAttributeName</strong>:
                                 @group.ToList().Aggregate(string.Empty, (current, next) =>
-                                    $"{(string.IsNullOrEmpty(current) ? string.Empty : $"{current} {T("Filtering.SpecificationFilter.Separator")}")}{next.SpecificationAttributeOptionName}")
+                                    $"{(string.IsNullOrEmpty(current) ? string.Empty : $"{current} {T("Filtering.SpecificationFilter.Separator")} ")}{next.SpecificationAttributeOptionName}")
                             </li>
                         }
                     </ul>


### PR DESCRIPTION
Trailing space was used for formatting purpose in language resource "Filtering.SpecificationFilter.Separator". Also it seems that leading and trailing spaces are trimmed during editing of a language resource value.
The Formatting got corrected in \Presentation\Nop.Web\Views\Catalog\_FilterSpecsBox.cshtml file.