### PR TITLE
Async operations wrapped in a Sync way.

### DIFF
--- a/src/Libraries/Nop.Core/Caching/RedisCacheManager.cs
+++ b/src/Libraries/Nop.Core/Caching/RedisCacheManager.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Nop.Core.Configuration;
+using Nop.Core.Infrastructure.Threading;
 using StackExchange.Redis;
 
 namespace Nop.Core.Caching
@@ -188,15 +189,15 @@ namespace Nop.Core.Caching
         public virtual T Get<T>(string key, Func<T> acquire, int? cacheTime = null)
         {
             //item already is in cache, so return it
-            if (this.IsSetAsync(key).Result)
-                return this.GetAsync<T>(key).Result;
+            if (this.IsSetAsync(key).AsSync())
+                return this.GetAsync<T>(key).AsSync();
 
             //or create it using passed function
             var result = acquire();
 
             //and set in cache (if cache time is defined)
             if ((cacheTime ?? NopCachingDefaults.CacheTime) > 0)
-                this.SetAsync(key, result, cacheTime ?? NopCachingDefaults.CacheTime).Wait();
+                this.SetAsync(key, result, cacheTime ?? NopCachingDefaults.CacheTime).AsSync();
 
             return result;
         }
@@ -207,9 +208,9 @@ namespace Nop.Core.Caching
         /// <param name="key">Key of cached item</param>
         /// <param name="data">Value for caching</param>
         /// <param name="cacheTime">Cache time in minutes</param>
-        public virtual async void Set(string key, object data, int cacheTime)
+        public virtual void Set(string key, object data, int cacheTime)
         {
-            await this.SetAsync(key, data, cacheTime);
+            this.SetAsync(key, data, cacheTime).AsSync();
         }
 
         /// <summary>
@@ -219,33 +220,33 @@ namespace Nop.Core.Caching
         /// <returns>True if item already is in cache; otherwise false</returns>
         public virtual bool IsSet(string key)
         {
-            return this.IsSetAsync(key).Result;
+            return this.IsSetAsync(key).AsSync();
         }
 
         /// <summary>
         /// Removes the value with the specified key from the cache
         /// </summary>
         /// <param name="key">Key of cached item</param>
-        public virtual async void Remove(string key)
+        public virtual void Remove(string key)
         {
-            await this.RemoveAsync(key);
+            this.RemoveAsync(key).AsSync();
         }
 
         /// <summary>
         /// Removes items by key pattern
         /// </summary>
         /// <param name="pattern">String key pattern</param>
-        public virtual async void RemoveByPattern(string pattern)
+        public virtual void RemoveByPattern(string pattern)
         {
-            await this.RemoveByPatternAsync(pattern);
+            this.RemoveByPatternAsync(pattern).AsSync();
         }
 
         /// <summary>
         /// Clear all cache data
         /// </summary>
-        public virtual async void Clear()
+        public virtual void Clear()
         {
-            await this.ClearAsync();
+            this.ClearAsync().AsSync();
         }
 
         /// <summary>

--- a/src/Libraries/Nop.Core/Http/ETagMiddleware.cs
+++ b/src/Libraries/Nop.Core/Http/ETagMiddleware.cs
@@ -1,0 +1,102 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Net.Http.Headers;
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+
+namespace Nop.Core.Http
+{
+    /// <summary>
+    /// Represents middleware that adds Etag to resources
+    /// <see cref="https://madskristensen.net/blog/send-etag-headers-in-aspnet-core/"/>
+    /// </summary>
+    public class ETagMiddleware
+    {
+        #region Fields
+
+        private readonly RequestDelegate _next;
+
+        #endregion
+
+        #region Ctor
+
+        public ETagMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Invoke middleware actions
+        /// </summary>
+        /// <param name="context">HTTP context</param>
+        /// <returns>Task</returns>
+        public async Task InvokeAsync(HttpContext context)
+        {
+            var response = context.Response;
+            var originalStream = response.Body;
+
+            using (var ms = new MemoryStream())
+            {
+                response.Body = ms;
+
+                await _next(context);
+
+                if (IsEtagSupported(response))
+                {
+                    string checksum = CalculateChecksum(ms);
+
+                    response.Headers[HeaderNames.ETag] = checksum;
+
+                    if (context.Request.Headers.TryGetValue(HeaderNames.IfNoneMatch, out var etag) && checksum == etag)
+                    {
+                        response.StatusCode = StatusCodes.Status304NotModified;
+                        response.Headers[HeaderNames.ContentLength] = "0";
+                        response.ContentLength = 0L;
+                        response.ContentType = null;
+                        response.Body = null;
+                        return;
+                    }
+                }
+
+                ms.Position = 0;
+                await ms.CopyToAsync(originalStream);
+            }
+        }
+
+        #endregion
+
+        private static bool IsEtagSupported(HttpResponse response)
+        {
+            if (response.StatusCode != StatusCodes.Status200OK)
+                return false;
+
+            // The 50kb length limit is not based in science. Feel free to change
+            if (response.Body.Length > 50 * 1024)
+                return false;
+
+            if (response.Headers.ContainsKey(HeaderNames.ETag))
+                return false;
+
+            return true;
+        }
+
+        private static string CalculateChecksum(MemoryStream ms)
+        {
+            string checksum = "";
+
+            using (var algo = SHA1.Create())
+            {
+                ms.Position = 0;
+                byte[] bytes = algo.ComputeHash(ms);
+                checksum = $"\"{WebEncoders.Base64UrlEncode(bytes)}\"";
+            }
+
+            return checksum;
+        }
+    }
+}

