### PR TITLE
Issue 3813 - Support globalization in alpine runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,11 @@ RUN dotnet publish Nop.Web.csproj -c Release -o /app/published
 
 # create the runtime instance 
 FROM microsoft/dotnet:2.2-aspnetcore-runtime-alpine AS runtime 
-                                   
+
+# add globalization support
+RUN apk add --no-cache icu-libs
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
+
 WORKDIR /app        
 RUN mkdir bin
 RUN mkdir logs  


### PR DESCRIPTION
To enable globalization support we need to add the icu-libs apk package to the runtime environment in the docker container. We also need the DOTNET_SYSTEM_GLOBALIZATION_INVARIANT variable set to false (default true in alpine runtime) to support globalization.