### PR TITLE
Issue 3709 RouteProvider refactorings

### DIFF
--- a/src/Presentation/Nop.Web/Controllers/BackInStockSubscriptionController.cs
+++ b/src/Presentation/Nop.Web/Controllers/BackInStockSubscriptionController.cs
@@ -187,7 +187,7 @@ namespace Nop.Web.Controllers
                 TotalRecords = list.TotalCount,
                 PageIndex = list.PageIndex,
                 ShowTotalSummary = false,
-                RouteActionName = "CustomerBackInStockSubscriptionsPaged",
+                RouteActionName = "CustomerBackInStockSubscriptions",
                 UseRouteLinks = true,
                 RouteValues = new BackInStockSubscriptionsRouteValues { pageNumber = pageIndex }
             };

--- a/src/Presentation/Nop.Web/Factories/ForumModelFactory.cs
+++ b/src/Presentation/Nop.Web/Factories/ForumModelFactory.cs
@@ -971,7 +971,7 @@ namespace Nop.Web.Factories
                 TotalRecords = list.TotalCount,
                 PageIndex = list.PageIndex,
                 ShowTotalSummary = false,
-                RouteActionName = "CustomerForumSubscriptionsPaged",
+                RouteActionName = "CustomerForumSubscriptions",
                 UseRouteLinks = true,
                 RouteValues = new ForumSubscriptionsRouteValues { pageNumber = pageIndex }
             };

--- a/src/Presentation/Nop.Web/Infrastructure/RouteProvider.cs
+++ b/src/Presentation/Nop.Web/Infrastructure/RouteProvider.cs
@@ -290,7 +290,7 @@ namespace Nop.Web.Infrastructure
             routeBuilder.MapLocalizedRoute("CustomerProfile", "profile/{id:min(0)}",
 				new { controller = "Profile", action = "Index" });
 
-            routeBuilder.MapLocalizedRoute("CustomerProfilePaged", "profile/{id}/page/{pageNumber:min(0)}",
+            routeBuilder.MapLocalizedRoute("CustomerProfilePaged", "profile/{id:min(0)}/page/{pageNumber:min(0)}",
 				new { controller = "Profile", action = "Index" });
 
             //orders

--- a/src/Presentation/Nop.Web/Infrastructure/RouteProvider.cs
+++ b/src/Presentation/Nop.Web/Infrastructure/RouteProvider.cs
@@ -342,7 +342,7 @@ namespace Nop.Web.Infrastructure
                 new { controller = "Customer", action = "GdprTools" });
 
             //customer check gift card balance 
