### PR TITLE
issue-4081-chrome-problem-for-RTL-languages

### DIFF
--- a/src/Presentation/Nop.Web/wwwroot/css/admin/styles.rtl.css
+++ b/src/Presentation/Nop.Web/wwwroot/css/admin/styles.rtl.css
@@ -965,10 +965,6 @@ div.dataTables_wrapper div.dataTables_processing .fa {
 .form-horizontal .label-wrapper i.fa {
     width: 16px;
 }
-.form-horizontal .label-wrapper i.fa:before {
-    position: absolute;
-    top: 9px;
-}
 .form-horizontal span.required {
     color: #ff2e2e;
     margin-right: 6px;


### PR DESCRIPTION
[please visit this link to comprehend what is the exact issue](https://github.com/nopSolutions/nopCommerce/issues/4081)

The solution is removing this part of Css which really is not needed.
please lets see (chrome 77.x):
![English Sol](https://user-images.githubusercontent.com/10775073/64712778-0fcf2d80-d4d1-11e9-95e1-d35b41f964dc.jpg)

and also the firefox :
![fireSol](https://user-images.githubusercontent.com/10775073/64713088-8bc97580-d4d1-11e9-8a47-292e271db504.jpg)

