### PR TITLE
Hotfix: DoesTypeImplementOpenGeneric

### DIFF
--- a/src/Libraries/Nop.Core/Infrastructure/AppDomainTypeFinder.cs
+++ b/src/Libraries/Nop.Core/Infrastructure/AppDomainTypeFinder.cs
@@ -164,7 +164,10 @@ namespace Nop.Core.Infrastructure
                         continue;
 
                     var isMatch = genericTypeDefinition.IsAssignableFrom(implementedInterface.GetGenericTypeDefinition());
-                    return isMatch;
+                    if (isMatch)
+                    {
+                        return true;
+                    }
                 }
 
                 return false;

--- a/src/Libraries/Nop.Core/Infrastructure/AppDomainTypeFinder.cs
+++ b/src/Libraries/Nop.Core/Infrastructure/AppDomainTypeFinder.cs
@@ -163,11 +163,8 @@ namespace Nop.Core.Infrastructure
                     if (!implementedInterface.IsGenericType)
                         continue;
 
-                    var isMatch = genericTypeDefinition.IsAssignableFrom(implementedInterface.GetGenericTypeDefinition());
-                    if (isMatch)
-                    {
+                    if (genericTypeDefinition.IsAssignableFrom(implementedInterface.GetGenericTypeDefinition()))
                         return true;
-                    }
                 }
 
                 return false;


### PR DESCRIPTION
The method DoesTypeImplementOpenGeneric now will check all implemented interfaces of given type, not only the first occurrence.