### PR TITLE
lowercase non-western char from the seo char table

### DIFF
--- a/src/Libraries/Nop.Services/Seo/UrlRecordService.cs
+++ b/src/Libraries/Nop.Services/Seo/UrlRecordService.cs
@@ -1589,7 +1589,7 @@ namespace Nop.Services.Seo
                 if (convertNonWesternChars)
                 {
                     if (_seoCharacterTable?.ContainsKey(c2) ?? false)
-                        c2 = _seoCharacterTable[c2];
+                        c2 = _seoCharacterTable[c2].ToLowerInvariant();
                 }
 
                 if (allowUnicodeCharsInUrls)


### PR DESCRIPTION
Seo-friendly slug generation does not work as expected for a content which contains a specific Turkish character (capital i -> `İ`).