### PR TITLE
#4133 Fix wrong values in disabled checkboxes for multistore settings

### DIFF
--- a/src/Presentation/Nop.Web/wwwroot/js/admin.common.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/admin.common.js
@@ -52,7 +52,7 @@ function checkOverriddenStoreValue(obj, selector) {
     // first toggle appropriate hidden inputs for checkboxes
     if ($(selector).is(':checkbox')) {
         var name = $(selector).attr('name');
-        $('input:hidden[name="' + name + '"]').attr('disabled', $(obj).is(':checked'));
+        $('input:hidden[name="' + name + '"]').attr('disabled', !$(obj).is(':checked'));
     }
 
     if (!$(obj).is(':checked')) {


### PR DESCRIPTION
The issue described in #4133 is still reproducible. This is a possible solution for this issue.

The state of the **disable** attribute should always be the same for both **checkbox input** and its hidden counterpart (which always has a **false** value).