### PR TITLE
Use latest .NET Core SDK version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 mono: none
-dotnet: 2.2.101
+dotnet: 2.2
 dist: xenial
 install:
 - dotnet restore ./src/NopCommerce.sln


### PR DESCRIPTION
Targeting `2.2` will select the latest version, which currently is `2.2.102`. Patch updates should never break the build so this should be fine.