### PR TITLE
#3380 ACL consideration when viewing product counts by tag

### DIFF
--- a/src/Libraries/Nop.Services/Catalog/IProductTagService.cs
+++ b/src/Libraries/Nop.Services/Catalog/IProductTagService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Nop.Core.Domain.Catalog;
+using Nop.Core.Domain.Customers;
 
 namespace Nop.Services.Catalog
 {
@@ -61,6 +62,7 @@ namespace Nop.Services.Catalog
         /// <returns>Number of products</returns>
         int GetProductCount(int productTagId, int storeId);
 
+        int GetProductCount(int productTagId, int storeId, Customer customer);
         /// <summary>
         /// Update product tags
         /// </summary>

--- a/src/Libraries/Nop.Services/Catalog/ProductTagService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ProductTagService.cs
@@ -84,7 +84,7 @@ namespace Nop.Services.Catalog
             var key = string.Format(NopCatalogDefaults.ProductTagCountCacheKey, storeId + "-" + roleParameters);
             return _staticCacheManager.Get(key, () =>
             {
-                return _dbContext.QueryFromSql<ProductTagWithCount>($"Exec ProductTagByRoleCountLoadAll {storeId}, ';{roleParameters};, {(_catalogSettings.IgnoreAcl ? 1 : 0)}'")
+                return _dbContext.QueryFromSql<ProductTagWithCount>($"Exec ProductTagByRoleCountLoadAll {storeId}, ';{roleParameters};', {(_catalogSettings.IgnoreAcl ? 1 : 0)}")
                     .ToDictionary(item => item.ProductTagId, item => item.ProductCount);
             });
         }

--- a/src/Presentation/Nop.Web/App_Data/Install/SqlServer.StoredProcedures.sql
+++ b/src/Presentation/Nop.Web/App_Data/Install/SqlServer.StoredProcedures.sql
@@ -736,6 +736,39 @@ BEGIN
 END
 GO
 
+CREATE PROCEDURE [dbo].[ProductTagByRoleCountLoadAll]
+(
+	@StoreId int,
+	@ActiveRoles as varchar(max),
+	@SettingIgnoreAcl int
+)
+AS
+BEGIN
+	SET NOCOUNT ON
+	
+	SELECT pt.Id as [ProductTagId], COUNT(p.Id) as [ProductCount]
+	FROM ProductTag pt with (NOLOCK)
+	LEFT JOIN Product_ProductTag_Mapping pptm with (NOLOCK) ON pt.[Id] = pptm.[ProductTag_Id]
+	LEFT JOIN Product p with (NOLOCK) ON pptm.[Product_Id] = p.[Id] 
+	WHERE
+		p.[Deleted] = 0
+		AND p.Published = 1
+		AND (@StoreId = 0 or (p.LimitedToStores = 0 OR EXISTS (
+			SELECT 1 FROM [StoreMapping] sm with (NOLOCK)
+			WHERE [sm].EntityId = p.Id AND [sm].EntityName = 'Product' and [sm].StoreId=@StoreId
+			)))
+		AND (@SettingIgnoreAcl = 1 
+			OR p.[SubjectToAcl] = 0 
+			OR EXISTS (
+				SELECT TOP (1) * FROM [AclRecord] acl with (NOLOCK)
+				where acl.[EntityName] = 'Product' AND acl.[EntityId] = p.[Id] AND @ActiveRoles LIKE '%;'+cast(acl.[CustomerRoleId] as varchar(20))+';%'
+			 )
+		)
+	GROUP BY pt.Id
+	ORDER BY pt.Id
+END
+GO
+
 CREATE PROCEDURE [dbo].[FullText_IsSupported]
 AS
 BEGIN	

--- a/src/Presentation/Nop.Web/Areas/Admin/Factories/ProductModelFactory.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Factories/ProductModelFactory.cs
@@ -1484,7 +1484,7 @@ namespace Nop.Web.Areas.Admin.Factories
 
             //get product tags
             var productTags = _productTagService.GetAllProductTags()
-                .OrderByDescending(tag => _productTagService.GetProductCount(tag.Id, storeId: 0)).ToList();
+                .OrderByDescending(tag => _productTagService.GetProductCount(tag.Id, storeId: 0, customer:_workContext.CurrentCustomer)).ToList();
 
             //prepare list model
             var model = new ProductTagListModel
@@ -1495,7 +1495,7 @@ namespace Nop.Web.Areas.Admin.Factories
                     var productTagModel = tag.ToModel<ProductTagModel>();
                     
                     //fill in additional values (not existing in the entity)
