### PR TITLE
Removed CurrencyExchangeRateModel inheritance from BaseNopModel

### DIFF
--- a/src/Presentation/Nop.Web/Areas/Admin/Models/Directory/CurrencyExchangeRateModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Models/Directory/CurrencyExchangeRateModel.cs
@@ -5,7 +5,7 @@ namespace Nop.Web.Areas.Admin.Models.Directory
     /// <summary>
     /// Represents a currency exchange rate model
     /// </summary>
-    public partial class CurrencyExchangeRateModel : BaseNopModel
+    public partial class CurrencyExchangeRateModel
     {
         #region Properties
 


### PR DESCRIPTION
<img width="938" alt="Memorydump" src="https://user-images.githubusercontent.com/29138349/54067743-d56e9600-41f8-11e9-82ed-82d04c61b20b.PNG">
This issue is happening due to a memory leak while binding the model. Please refer attached screenshot of the memory dump that shows that number of CurrencyExchangeRateModel objects in the memory while reproducing this issue. As per ASP.NET Core documentation model binding is taken care by the framework with an option of extending it with custom methods. I don't see any extensions for model binding in this case , so removed the inheritance of CurrencyExchangeRateModel. Tested the functionality (applied the exchange rate for a single currency as well as for all currencies (Apply All)) and it is working fine after this change