### PR TITLE
Check if headers are sent before setting cookie

### DIFF
--- a/src/Presentation/Nop.Web.Framework/WebWorkContext.cs
+++ b/src/Presentation/Nop.Web.Framework/WebWorkContext.cs
@@ -102,7 +102,7 @@ namespace Nop.Web.Framework
         /// <param name="customerGuid">Guid of the customer</param>
         protected virtual void SetCustomerCookie(Guid customerGuid)
         {
-            if (_httpContextAccessor.HttpContext?.Response == null)
+            if (_httpContextAccessor.HttpContext?.Response == null || _httpContextAccessor.HttpContext.Response.HasStarted)
                 return;
 
             //delete current cookie value


### PR DESCRIPTION
This allows using `_workContext.CurrentCustomer` from signal-r hub callbacks, which set their own headers. Without this check, an error is thrown that complains that headers have already been sent.