-            routeBuilder.MapLocalizedRoute("CheckGiftCardBalance", "customer/CheckGiftCardBalance",
+            routeBuilder.MapLocalizedRoute("CheckGiftCardBalance", "customer/checkgiftcardbalance",
                 new { controller = "Customer", action = "CheckGiftCardBalance" });
 
             //poll vote AJAX link

--- a/src/Presentation/Nop.Web/Infrastructure/RouteProvider.cs
+++ b/src/Presentation/Nop.Web/Infrastructure/RouteProvider.cs
@@ -192,8 +192,8 @@ namespace Nop.Web.Infrastructure
             routeBuilder.MapLocalizedRoute("CheckoutConfirm", "checkout/confirm",
 				new { controller = "Checkout", action = "Confirm" });
 
-            routeBuilder.MapLocalizedRoute("CheckoutCompleted", "checkout/completed/{orderId:regex(\\d*)}",
-				new { controller = "Checkout", action = "Completed" });
+            routeBuilder.MapLocalizedRoute("CheckoutCompleted", "checkout/completed/{orderId:int}",
+                new { controller = "Checkout", action = "Completed" });
 
             //subscribe newsletters
             routeBuilder.MapLocalizedRoute("SubscribeNewsletter", "subscribenewsletter",
@@ -253,8 +253,8 @@ namespace Nop.Web.Infrastructure
             routeBuilder.MapLocalizedRoute("CustomerDownloadableProducts", "customer/downloadableproducts",
 				new { controller = "Customer", action = "DownloadableProducts" });
 
-            routeBuilder.MapLocalizedRoute("CustomerBackInStockSubscriptions", "backinstocksubscriptions/manage/{pageNumber:regex(\\d*)?}",
-				new { controller = "BackInStockSubscription", action = "CustomerSubscriptions" });
+            routeBuilder.MapLocalizedRoute("CustomerBackInStockSubscriptions", "backinstocksubscriptions/manage/{pageNumber:int?}",
+                new { controller = "BackInStockSubscription", action = "CustomerSubscriptions" });
 
             routeBuilder.MapLocalizedRoute("CustomerRewardPoints", "rewardpoints/history",
 				new { controller = "Order", action = "CustomerRewardPoints" });
@@ -277,8 +277,8 @@ namespace Nop.Web.Infrastructure
             routeBuilder.MapLocalizedRoute("CustomerForumSubscriptions", "boards/forumsubscriptions",
 				new { controller = "Boards", action = "CustomerForumSubscriptions" });
 
-            routeBuilder.MapLocalizedRoute("CustomerForumSubscriptionsPaged", "boards/forumsubscriptions/{pageNumber:regex(\\d*)}",
-				new { controller = "Boards", action = "CustomerForumSubscriptions" });
+            routeBuilder.MapLocalizedRoute("CustomerForumSubscriptionsPaged", "boards/forumsubscriptions/{pageNumber:int}",
+                new { controller = "Boards", action = "CustomerForumSubscriptions" });
 
             routeBuilder.MapLocalizedRoute("CustomerAddressEdit", "customer/addressedit/{addressId:min(0)}",
 				new { controller = "Customer", action = "AddressEdit" });
@@ -388,8 +388,8 @@ namespace Nop.Web.Infrastructure
             routeBuilder.MapLocalizedRoute("ActiveDiscussions", "boards/activediscussions",
 				new { controller = "Boards", action = "ActiveDiscussions" });
 
-            routeBuilder.MapLocalizedRoute("ActiveDiscussionsPaged", "boards/activediscussions/page/{pageNumber:regex(\\d*)}",
-				new { controller = "Boards", action = "ActiveDiscussions" });
+            routeBuilder.MapLocalizedRoute("ActiveDiscussionsPaged", "boards/activediscussions/page/{pageNumber:int}",
+                new { controller = "Boards", action = "ActiveDiscussions" });
 
             routeBuilder.MapLocalizedRoute("ActiveDiscussionsRSS", "boards/activediscussionsrss",
 				new { controller = "Boards", action = "ActiveDiscussionsRSS" });
@@ -424,8 +424,8 @@ namespace Nop.Web.Infrastructure
             routeBuilder.MapLocalizedRoute("TopicSlug", "boards/topic/{id:min(0)}/{slug?}",
 				new { controller = "Boards", action = "Topic" });
 
-            routeBuilder.MapLocalizedRoute("TopicSlugPaged", "boards/topic/{id:min(0)}/{slug?}/page/{pageNumber:regex(\\d*)}",
-				new { controller = "Boards", action = "Topic" });
+            routeBuilder.MapLocalizedRoute("TopicSlugPaged", "boards/topic/{id:min(0)}/{slug?}/page/{pageNumber:int}",
+                new { controller = "Boards", action = "Topic" });
 
             routeBuilder.MapLocalizedRoute("ForumWatch", "boards/forumwatch/{id:min(0)}",
 				new { controller = "Boards", action = "ForumWatch" });
@@ -436,8 +436,8 @@ namespace Nop.Web.Infrastructure
             routeBuilder.MapLocalizedRoute("ForumSlug", "boards/forum/{id:min(0)}/{slug?}",
 				new { controller = "Boards", action = "Forum" });
 
-            routeBuilder.MapLocalizedRoute("ForumSlugPaged", "boards/forum/{id:min(0)}/{slug?}/page/{pageNumber:regex(\\d*)}",
-				new { controller = "Boards", action = "Forum" });
+            routeBuilder.MapLocalizedRoute("ForumSlugPaged", "boards/forum/{id:min(0)}/{slug?}/page/{pageNumber:int}",
+                new { controller = "Boards", action = "Forum" });
 
             routeBuilder.MapLocalizedRoute("ForumGroupSlug", "boards/forumgroup/{id:min(0)}/{slug?}",
 				new { controller = "Boards", action = "ForumGroup"});

--- a/src/Presentation/Nop.Web/Infrastructure/RouteProvider.cs
+++ b/src/Presentation/Nop.Web/Infrastructure/RouteProvider.cs
@@ -253,10 +253,7 @@ namespace Nop.Web.Infrastructure
             routeBuilder.MapLocalizedRoute("CustomerDownloadableProducts", "customer/downloadableproducts",
 				new { controller = "Customer", action = "DownloadableProducts" });
 
-            routeBuilder.MapLocalizedRoute("CustomerBackInStockSubscriptions", "backinstocksubscriptions/manage",
-				new { controller = "BackInStockSubscription", action = "CustomerSubscriptions" });
-
-            routeBuilder.MapLocalizedRoute("CustomerBackInStockSubscriptionsPaged", "backinstocksubscriptions/manage/{pageNumber:regex(\\d*)}",
+            routeBuilder.MapLocalizedRoute("CustomerBackInStockSubscriptions", "backinstocksubscriptions/manage/{pageNumber:regex(\\d*)?}",
 				new { controller = "BackInStockSubscription", action = "CustomerSubscriptions" });
 
             routeBuilder.MapLocalizedRoute("CustomerRewardPoints", "rewardpoints/history",

--- a/src/Presentation/Nop.Web/Infrastructure/RouteProvider.cs
+++ b/src/Presentation/Nop.Web/Infrastructure/RouteProvider.cs
@@ -274,11 +274,8 @@ namespace Nop.Web.Infrastructure
             routeBuilder.MapLocalizedRoute("EmailRevalidation", "customer/revalidateemail",
 				new { controller = "Customer", action = "EmailRevalidation" });
 
-            routeBuilder.MapLocalizedRoute("CustomerForumSubscriptions", "boards/forumsubscriptions",
+            routeBuilder.MapLocalizedRoute("CustomerForumSubscriptions", "boards/forumsubscriptions/{pageNumber:int?}",
 				new { controller = "Boards", action = "CustomerForumSubscriptions" });
-
-            routeBuilder.MapLocalizedRoute("CustomerForumSubscriptionsPaged", "boards/forumsubscriptions/{pageNumber:int}",
-                new { controller = "Boards", action = "CustomerForumSubscriptions" });
 
             routeBuilder.MapLocalizedRoute("CustomerAddressEdit", "customer/addressedit/{addressId:min(0)}",
 				new { controller = "Customer", action = "AddressEdit" });


### PR DESCRIPTION
These commits fix the 4 route suggestions made in issue [3709](https://github.com/nopSolutions/nopCommerce/issues/3709).

As there are no unit tests for routes, I have gone through the changes to ensure that these routes still work as expected. Where routes have been removed, I have also gone through the code to find those removed route usages and point them to the correct route.