### PR TITLE
Null property in UPSShippingController causes 500 error on the config page for UPS plugin

### DIFF
--- a/src/Plugins/Nop.Plugin.Shipping.UPS/Controllers/UPSShippingController.cs
+++ b/src/Plugins/Nop.Plugin.Shipping.UPS/Controllers/UPSShippingController.cs
@@ -81,8 +81,17 @@ namespace Nop.Plugin.Shipping.UPS.Controllers
             };
 
             //prepare offered delivery services
-            var servicesCodes = _upsSettings.CarrierServicesOffered.Split(':', StringSplitOptions.RemoveEmptyEntries)
-                .Select(idValue => idValue.Trim('[', ']')).ToList();
+            if (_upsSettings.CarrierServicesOffered != null)
+            {
+                var servicesCodes = _upsSettings.CarrierServicesOffered.Split(':', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(idValue => idValue.Trim('[', ']')).ToList();
+
+                model.AvailableCarrierServices = DeliveryService.Standard.ToSelectList(false).Select(item =>
+                {
+                    var serviceCode = _upsService.GetUpsCode((DeliveryService)int.Parse(item.Value));
+                    return new SelectListItem($"UPS {item.Text?.TrimStart('_')}", serviceCode, servicesCodes.Contains(serviceCode));
+                }).ToList();
+            }
 
             //prepare available options
             model.AvailableCustomerClassifications = CustomerClassification.DailyRates.ToSelectList(false)
@@ -93,11 +102,8 @@ namespace Nop.Plugin.Shipping.UPS.Controllers
                 .Select(item => new SelectListItem(item.Text?.TrimStart('_'), item.Value)).ToList();
             model.AvaliablePackingTypes = PackingType.PackByDimensions.ToSelectList(false)
                 .Select(item => new SelectListItem(item.Text, item.Value)).ToList();
-            model.AvailableCarrierServices = DeliveryService.Standard.ToSelectList(false).Select(item =>
-            {
-                var serviceCode = _upsService.GetUpsCode((DeliveryService)int.Parse(item.Value));
-                return new SelectListItem($"UPS {item.Text?.TrimStart('_')}", serviceCode, servicesCodes.Contains(serviceCode));
-            }).ToList();
+
+            
 
             return View("~/Plugins/Shipping.UPS/Views/Configure.cshtml", model);
         }


### PR DESCRIPTION
If CarrierServiceOffered property is null, it breaks loading of the UPS configure page.  This in turn makes it impossible to set the value attempting to be loaded into that property.  Fix adds a null check and if it is found to be null, the config page still loads, allowing values to be set instead of a 500 error.