### PR TITLE
Update public.accordion.js

### DIFF
--- a/src/Presentation/Nop.Web/wwwroot/js/public.accordion.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/public.accordion.js
@@ -37,6 +37,7 @@ var Accordion = {
             $('#' + this.currentSectionId).addClass('active');
             var contents = section.children('.a-item');
             $(contents[0]).show();
+            location.hash = section.attr('id');
 
             $(document).trigger({ type: "accordion_section_opened", previousSectionId: previousSectionId, currentSectionId: this.currentSectionId });
             
@@ -73,6 +74,7 @@ var Accordion = {
     showSection: function (section) {
         var section = $(section);
         section.show();
+        location.hash = section.attr('id');
 
         $(document).trigger({ type: "accordion_section_shown", sectionId: section.attr('id') });  
     },


### PR DESCRIPTION
On the OnePageCheckout page the location of the page does not move with the changing of the accordion sections.

This is not that noticeable on a desktop display but could become quiet annoying on mobile device's as you often end up at the bottom of the page when clicking continue to next section.

Stores that may have additional forms towards the footer of the page may loose sales due to customers not scrolling up to see if they filling in the correct form to complete the checkout process.
