### PR TITLE
Add database type mapping for int64/long #4891

### DIFF
--- a/src/Libraries/Nop.Data/Migrations/MigrationManager.cs
+++ b/src/Libraries/Nop.Data/Migrations/MigrationManager.cs
@@ -49,6 +49,7 @@ namespace Nop.Data.Migrations
             _typeMapping = new Dictionary<Type, Action<ICreateTableColumnAsTypeSyntax>>()
             {
                 [typeof(int)] = c => c.AsInt32(),
+                [typeof(long)] = c => c.AsInt64(),
                 [typeof(string)] = c => c.AsString(int.MaxValue).Nullable(),
                 [typeof(bool)] = c => c.AsBoolean(),
                 [typeof(decimal)] = c => c.AsDecimal(18, 4),


### PR DESCRIPTION
There is no type mapping in MigrationManager.cs for long type.

A line should be added to _typeMapping :
[typeof(long)] = c => c.AsInt64(),

Source: https://www.nopcommerce.com/en/boards/topic/82849/43-missing-database-type-mapping-for-int64long