### PR TITLE
Fix feature 3386

### DIFF
--- a/src/Presentation/Nop.Web/Areas/Admin/Controllers/ProductController.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Controllers/ProductController.cs
@@ -1326,6 +1326,9 @@ namespace Nop.Web.Areas.Admin.Controllers
                     if (_productService.FindRelatedProduct(existingRelatedProducts, model.ProductId, product.Id) != null)
                         continue;
 
+                    if (model.ProductId == product.Id)
+                        continue;
+
                     _productService.InsertRelatedProduct(new RelatedProduct
                     {
                         ProductId1 = model.ProductId,


### PR DESCRIPTION
I added a simple check to see if the parent product id was equal to any of the new products that were being added. If the two matched, then I skipped over that product. 