### PR TITLE
Add LoginUsernamesEnabled to allow having usernames but requiring login with email address

### DIFF
--- a/src/Libraries/Nop.Core/Domain/Customers/CustomerSettings.cs
+++ b/src/Libraries/Nop.Core/Domain/Customers/CustomerSettings.cs
@@ -1,4 +1,4 @@
-﻿using Nop.Core.Configuration;
+using Nop.Core.Configuration;
 
 namespace Nop.Core.Domain.Customers
 {
@@ -11,6 +11,11 @@ namespace Nop.Core.Domain.Customers
         /// Gets or sets a value indicating whether usernames are used instead of emails
         /// </summary>
         public bool UsernamesEnabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether usernames are used to login instead of emails
+        /// </summary>
+        public bool LoginUsernamesEnabled { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether users can check the availability of usernames (when registering or changing on the 'My Account' page)

--- a/src/Libraries/Nop.Services/Customers/CustomerRegistrationService.cs
+++ b/src/Libraries/Nop.Services/Customers/CustomerRegistrationService.cs
@@ -110,7 +110,7 @@ namespace Nop.Services.Customers
         /// <returns>Result</returns>
         public virtual CustomerLoginResults ValidateCustomer(string usernameOrEmail, string password)
         {
-            var customer = _customerSettings.UsernamesEnabled ?
+            var customer = _customerSettings.LoginUsernamesEnabled ?
                 _customerService.GetCustomerByUsername(usernameOrEmail) :
                 _customerService.GetCustomerByEmail(usernameOrEmail);
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Models/Settings/CustomerSettingsModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Models/Settings/CustomerSettingsModel.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 using Nop.Web.Framework.Models;
 using Nop.Web.Framework.Mvc.ModelBinding;
 
@@ -15,6 +15,9 @@ namespace Nop.Web.Areas.Admin.Models.Settings
 
         [NopResourceDisplayName("Admin.Configuration.Settings.CustomerUser.UsernamesEnabled")]
         public bool UsernamesEnabled { get; set; }
+
+        [NopResourceDisplayName("Admin.Configuration.Settings.CustomerUser.LoginUsernamesEnabled")]
+        public bool LoginUsernamesEnabled { get; set; }
 
         [NopResourceDisplayName("Admin.Configuration.Settings.CustomerUser.AllowUsersToChangeUsernames")]
         public bool AllowUsersToChangeUsernames { get; set; }

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_CustomerUser.Account.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_CustomerUser.Account.cshtml
@@ -13,6 +13,15 @@
         </div>
     </div>
     <nop-nested-setting asp-for="CustomerSettings.UsernamesEnabled">
+        <div class="form-group advanced-setting" id="pnlLoginUsernamesEnabled">
+            <div class="col-md-3">
+                <nop-label asp-for="CustomerSettings.LoginUsernamesEnabled" />
+            </div>
+            <div class="col-md-9">
+                <nop-editor asp-for="CustomerSettings.LoginUsernamesEnabled" />
+                <span asp-validation-for="CustomerSettings.LoginUsernamesEnabled"></span>
+            </div>
+        </div>
         <div class="form-group advanced-setting" id="pnlAllowUsersToChangeUsernames">
             <div class="col-md-3">
                 <nop-label asp-for="CustomerSettings.AllowUsersToChangeUsernames" />

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_CustomerUser.Profile.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_CustomerUser.Profile.cshtml
@@ -50,10 +50,12 @@ function toggleAvatar() {
 
 function toggleUsername() {
     if ($('#@Html.IdFor(model => model.CustomerSettings.UsernamesEnabled)').is(':checked')) {
+        $('#pnlLoginUsernamesEnabled').show();
         $('#pnlAllowUsersToChangeUsernames').show();
         $('#pnlCheckUsernameAvailability').show();
         $('#pnlUsernameValidationEnabled').show();
     } else {
+        $('#pnlLoginUsernamesEnabled').hide();
         $('#pnlAllowUsersToChangeUsernames').hide();
         $('#pnlCheckUsernameAvailability').hide();
         $('#pnlUsernameValidationEnabled').hide();

--- a/src/Presentation/Nop.Web/Controllers/CustomerController.cs
+++ b/src/Presentation/Nop.Web/Controllers/CustomerController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -396,12 +396,12 @@ namespace Nop.Web.Controllers
                 {
                     model.Username = model.Username.Trim();
                 }
-                var loginResult = _customerRegistrationService.ValidateCustomer(_customerSettings.UsernamesEnabled ? model.Username : model.Email, model.Password);
+                var loginResult = _customerRegistrationService.ValidateCustomer(_customerSettings.LoginUsernamesEnabled ? model.Username : model.Email, model.Password);
                 switch (loginResult)
                 {
                     case CustomerLoginResults.Successful:
                         {
-                            var customer = _customerSettings.UsernamesEnabled
+                            var customer = _customerSettings.LoginUsernamesEnabled
                                 ? _customerService.GetCustomerByUsername(model.Username)
                                 : _customerService.GetCustomerByEmail(model.Email);
 

--- a/src/Presentation/Nop.Web/Factories/CustomerModelFactory.cs
+++ b/src/Presentation/Nop.Web/Factories/CustomerModelFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -569,7 +569,7 @@ namespace Nop.Web.Factories
         {
             var model = new LoginModel
             {
-                UsernamesEnabled = _customerSettings.UsernamesEnabled,
+                UsernamesEnabled = _customerSettings.LoginUsernamesEnabled,
                 RegistrationType = _customerSettings.UserRegistrationType,
                 CheckoutAsGuest = checkoutAsGuest.GetValueOrDefault(),
                 DisplayCaptcha = _captchaSettings.Enabled && _captchaSettings.ShowOnLoginPage

--- a/src/Presentation/Nop.Web/Validators/Customer/LoginValidator.cs
+++ b/src/Presentation/Nop.Web/Validators/Customer/LoginValidator.cs
@@ -10,7 +10,7 @@ namespace Nop.Web.Validators.Customer
     {
         public LoginValidator(ILocalizationService localizationService, CustomerSettings customerSettings)
         {
-            if (!customerSettings.UsernamesEnabled)
+            if (!customerSettings.LoginUsernamesEnabled)
             {
                 //login by email
                 RuleFor(x => x.Email).NotEmpty().WithMessage(localizationService.GetResource("Account.Login.Fields.Email.Required"));


### PR DESCRIPTION
This is for security reasons—usernames are public and as such it is easier to target a specific account. If login is done with email instead, then there is no such way to target a user—the email is private.

Let me know if anything else needs doing to get this merged.