### PR TITLE
Allow use of integrated security with Azure SQL

### DIFF
--- a/src/Libraries/Nop.Core/Data/DataSettings.cs
+++ b/src/Libraries/Nop.Core/Data/DataSettings.cs
@@ -32,6 +32,11 @@ namespace Nop.Core.Data
         public string DataConnectionString { get; set; }
 
         /// <summary>
+        /// Whether to request an Azure token to use when authenticating with Azure SQL. Allows for connecting to Azure SQL using integrated security with a managed identity. Using integrated security, a password does not need to be embedded in the connection string. See https://docs.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-connect-msi.
+        /// </summary>
+        public bool UseAzureIntegratedSecurity { get; set; }
+
+        /// <summary>
         /// Gets or sets a raw settings
         /// </summary>
         public IDictionary<string, string> RawDataSettings { get; }

--- a/src/Libraries/Nop.Core/Data/DataSettingsManager.cs
+++ b/src/Libraries/Nop.Core/Data/DataSettingsManager.cs
@@ -64,6 +64,9 @@ namespace Nop.Core.Data
                             case "DataConnectionString":
                                 dataSettings.DataConnectionString = value;
                                 continue;
+                            case "UseAzureIntegratedSecurity":
+                                dataSettings.UseAzureIntegratedSecurity = value.Equals("true", StringComparison.OrdinalIgnoreCase);
+                                continue;
                             default:
                                 dataSettings.RawDataSettings.Add(key, value);
                                 continue;

--- a/src/Libraries/Nop.Data/Nop.Data.csproj
+++ b/src/Libraries/Nop.Data/Nop.Data.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="2.2.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.6" />
     <PackageReference Include="MiniProfiler.EntityFrameworkCore" Version="4.0.180" />

--- a/src/Libraries/Nop.Data/NopObjectContext.cs
+++ b/src/Libraries/Nop.Data/NopObjectContext.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Data;
 using System.Data.Common;
+using System.Data.SqlClient;
 using System.Linq;
 using System.Reflection;
+using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.EntityFrameworkCore;
 using Nop.Core;
+using Nop.Core.Data;
 using Nop.Data.Mapping;
 
 namespace Nop.Data
@@ -18,6 +21,12 @@ namespace Nop.Data
 
         public NopObjectContext(DbContextOptions<NopObjectContext> options) : base(options)
         {
+            var dataSettings = DataSettingsManager.LoadSettings();
+
+            if (dataSettings.UseAzureIntegratedSecurity)
+            {
+                ((SqlConnection)Database.GetDbConnection()).AccessToken = new AzureServiceTokenProvider().GetAccessTokenAsync("https://database.windows.net/").GetAwaiter().GetResult();
+            }
         }
 
         #endregion


### PR DESCRIPTION
For issue #4165. This change adds a flag to datasettings.json called 'UseAzureIntegratedSecurity'. When enabled, when constructing a NopObjectContext, an access token is obtained using AppAuthentication.AzureServiceTokenProvider and assigned to the SqlConnection. This allows for connecting to SQL using Azure Active Directory with integrated security. It works locally in Visual Studio (once configured) and on Azure using a managed identity.

More info:
https://docs.microsoft.com/en-us/azure/app-service/app-service-web-tutorial-connect-msi