### PR TITLE
Fixes issue if customer was previously deleted and re-created.

### DIFF
--- a/src/Libraries/Nop.Services/Customers/CustomerService.cs
+++ b/src/Libraries/Nop.Services/Customers/CustomerService.cs
@@ -415,7 +415,7 @@ namespace Nop.Services.Customers
                 return null;
 
             var query = from c in _customerRepository.Table
-                        orderby c.Id
+                        orderby c.Deleted == true
                         where c.Email == email
                         select c;
             var customer = query.FirstOrDefault();
@@ -433,7 +433,7 @@ namespace Nop.Services.Customers
                 return null;
 
             var query = from c in _customerRepository.Table
-                        orderby c.Id
+                        orderby c.Deleted == true
                         where c.SystemName == systemName
                         select c;
             var customer = query.FirstOrDefault();
@@ -451,7 +451,7 @@ namespace Nop.Services.Customers
                 return null;
 
             var query = from c in _customerRepository.Table
-                        orderby c.Id
+                        orderby c.Deleted == true
                         where c.Username == username
                         select c;
             var customer = query.FirstOrDefault();


### PR DESCRIPTION
This issue sprouted up for our Administrative users.  We create logins for all of our employees so access isn't shared.  One employee left due to medical reasons and her account was "deleted".  2 years later she came back so her account had to be re-created.  In the Customers table - there's now 2 records for her by email.

On login - it fails because when looking up the user by Email, it will always return the first ever account that was created - which is now deleted in our Use-Case.  By changing the ordering it will return all matching results that are ACTIVE first - then take the FirstOrDefault.  Thus allowing her to login and utilize the site.

Worth Noting: also in CustomerService.cs n GetAllCustomers call - line # 167 is set to only ever return users that are active - thus no way of re-activating old/deleted users.

While the administrative user is the most likely use-case - I could see this as a use-case for clients that only sell to certain users EG: no-freely available login.  If they have a customer that "leaves" them - they may "delete" the user to deactivate the account.  And if the customer comes back.  I'm just spit-balling other use-cases.  I'm not sure how deleting a user with orders affects all the rest of the sales history.  Maybe this is only a valid use-case in the Admin user instance because there are no orders for the  user.