--- a/src/Libraries/Nop.Core/Infrastructure/Threading/AsyncExtensions.cs
+++ b/src/Libraries/Nop.Core/Infrastructure/Threading/AsyncExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Nop.Core.Infrastructure.Threading
+{
+    public static class AsyncExtensions
+    {
+        public static T AsSync<T>(this Task<T> asyncTask)
+        {
+            return asyncTask.ConfigureAwait(false)
+                    .GetAwaiter()
+                    .GetResult();
+        }
+
+        public static void AsSync(this Task asyncTask)
+        {
+            asyncTask.ConfigureAwait(false)
+                    .GetAwaiter()
+                    .GetResult();
+        }
+    }
+}

--- a/src/Libraries/Nop.Core/Infrastructure/Threading/AsyncHelper.cs
+++ b/src/Libraries/Nop.Core/Infrastructure/Threading/AsyncHelper.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nop.Core.Infrastructure.Threading
+{
+    /// <summary>
+    /// https://github.com/aspnet/AspNetIdentity/blob/master/src/Microsoft.AspNet.Identity.Core/AsyncHelper.cs
+    /// </summary>
+    public static class AsyncHelper
+    {
+        private static readonly TaskFactory HelperTaskFactory = new TaskFactory(CancellationToken.None, TaskCreationOptions.None, TaskContinuationOptions.None, TaskScheduler.Default);
+
+        public static TResult RunSync<TResult>(Func<Task<TResult>> func)
+        {
+            var cultureUi = CultureInfo.CurrentUICulture;
+            var culture = CultureInfo.CurrentCulture;
+
+            return HelperTaskFactory.StartNew(() =>
+            {
+                Thread.CurrentThread.CurrentCulture = culture;
+                Thread.CurrentThread.CurrentUICulture = cultureUi;
+
+                return func();
+            })
+            .Unwrap()
+            .GetAwaiter()
+            .GetResult();
+        }
+
+        public static void RunSync(Func<Task> func)
+        {
+            var cultureUi = CultureInfo.CurrentUICulture;
+            var culture = CultureInfo.CurrentCulture;
+
+            HelperTaskFactory.StartNew(() =>
+            {
+                Thread.CurrentThread.CurrentCulture = culture;
+                Thread.CurrentThread.CurrentUICulture = cultureUi;
+                return func();
+            })
+            .Unwrap()
+            .GetAwaiter()
+            .GetResult();
+        }
+    }
+}

--- a/src/Libraries/Nop.Services/Authentication/CookieAuthenticationService.cs
+++ b/src/Libraries/Nop.Services/Authentication/CookieAuthenticationService.cs
@@ -4,6 +4,7 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
 using Nop.Core.Domain.Customers;
+using Nop.Core.Infrastructure.Threading;
 using Nop.Services.Customers;
 
 namespace Nop.Services.Authentication
@@ -43,7 +44,7 @@ namespace Nop.Services.Authentication
         /// </summary>
         /// <param name="customer">Customer</param>
         /// <param name="isPersistent">Whether the authentication session is persisted across multiple requests</param>
-        public virtual async void SignIn(Customer customer, bool isPersistent)
+        public virtual void SignIn(Customer customer, bool isPersistent)
         {
             if (customer == null)
                 throw new ArgumentNullException(nameof(customer));
@@ -69,7 +70,7 @@ namespace Nop.Services.Authentication
             };
 
             //sign in
