### PR TITLE
Add IMapper for Dependency Injection

### DIFF
--- a/src/Libraries/Nop.Core/Infrastructure/NopEngine.cs
+++ b/src/Libraries/Nop.Core/Infrastructure/NopEngine.cs
@@ -78,6 +78,9 @@ namespace Nop.Core.Infrastructure
 
             //register type finder
             containerBuilder.RegisterInstance(typeFinder).As<ITypeFinder>().SingleInstance();
+            
+            //register automapper
+            containerBuilder.RegisterInstance(AutoMapperConfiguration.Mapper).As<IMapper>().SingleInstance();
 
             //populate Autofac container builder with the set of registered service descriptors
             containerBuilder.Populate(services);


### PR DESCRIPTION
Currently the only possible way to access the mapper is through extension methods like .ToEntity or .ToModel and through a static property: AutoMapperConfiguration.Mapper . In my opinion this should also support DI. This PR will implement this.