### PR TITLE
Fix wrong decimal precision under certain culture in PayPal standard, smart button plugin

### DIFF
--- a/src/Plugins/Nop.Plugin.Payments.PayPalSmartPaymentButtons/Services/ServiceManager.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalSmartPaymentButtons/Services/ServiceManager.cs
@@ -368,7 +368,7 @@ namespace Nop.Plugin.Payments.PayPalSmartPaymentButtons.Services
                     Quantity = item.Quantity.ToString(),
                     Category = (product.IsDownload ? ItemCategoryType.Digital_goods : ItemCategoryType.Physical_goods)
                         .ToString().ToUpper(),
-                    UnitAmount = new PayPalCheckoutSdk.Orders.Money { CurrencyCode = currency, Value = itemPrice.ToString("F") }
+                    UnitAmount = new PayPalCheckoutSdk.Orders.Money { CurrencyCode = currency, Value = $"{itemPrice:N2}" }
                 };
             }).ToList();
 
@@ -389,7 +389,7 @@ namespace Nop.Plugin.Payments.PayPalSmartPaymentButtons.Services
                         Name = CommonHelper.EnsureMaximumLength(attribute.Name, 127),
                         Description = CommonHelper.EnsureMaximumLength($"{attribute.Name} - {attributeValue.Name}", 127),
                         Quantity = 1.ToString(),
-                        UnitAmount = new PayPalCheckoutSdk.Orders.Money { CurrencyCode = currency, Value = roundedAttributePrice.ToString("F") }
+                        UnitAmount = new PayPalCheckoutSdk.Orders.Money { CurrencyCode = currency, Value = $"{roundedAttributePrice:N2}" }
                     });
                 }
             }
@@ -400,13 +400,13 @@ namespace Nop.Plugin.Payments.PayPalSmartPaymentButtons.Services
             purchaseUnit.AmountWithBreakdown = new AmountWithBreakdown
             {
                 CurrencyCode = currency,
-                Value = orderTotal.ToString("F"),
+                Value = $"{orderTotal:N2}",
                 AmountBreakdown = new AmountBreakdown
                 {
-                    ItemTotal = new PayPalCheckoutSdk.Orders.Money { CurrencyCode = currency, Value = itemTotal.ToString("F") },
-                    TaxTotal = new PayPalCheckoutSdk.Orders.Money { CurrencyCode = currency, Value = taxTotal.ToString("F") },
-                    Shipping = new PayPalCheckoutSdk.Orders.Money { CurrencyCode = currency, Value = shippingTotal.ToString("F") },
-                    Discount = new PayPalCheckoutSdk.Orders.Money { CurrencyCode = currency, Value = discountTotal.ToString("F") }
+                    ItemTotal = new PayPalCheckoutSdk.Orders.Money { CurrencyCode = currency, Value = $"{itemTotal:N2}" },
+                    TaxTotal = new PayPalCheckoutSdk.Orders.Money { CurrencyCode = currency, Value = $"{taxTotal:N2}" },
+                    Shipping = new PayPalCheckoutSdk.Orders.Money { CurrencyCode = currency, Value = $"{shippingTotal:N2}" },
+                    Discount = new PayPalCheckoutSdk.Orders.Money { CurrencyCode = currency, Value = $"{discountTotal:N2}" }
                 }
             };
 
@@ -475,7 +475,7 @@ namespace Nop.Plugin.Payments.PayPalSmartPaymentButtons.Services
             var request = new CapturesRefundRequest(captureId);
             var refundRequest = new RefundRequest();
             if (amount.HasValue)
-                refundRequest.Amount = new PayPalCheckoutSdk.Payments.Money { CurrencyCode = currency, Value = amount.Value.ToString("F") };
+                refundRequest.Amount = new PayPalCheckoutSdk.Payments.Money { CurrencyCode = currency, Value = $"{amount.Value:N2}" };
             request.RequestBody(refundRequest);
             return HandleRequest<PayPalHttpClient, CapturesRefundRequest, PayPalCheckoutSdk.Payments.Refund>(_client, request);
         }

--- a/src/Plugins/Nop.Plugin.Payments.PayPalStandard/PayPalStandardPaymentProcessor.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalStandard/PayPalStandardPaymentProcessor.cs
@@ -229,7 +229,7 @@ namespace Nop.Plugin.Payments.PayPalStandard
 
                 //add query parameters
                 parameters.Add($"item_name_{itemCount}", product.Name);
