### PR TITLE
Do not ignore email in GDPR when UsernamesEnabled

### DIFF
--- a/src/Libraries/Nop.Services/ExportImport/ExportManager.cs
+++ b/src/Libraries/Nop.Services/ExportImport/ExportManager.cs
@@ -1757,7 +1757,7 @@ namespace Nop.Services.ExportImport
             //customer info and customer attributes
             var customerManager = new PropertyManager<Customer>(new[]
             {
-                new PropertyByName<Customer>("Email", p => p.Email, _customerSettings.UsernamesEnabled),
+                new PropertyByName<Customer>("Email", p => p.Email),
                 new PropertyByName<Customer>("Username", p => p.Username, !_customerSettings.UsernamesEnabled), 
                 //attributes
                 new PropertyByName<Customer>("First name", p => _genericAttributeService.GetAttribute<string>(p, NopCustomerDefaults.FirstNameAttribute)),


### PR DESCRIPTION
When UsernamesEnabled, the registration form still asks for email. This means that the email is collected info regardless of UsernamesEnabled. The GDPR requires exporting *all* information related to the user, so this must also be exported regardless of the UsernamesEnabled setting.