-            await _httpContextAccessor.HttpContext.SignInAsync(NopAuthenticationDefaults.AuthenticationScheme, userPrincipal, authenticationProperties);
+            _httpContextAccessor.HttpContext.SignInAsync(NopAuthenticationDefaults.AuthenticationScheme, userPrincipal, authenticationProperties).AsSync();
 
             //cache authenticated customer
             _cachedCustomer = customer;
@@ -78,13 +79,13 @@ namespace Nop.Services.Authentication
         /// <summary>
         /// Sign out
         /// </summary>
-        public virtual async void SignOut()
+        public virtual void SignOut()
         {
             //reset cached customer
             _cachedCustomer = null;
 
             //and sign out from the current authentication scheme
-            await _httpContextAccessor.HttpContext.SignOutAsync(NopAuthenticationDefaults.AuthenticationScheme);
+            _httpContextAccessor.HttpContext.SignOutAsync(NopAuthenticationDefaults.AuthenticationScheme).AsSync();
         }
 
         /// <summary>

--- a/src/Libraries/Nop.Services/Media/AzurePictureService.cs
+++ b/src/Libraries/Nop.Services/Media/AzurePictureService.cs
@@ -10,6 +10,7 @@ using Nop.Core.Data;
 using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Media;
 using Nop.Core.Infrastructure;
+using Nop.Core.Infrastructure.Threading;
 using Nop.Data;
 using Nop.Services.Catalog;
 using Nop.Services.Configuration;
@@ -100,8 +101,8 @@ namespace Nop.Services.Media
                 _azureBlobStorageConnectionString = config.AzureBlobStorageConnectionString;
                 _azureBlobStorageContainerName = config.AzureBlobStorageContainerName.Trim().ToLower();
                 _azureBlobStorageEndPoint = config.AzureBlobStorageEndPoint.Trim().ToLower().TrimEnd('/');
-                
-                CreateCloudBlobContainer();
+
+                CreateCloudBlobContainer().AsSync();
 
                 _isInitialized = true;
             }
@@ -110,7 +111,7 @@ namespace Nop.Services.Media
         /// <summary>
         /// Create cloud blob container
         /// </summary>
-        protected virtual async void CreateCloudBlobContainer()
+        protected virtual async Task CreateCloudBlobContainer()
         {
             var storageAccount = CloudStorageAccount.Parse(_azureBlobStorageConnectionString);
             if (storageAccount == null)
@@ -133,9 +134,9 @@ namespace Nop.Services.Media
         /// Delete picture thumbs
         /// </summary>
         /// <param name="picture">Picture</param>
-        protected override async void DeletePictureThumbs(Picture picture)
+        protected override void DeletePictureThumbs(Picture picture)
         {
-            await DeletePictureThumbsAsync(picture);
+            DeletePictureThumbsAsync(picture).AsSync();
         }
 
         /// <summary>
@@ -169,7 +170,7 @@ namespace Nop.Services.Media
         /// <returns>Result</returns>
         protected override bool GeneratedThumbExists(string thumbFilePath, string thumbFileName)
         {
-            return GeneratedThumbExistsAsync(thumbFilePath, thumbFileName).Result;
+            return GeneratedThumbExistsAsync(thumbFilePath, thumbFileName).AsSync();
         }
 
         /// <summary>
@@ -179,9 +180,9 @@ namespace Nop.Services.Media
         /// <param name="thumbFileName">Thumb file name</param>
         /// <param name="mimeType">MIME type</param>
         /// <param name="binary">Picture binary</param>
-        protected override async void SaveThumb(string thumbFilePath, string thumbFileName, string mimeType, byte[] binary)
+        protected override void SaveThumb(string thumbFilePath, string thumbFileName, string mimeType, byte[] binary)
         {
-            await SaveThumbAsync(thumbFilePath, thumbFileName, mimeType, binary);
+            SaveThumbAsync(thumbFilePath, thumbFileName, mimeType, binary).AsSync();
         }
 
         /// <summary>

--- a/src/Plugins/Nop.Plugin.Widgets.GoogleAnalytics/Api/GoogleRequest.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.GoogleAnalytics/Api/GoogleRequest.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Net.Http;
 using Nop.Core;
+using Nop.Core.Infrastructure.Threading;
 
 namespace Nop.Plugin.Widgets.GoogleAnalytics.Api
 {
@@ -28,7 +29,7 @@ namespace Nop.Plugin.Widgets.GoogleAnalytics.Api
         
         #region Utilities
 
-        private async void FireRequest(string url)
+        private void FireRequest(string url)
         {
             if (_requestCount < 500)
             {
@@ -38,7 +39,7 @@ namespace Nop.Plugin.Widgets.GoogleAnalytics.Api
                 try
                 {
                     // we don't need the response so this is the end of the request
-                    var response = (await httpClient.GetAsync(url)).EnsureSuccessStatusCode();
+                    var response = httpClient.GetAsync(url).AsSync().EnsureSuccessStatusCode();
                 }
                 catch (Exception)
                 {

--- a/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
@@ -296,5 +296,15 @@ namespace Nop.Web.Framework.Infrastructure.Extensions
                 EngineContext.Current.Resolve<IRoutePublisher>().RegisterRoutes(routeBuilder);
             });
         }
+
+        /// <summary>
+        /// Configure ETag headers in ASP.NET Core
+        /// Add this after static files but before MVC in order to provide ETags to MVC Views and Razor Pages.
+        /// </summary>
+        /// <param name="application">Builder for configuring an application's request pipeline</param>
+        public static void UseETagger(this IApplicationBuilder application)
+        {
+            application.UseMiddleware<ETagMiddleware>();
+        }
     }
 }