-                parameters.Add($"amount_{itemCount}", roundedItemPrice.ToString("0.00", CultureInfo.InvariantCulture));
+                parameters.Add($"amount_{itemCount}", $"{roundedItemPrice:N2}");
                 parameters.Add($"quantity_{itemCount}", item.Quantity.ToString());
 
                 cartTotal += item.PriceExclTax;
@@ -253,7 +253,7 @@ namespace Nop.Plugin.Payments.PayPalStandard
                         continue;
 
                     parameters.Add($"item_name_{itemCount}", attribute.Name);
-                    parameters.Add($"amount_{itemCount}", roundedAttributePrice.ToString("0.00", CultureInfo.InvariantCulture));
+                    parameters.Add($"amount_{itemCount}", $"{roundedAttributePrice:N2}");
                     parameters.Add($"quantity_{itemCount}", "1");
 
                     cartTotal += attributePrice;
@@ -267,7 +267,7 @@ namespace Nop.Plugin.Payments.PayPalStandard
             if (roundedShippingPrice > decimal.Zero)
             {
                 parameters.Add($"item_name_{itemCount}", "Shipping fee");
-                parameters.Add($"amount_{itemCount}", roundedShippingPrice.ToString("0.00", CultureInfo.InvariantCulture));
+                parameters.Add($"amount_{itemCount}", $"{roundedShippingPrice:N2}");
                 parameters.Add($"quantity_{itemCount}", "1");
 
                 cartTotal += postProcessPaymentRequest.Order.OrderShippingExclTax;
@@ -280,7 +280,7 @@ namespace Nop.Plugin.Payments.PayPalStandard
             if (roundedPaymentMethodPrice > decimal.Zero)
             {
                 parameters.Add($"item_name_{itemCount}", "Payment method fee");
-                parameters.Add($"amount_{itemCount}", roundedPaymentMethodPrice.ToString("0.00", CultureInfo.InvariantCulture));
+                parameters.Add($"amount_{itemCount}", $"{roundedPaymentMethodPrice:N2}");
                 parameters.Add($"quantity_{itemCount}", "1");
 
                 cartTotal += postProcessPaymentRequest.Order.PaymentMethodAdditionalFeeExclTax;
@@ -293,7 +293,7 @@ namespace Nop.Plugin.Payments.PayPalStandard
             if (roundedTaxAmount > decimal.Zero)
             {
                 parameters.Add($"item_name_{itemCount}", "Tax amount");
-                parameters.Add($"amount_{itemCount}", roundedTaxAmount.ToString("0.00", CultureInfo.InvariantCulture));
+                parameters.Add($"amount_{itemCount}", $"{roundedTaxAmount:N2}");
                 parameters.Add($"quantity_{itemCount}", "1");
 
                 cartTotal += postProcessPaymentRequest.Order.OrderTax;
@@ -307,7 +307,7 @@ namespace Nop.Plugin.Payments.PayPalStandard
                 roundedCartTotal -= discountTotal;
 
                 //gift card or rewarded point amount applied to cart in nopCommerce - shows in PayPal as "discount"
-                parameters.Add("discount_amount_cart", discountTotal.ToString("0.00", CultureInfo.InvariantCulture));
+                parameters.Add("discount_amount_cart", $"{discountTotal:N2}");
             }
 
             //save order total that actually sent to PayPal (used for PDT order total validation)
@@ -326,7 +326,7 @@ namespace Nop.Plugin.Payments.PayPalStandard
 
             parameters.Add("cmd", "_xclick");
             parameters.Add("item_name", $"Order Number {postProcessPaymentRequest.Order.CustomOrderNumber}");
-            parameters.Add("amount", roundedOrderTotal.ToString("0.00", CultureInfo.InvariantCulture));
+            parameters.Add("amount", $"{roundedOrderTotal:N2}");
 
             //save order total that actually sent to PayPal (used for PDT order total validation)
             _genericAttributeService.SaveAttribute(postProcessPaymentRequest.Order, PayPalHelper.OrderTotalSentToPayPal, roundedOrderTotal);


### PR DESCRIPTION
The current implementation uses toString("F") to convert money to string and send it to PayPal API. However, toString("F") gives 3 decimal places under some(if not all) culture settings resulting in rejection from PayPal API(only 2 decimal places is accepted).

So I think it is a good idea to enforce this 2 d.p. requirement by formatting it explicitly.