### PR TITLE
Revise exception handler to not rethrow exception

### DIFF
--- a/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;


### PR DESCRIPTION
I'm on Nop 4.1 where stack traces are hidden.  This is the code I used to fix the issue.  It seems that the problem was already somewhat fixed by utilizing `ExceptionDispatchInfo.Throw` in a prior commit.  This method does not modify the call stack at all.

Since it would seem that you've already fixed the problem, there's no need to pull this PR unless you think this technique is better.  Thanks!!