--- a/src/Presentation/Nop.Web.Framework/Infrastructure/NopMvcStartup.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/NopMvcStartup.cs
@@ -34,6 +34,9 @@ namespace Nop.Web.Framework.Infrastructure
         /// <param name="application">Builder for configuring an application's request pipeline</param>
         public void Configure(IApplicationBuilder application)
         {
+            // add Etag Middleware
+            application.UseETagger();
+
             //add MiniProfiler
             application.UseMiniProfiler();
 

--- a/src/Presentation/Nop.Web.Framework/Mvc/Filters/SignOutFromExternalAuthenticationAttribute.cs
+++ b/src/Presentation/Nop.Web.Framework/Mvc/Filters/SignOutFromExternalAuthenticationAttribute.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Nop.Core.Infrastructure.Threading;
 using Nop.Services.Authentication;
 
 namespace Nop.Web.Framework.Mvc.Filters
@@ -35,15 +36,15 @@ namespace Nop.Web.Framework.Mvc.Filters
             /// Called early in the filter pipeline to confirm request is authorized
             /// </summary>
             /// <param name="filterContext">Authorization filter context</param>
-            public async void OnAuthorization(AuthorizationFilterContext filterContext)
+            public void OnAuthorization(AuthorizationFilterContext filterContext)
             {
                 if (filterContext == null)
                     throw new ArgumentNullException(nameof(filterContext));
 
                 //sign out from the external authentication scheme
-                var authenticateResult = await filterContext.HttpContext.AuthenticateAsync(NopAuthenticationDefaults.ExternalAuthenticationScheme);
+                var authenticateResult = filterContext.HttpContext.AuthenticateAsync(NopAuthenticationDefaults.ExternalAuthenticationScheme).AsSync();
                 if (authenticateResult.Succeeded)
-                    await filterContext.HttpContext.SignOutAsync(NopAuthenticationDefaults.ExternalAuthenticationScheme);
+                    filterContext.HttpContext.SignOutAsync(NopAuthenticationDefaults.ExternalAuthenticationScheme).AsSync();
             }
 
             #endregion


### PR DESCRIPTION
I've changed the implementation for the sync operations calling async methods.

All the async method should always be awaited. It is not always the case in NopCommerce.

`async void` should always be [avoided](http://blog.stephencleary.com/2013/01/async-oop-2-constructors.html#what-not-to-do):

> At first glance, this seems like a reasonable approach: you get a regular constructor that kicks off an asynchronous operation; however, there are several drawbacks that are due to the use of async void.
> 
> The first problem is that when the constructor completes, the instance is still being asynchronously initialized, and there isn’t an obvious way to determine when the asynchronous initialization has completed.

Another [article](https://johnthiriet.com/removing-async-void/) worth reading on the subject.

And [this](https://cpratt.co/async-tips-tricks/) is a must read on different option when dealing with async operations in a sync methods.

I've included an helper `AsyncHelper `(with links to the source) which I've used in the past and it has worked pretty well. It is a bit expensive in terms of resource though.

It could be used like this:

`AsyncHelper.RunSync(() => this.RemoveByPatternAsync(pattern));`

There's never a real solutions to the [problem](https://stackoverflow.com/a/40344759/219406). The only option is to convert everything to Async. And I guess it make a lot of sense in ASP.NET CORE.
