### PR TITLE
Issue 4597 handling videos

### DIFF
--- a/src/Libraries/Nop.Services/Media/RoxyFileman/BaseRoxyFilemanService.cs
+++ b/src/Libraries/Nop.Services/Media/RoxyFileman/BaseRoxyFilemanService.cs
@@ -112,7 +112,28 @@ namespace Nop.Services.Media.RoxyFileman
             if (fileExtension == ".swf" || fileExtension == ".flv")
                 fileType = "flash";
 
-            return fileType;
+            // Media file types supported by HTML5
+            if (fileExtension == ".mp4" || fileExtension == ".webm" // video
+                || fileExtension == ".ogg") // audio
+                fileType = "media";
+
+            // These media extensions are supported by tinyMCE
+            if (fileExtension == ".mov" // video
+                || fileExtension == ".m4a" || fileExtension == ".mp3" || fileExtension == ".wav") // audio
+                fileType = "media";
+
+            /* These media extensions are not supported by HTML5 or tinyMCE out of the box
+             * but may possibly be supported if You find players for them.
+             * if (fileExtension == ".3gp" || fileExtension == ".flv" 
+             *     || fileExtension == ".rmvb" || fileExtension == ".wmv" || fileExtension == ".divx"
+             *     || fileExtension == ".divx" || fileExtension == ".mpg" || fileExtension == ".rmvb"
+             *     || fileExtension == ".vob" // video
+             *     || fileExtension == ".aif" || fileExtension == ".aiff" || fileExtension == ".amr"
+             *     || fileExtension == ".asf" || fileExtension == ".asx" || fileExtension == ".wma"
+             *     || fileExtension == ".mid" || fileExtension == ".mp2") // audio
+             *     fileType = "media"; */
+
+             return fileType;
         }
 
         /// <summary>


### PR DESCRIPTION
This is a possible solution for issue #4597 .
This change allows Roxy Fileman to display many types of media files.
Please take a look at this list of extensions - it was based on list of extension icons in Roxy js files and may be incomplete.

I've included video and audio files, because Roxy treats them all as Media type. You may want to remove audio extensions, because tinyMCE show these files in "Add Video" tab.