### PR TITLE
Replace 'payment_fee' to 'mc_fee'

### DIFF
--- a/src/Plugins/Nop.Plugin.Payments.PayPalStandard/Controllers/PaymentPayPalStandardController.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalStandard/Controllers/PaymentPayPalStandardController.cs
@@ -379,7 +379,7 @@ namespace Nop.Plugin.Payments.PayPalStandard.Controllers
                 values.TryGetValue("payer_id", out var payerId);
                 values.TryGetValue("receiver_id", out var receiverId);
                 values.TryGetValue("invoice", out var invoice);
-                values.TryGetValue("payment_fee", out var paymentFee);
+                values.TryGetValue("mc_fee", out var mcFee);
 
                 var sb = new StringBuilder();
                 sb.AppendLine("PayPal PDT:");
@@ -393,7 +393,7 @@ namespace Nop.Plugin.Payments.PayPalStandard.Controllers
                 sb.AppendLine("payer_id: " + payerId);
                 sb.AppendLine("receiver_id: " + receiverId);
                 sb.AppendLine("invoice: " + invoice);
-                sb.AppendLine("payment_fee: " + paymentFee);
+                sb.AppendLine("mc_fee: " + mcFee);
 
                 var newPaymentStatus = PayPalHelper.GetPaymentStatus(paymentStatus, string.Empty);
                 sb.AppendLine("New payment status: " + newPaymentStatus);


### PR DESCRIPTION
According to the PayPal documentation:
'payment_fee' is a deprecated field. Use 'mc_fee' instead.