### PR TITLE
The Version Not needed for Microsoft.AspNetCore

### DIFF
--- a/src/Libraries/Nop.Core/Nop.Core.csproj
+++ b/src/Libraries/Nop.Core/Nop.Core.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.3.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.1" />
+    <PackageReference Include="Microsoft.AspNetCore.App"/>
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Redis" Version="0.4.1" />
     <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.0.138" />
     <PackageReference Include="RedLock.net.StrongName" Version="2.1.0" />


### PR DESCRIPTION
To solve the warning below optionally you can remove the version of  **"Microsoft.AspNetCore.App"**

`C:\Program Files\dotnet\sdk\2.2.102\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.DefaultItems.targets(153,5): warning
NETSDK1071: A PackageReference to 'Microsoft.AspNetCore.App' specified a Version of `2.2.1`. Specifying the version of this package is not recommended. For more information, see`  [https://aka.ms/sdkimplicitrefs](https://aka.ms/sdkimplicitrefs)