### PR TITLE
Allow DataProtectionKeys to be stored in Azure Blob Storage

### DIFF
--- a/src/Libraries/Nop.Core/Configuration/NopConfig.cs
+++ b/src/Libraries/Nop.Core/Configuration/NopConfig.cs
@@ -32,6 +32,19 @@ namespace Nop.Core.Configuration
         public bool AzureBlobStorageAppendContainerName { get; set; }
 
         /// <summary>
+        /// Gets or sets whether to store Data Protection Keys in Azure Blob Storage
+        /// </summary>
+        public bool UseAzureBlobStorageToStoreDataProtectionKeys { get; set; }
+        /// <summary>
+        /// Gets or sets the Azure container name for storing Data Prtection Keys (this container should be separate from the container used for media and should be Private)
+        /// </summary>
+        public string AzureBlobStorageContainerNameForDataProtectionKeys { get; set; }
+        /// <summary>
+        /// Gets or sets the Azure key vault ID used to encrypt the Data Protection Keys. (this is optional)
+        /// </summary>
+        public string AzureKeyVaultIdForDataProtectionKeys { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether we should use Redis server
         /// </summary>
         public bool RedisEnabled { get; set; }
@@ -120,5 +133,11 @@ namespace Nop.Core.Configuration
         /// </summary>
         [JsonIgnore]
         public bool AzureBlobStorageEnabled => !string.IsNullOrEmpty(AzureBlobStorageConnectionString);
+
+        /// <summary>
+        /// Whether to use an Azure Key Vault to encrypt the Data Protection Keys
+        /// </summary>
+        [JsonIgnore]
+        public bool EncryptDataProtectionKeysWithAzureKeyVault => !string.IsNullOrEmpty(AzureKeyVaultIdForDataProtectionKeys);
     }
 }

--- a/src/Presentation/Nop.Web.Framework/Nop.Web.Framework.csproj
+++ b/src/Presentation/Nop.Web.Framework/Nop.Web.Framework.csproj
@@ -16,6 +16,9 @@
   <ItemGroup>
     <PackageReference Include="BundlerMinifier.Core" Version="2.9.406" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="8.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureKeyVault" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.AzureStorage" Version="2.2.7" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
     <PackageReference Include="WebMarkupMin.AspNetCore2" Version="2.6.1" />
     <PackageReference Include="WebMarkupMin.NUglify" Version="2.6.0" />
   </ItemGroup>

--- a/src/Presentation/Nop.Web/appsettings.json
+++ b/src/Presentation/Nop.Web/appsettings.json
@@ -20,6 +20,13 @@
     "AzureBlobStorageEndPoint": "",
     "AzureBlobStorageAppendContainerName": "true",
 
+    //Windows Azure BLOB storage for Data Protection Keys
+    "UseAzureBlobStorageToStoreDataProtectionKeys": "false",
+    //This should be a _PRIVATE_ container separate from the blob container used for media storage
+    "AzureBlobStorageContainerNameForDataProtectionKeys": "",
+    //Optionally encrypt the Data Protection Keys using an Azure Key Vault
+    "AzureKeyVaultIdForDataProtectionKeys": "",
+
     //Redis support (used by web farms, Azure, etc). Find more about it at https://azure.microsoft.com/en-us/documentation/articles/cache-dotnet-how-to-use-azure-redis-cache/
     "RedisEnabled": false,
     //Redis database id; If you need to use a specific redis database, just set its number here. Set empty if should use the different database for each data type (used by default); set -1 if you want to use the default database


### PR DESCRIPTION
Resolves issue #4166 

This has been tested and we are running it in production.

This PR adds 3 appsettings.json settings:

**UseAzureBlobStorageToStoreDataProtectionKeys**
true/false: whether to store data protection keys in an Azure blob storage container

**AzureBlobStorageContainerNameForDataProtectionKeys**
The container name to store the data protection keys. The connection string used is AzureBlobStorageConnectionString but the data protection keys need to live in a private container separate from the media container.

**AzureKeyVaultIdForDataProtectionKeys**
Optional key vault ID. If non-empty, the key stored in the blob container is encrypted using this Azure Key Vault.