### PR TITLE
Fixes #4821, adds 'back to' link for Shipping Methods page

### DIFF
--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shipping/Methods.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shipping/Methods.cshtml
@@ -10,6 +10,10 @@
 <div class="content-header clearfix">
     <h1 class="pull-left">
         @T("Admin.Configuration.Shipping.Methods")
+        <small>
+            <i class="fa fa-arrow-circle-left"></i>
+            <a asp-action="Providers">@T("Admin.Configuration.Shipping.Providers.BackToList")</a>
+        </small>
     </h1>
     <div class="pull-right">
         <a asp-action="CreateMethod" class="btn bg-blue">


### PR DESCRIPTION
This links back to the shipping rate computation method list instead of the plugin page.

![image](https://user-images.githubusercontent.com/564106/84192384-e5160380-aa67-11ea-9ae0-a402c3d9d45b.png)
