### PR TITLE
Allow use if integrated security with Azure SQL

### DIFF
--- a/src/Libraries/Nop.Core/Configuration/NopConfig.cs
+++ b/src/Libraries/Nop.Core/Configuration/NopConfig.cs
@@ -32,6 +32,11 @@ namespace Nop.Core.Configuration
         public bool AzureBlobStorageAppendContainerName { get; set; }
 
         /// <summary>
+        /// Setting this to true allows for connecting to Azure SQL using integrated security with a managed identity. Using integrated security, a password does not need to be embedded in the connection string. The connection uses the AppAuthentication package to request an access token from Azure when connecting.
+        /// </summary>
+        public bool UseAzureAccessTokenForSqlServer { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether we should use Redis server
         /// </summary>
         public bool RedisEnabled { get; set; }

--- a/src/Presentation/Nop.Web.Framework/Nop.Web.Framework.csproj
+++ b/src/Presentation/Nop.Web.Framework/Nop.Web.Framework.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="BundlerMinifier.Core" Version="2.9.406" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.4.0" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
     <PackageReference Include="WebMarkupMin.AspNetCore2" Version="2.6.1" />
     <PackageReference Include="WebMarkupMin.NUglify" Version="2.6.0" />
   </ItemGroup>

--- a/src/Presentation/Nop.Web/appsettings.json
+++ b/src/Presentation/Nop.Web/appsettings.json
@@ -20,6 +20,10 @@
     "AzureBlobStorageEndPoint": "",
     "AzureBlobStorageAppendContainerName": "true",
 
+    //Connects to Azure SQL using integrated security with a managed identity. Using integrated security, a password does not need to be embedded in the connection string. The connection uses the AppAuthentication package to request an access token from Azure when connecting.
+    //Find more about it at https://docs.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-connect-msi
+    "UseAzureAccessTokenForSqlServer": false,
+
     //Redis support (used by web farms, Azure, etc). Find more about it at https://azure.microsoft.com/en-us/documentation/articles/cache-dotnet-how-to-use-azure-redis-cache/
     "RedisEnabled": false,
     //Redis database id; If you need to use a specific redis database, just set its number here. Set empty if should use the different database for each data type (used by default); set -1 if you want to use the default database


### PR DESCRIPTION
For issue #4165. This change adds a flag to appsettings.json called 'UseAzureAccessTokenForSqlServer'. When enabled, when configuring the DbContextOptionsBuilder, an access token is obtained using AppAuthentication.AzureServiceTokenProvider and assigned to the SqlConnection. This allows for connecting to SQL using Azure Active Directory with integrated security. It works locally in Visual Studio (once configured) and on Azure using a managed identity.

More info:
https://docs.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-connect-msi