### PR TITLE
Edit Checkout Attribute issue from Admin

### DIFF
--- a/src/Presentation/Nop.Web/Areas/Admin/Views/CheckoutAttribute/_CreateOrUpdate.Condition.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/CheckoutAttribute/_CreateOrUpdate.Condition.cshtml
@@ -86,7 +86,7 @@
                                             <div class="checkbox">
                                                 <label>
                                                     <input type="hidden" asp-for="@Model.ConditionModel.ConditionAttributes[i].Values[j].Value" />
-                                                    <nop-editor asp-for="@Model.ConditionModel.ConditionAttributes[i].Values[j].Selected" />
+                                                    <input type="checkbox" asp-for="@Model.ConditionModel.ConditionAttributes[i].Values[j].Selected"/>
                                                     @Model.ConditionModel.ConditionAttributes[i].Values[j].Text
                                                 </label>
                                             </div>


### PR DESCRIPTION
#4858
The issue is relatively simple, as was used `<nop-editor>` with a complex "asp-for" expression and in "NopEditorTagHelper.cs" we do
"var htmlOutput = _htmlHelper.Editor(For.Name, Template, new { htmlAttributes, postfix = Postfix });" so we leave to get type for input for Framework, but Framework is working with ModelExplorer, and with this complex expression from "asp-for" ModelExplorer can't get the right Type for the property, and will render always as "text".

as Is a problem just for Conditional Part, Checkbox will always have just 2 values, so any validation here dont make too much sense, so i think we are ok using `<input type=checkbox>`
 