### PR TITLE
Apply font family settings to button elements

### DIFF
--- a/src/Presentation/Nop.Web/Themes/DefaultClean/Content/css/styles.css
+++ b/src/Presentation/Nop.Web/Themes/DefaultClean/Content/css/styles.css
@@ -94,7 +94,7 @@ textarea, select {
     padding: 8px;
     vertical-align: middle;
 }
-input, textarea, select {
+input, textarea, select, button {
 	font-size: 14px;
 	font-family: Arial, Helvetica, sans-serif;
 	color: #777;

--- a/src/Presentation/Nop.Web/Themes/DefaultClean/Content/css/styles.rtl.css
+++ b/src/Presentation/Nop.Web/Themes/DefaultClean/Content/css/styles.rtl.css
@@ -94,7 +94,7 @@ textarea, select {
     padding: 8px;
     vertical-align: middle;
 }
-input, textarea, select {
+input, textarea, select, button {
 	font-size: 14px;
 	font-family: Arial, Helvetica, sans-serif;
 	color: #777;


### PR DESCRIPTION
Apply font family settings to button elements in styles.css and styles.rtl.css
Currently web browser's font settings take precedence.
Example: "Proceed to checkout" button on shopping cart page.