-                    productTagModel.ProductCount = _productTagService.GetProductCount(tag.Id, storeId: 0);
+                    productTagModel.ProductCount = _productTagService.GetProductCount(tag.Id, storeId: 0, customer: _workContext.CurrentCustomer);
 
                     return productTagModel;
                 }),
@@ -1524,7 +1524,7 @@ namespace Nop.Web.Areas.Admin.Factories
                     model = productTag.ToModel<ProductTagModel>();
                 }
                
-                model.ProductCount = _productTagService.GetProductCount(productTag.Id, storeId: 0);
+                model.ProductCount = _productTagService.GetProductCount(productTag.Id, storeId: 0, customer: _workContext.CurrentCustomer);
 
                 //define localized model configuration action
                 localizedModelConfiguration = (locale, languageId) =>

--- a/src/Presentation/Nop.Web/Factories/CatalogModelFactory.cs
+++ b/src/Presentation/Nop.Web/Factories/CatalogModelFactory.cs
@@ -1055,9 +1055,9 @@ namespace Nop.Web.Factories
                 var allTags = _productTagService
                     .GetAllProductTags()
                     //filter by current store
-                    .Where(x => _productTagService.GetProductCount(x.Id, _storeContext.CurrentStore.Id) > 0)
+                    .Where(x => _productTagService.GetProductCount(x.Id, _storeContext.CurrentStore.Id, _workContext.CurrentCustomer) > 0)
                     //order by product count
-                    .OrderByDescending(x => _productTagService.GetProductCount(x.Id, _storeContext.CurrentStore.Id))
+                    .OrderByDescending(x => _productTagService.GetProductCount(x.Id, _storeContext.CurrentStore.Id, _workContext.CurrentCustomer))
                     .ToList();
 
                 var tags = allTags
@@ -1074,7 +1074,7 @@ namespace Nop.Web.Factories
                         Id = tag.Id,
                         Name = _localizationService.GetLocalized(tag, y => y.Name),
                         SeName = _urlRecordService.GetSeName(tag),
-                        ProductCount = _productTagService.GetProductCount(tag.Id, _storeContext.CurrentStore.Id)
+                        ProductCount = _productTagService.GetProductCount(tag.Id, _storeContext.CurrentStore.Id, _workContext.CurrentCustomer)
                     });
                 return model;
             });
@@ -1135,7 +1135,7 @@ namespace Nop.Web.Factories
                 Tags = _productTagService
                 .GetAllProductTags()
                 //filter by current store
-                .Where(x => _productTagService.GetProductCount(x.Id, _storeContext.CurrentStore.Id) > 0)
+                .Where(x => _productTagService.GetProductCount(x.Id, _storeContext.CurrentStore.Id, _workContext.CurrentCustomer) > 0)
                 //sort by name
                 .OrderBy(x => _localizationService.GetLocalized(x, y => y.Name))
                 .Select(x =>
@@ -1145,7 +1145,7 @@ namespace Nop.Web.Factories
                         Id = x.Id,
                         Name = _localizationService.GetLocalized(x, y => y.Name),
                         SeName = _urlRecordService.GetSeName(x),
-                        ProductCount = _productTagService.GetProductCount(x.Id, _storeContext.CurrentStore.Id)
+                        ProductCount = _productTagService.GetProductCount(x.Id, _storeContext.CurrentStore.Id, _workContext.CurrentCustomer)
                     };
                     return ptModel;
                 })

--- a/src/Presentation/Nop.Web/Infrastructure/Cache/ModelCacheEventConsumer.cs
+++ b/src/Presentation/Nop.Web/Infrastructure/Cache/ModelCacheEventConsumer.cs
@@ -309,7 +309,7 @@ namespace Nop.Web.Infrastructure.Cache
         /// {1} : language id
         /// {2} : current store ID
         /// </remarks>
-        public const string PRODUCTTAG_BY_PRODUCT_MODEL_KEY = "Nop.pres.producttag.byproduct-{0}-{1}-{2}";
+        public const string PRODUCTTAG_BY_PRODUCT_MODEL_KEY = "Nop.pres.producttag.byproduct-{0}-{1}-{2}-{3}";
         public const string PRODUCTTAG_BY_PRODUCT_PATTERN_KEY = "Nop.pres.producttag.byproduct";
 
         /// <summary>


### PR DESCRIPTION
Product pages have a series of links for viewing the catalogue with a tag filter. These links display the count for the number of items in the catalogue with that tag.

Currently a product might not be visible to the user (because of their role) but will still add towards this count for a tag.

This PR adds extends the counts calculation with an additional stored procedure that queries AclRecords (access control list) if enabled.