### PR TITLE
Add DbContext pooling

### DIFF
--- a/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -305,7 +305,7 @@ namespace Nop.Web.Framework.Infrastructure.Extensions
         /// <param name="services">Collection of service descriptors</param>
         public static void AddNopObjectContext(this IServiceCollection services)
         {
-            services.AddDbContext<NopObjectContext>(optionsBuilder =>
+            services.AddDbContextPool<NopObjectContext>(optionsBuilder =>
             {
                 optionsBuilder.UseSqlServerWithLazyLoading(services);
             });


### PR DESCRIPTION
@AndreiMaz, @RomanovM, @skoshelev 
I haven't found any mentions and reasons why DbContext Pooling was avoided, so decided to add it.
The code change is very small and easy to roll back, but it can be very effective for performance and scaling.

Docs:
https://docs.microsoft.com/en-us/ef/core/what-is-new/ef-core-2.0#dbcontext-pooling