### PR TITLE
Fix FluentMigratorMetadataReader to enable dictionary use

### DIFF
--- a/src/Libraries/Nop.Data/Mapping/FluentMigratorMetadataReader.cs
+++ b/src/Libraries/Nop.Data/Mapping/FluentMigratorMetadataReader.cs
@@ -121,8 +121,8 @@ namespace Nop.Data.Mapping
 
         #region Properties
 
-        protected static ConcurrentDictionary<(Type, MemberInfo), Attribute> Types => new ConcurrentDictionary<(Type, MemberInfo), Attribute>();
-        protected static ConcurrentDictionary<Type, CreateTableExpression> Expressions => new ConcurrentDictionary<Type, CreateTableExpression>();
+        protected static ConcurrentDictionary<(Type, MemberInfo), Attribute> Types { get; } = new ConcurrentDictionary<(Type, MemberInfo), Attribute>();
+        protected static ConcurrentDictionary<Type, CreateTableExpression> Expressions { get; } = new ConcurrentDictionary<Type, CreateTableExpression>();
 
         #endregion
     }


### PR DESCRIPTION
The dictionaries in the `FluentMigratorMetadataReader` are recreated for every call to the `GetAttribute` method, so the dictionary is completely ineffective.  This PR fixes the code to operate in its intended fashion.

This is because:
```csharp
public string Test => "hello";
```
is equivalent to:
```csharp
public string Test
{
  get {
    return "hello";
  }
}
```

On the other hand, this:
```csharp
public string Test { get; } = "hello";
```
is equivalent to:
```csharp
private string _test = "hello";  // hidden field on the class, set during the constructor or static constructor
public string Test
{
  get {
    return _test;
  }
}
```

Note that there are many other uses through the code of the `=>` operator for a static readonly property -- usually for `CacheKey` objects.  I'm guessing that all of these should probably be similarly changed (assuming the object is immutable, and/or intended to be accessed by multiple threads).