### PR TITLE
#4850 Added inheritance support mapping for base entity

### DIFF
--- a/src/Libraries/Nop.Data/Migrations/MigrationManager.cs
+++ b/src/Libraries/Nop.Data/Migrations/MigrationManager.cs
@@ -88,7 +88,7 @@ namespace Nop.Data.Migrations
 
             if (!_typeMapping.ContainsKey(propType))
                 return;
-                
+            
             if (type == typeof(string) || propType.FindInterfaces((t, o) => t.FullName?.Equals(o.ToString(), StringComparison.InvariantCultureIgnoreCase) ?? false, "System.Collections.IEnumerable").Any())
                 canBeNullable = true;
 
@@ -211,7 +211,7 @@ namespace Nop.Data.Migrations
         public virtual void BuildTable<TEntity>(ICreateExpressionRoot expressionRoot)
         {
             var type = typeof(TEntity);
-
+            
             var builder = expressionRoot.Table(NameCompatibilityManager.GetTableName(type)) as CreateTableExpressionBuilder;
 
             RetrieveTableExpressions(type, builder);

--- a/src/Libraries/Nop.Data/Migrations/MigrationManager.cs
+++ b/src/Libraries/Nop.Data/Migrations/MigrationManager.cs
@@ -88,7 +88,7 @@ namespace Nop.Data.Migrations
 
             if (!_typeMapping.ContainsKey(propType))
                 return;
-            
+                
             if (type == typeof(string) || propType.FindInterfaces((t, o) => t.FullName?.Equals(o.ToString(), StringComparison.InvariantCultureIgnoreCase) ?? false, "System.Collections.IEnumerable").Any())
                 canBeNullable = true;
 
@@ -132,7 +132,8 @@ namespace Nop.Data.Migrations
             }
 
             var propertiesToAutoMap = type
-                .GetProperties(BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.SetProperty)
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.SetProperty)
+                .Where(p => p.CanWrite && p.CanRead)
                 .Where(p =>
                     !expression.Columns.Any(x => x.Name.Equals(NameCompatibilityManager.GetColumnName(type, p.Name), StringComparison.OrdinalIgnoreCase)));
 


### PR DESCRIPTION
Right now from type has DeclaredOnly binding gFlags which means we will get just declared properties form Current Instance. From some reason there are cases when we want to have extend base entity and based on this we will get all writable