### PR TITLE
Display more user-friendly error when uploading non-picture file as a picture

### DIFF
--- a/src/Presentation/Nop.Web/Areas/Admin/Controllers/PictureController.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Controllers/PictureController.cs
@@ -51,6 +51,12 @@ namespace Nop.Web.Areas.Admin.Controllers
 
             //when returning JSON the mime-type must be set to text/plain
             //otherwise some browsers will pop-up a "Save As" dialog.
+
+            ///todo 
+            ///not sure we need this, as valid formats already handled on front-end side - Picture.cstml
+            if (picture == null)
+                return Json(new { success = false, message = "Wrong file format" });
+
             return Json(new
             {
                 success = true,

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/Picture.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/Picture.cshtml
@@ -24,7 +24,7 @@
 <div class="upload-picture-block">
     <div class="picture-container">
         <div id="@(clientId + "image")" class="uploaded-image">
-            <img src="@(pictureService.GetPictureUrl(Model, pictureSize, true))"/>
+            <img src="@(pictureService.GetPictureUrl(Model, pictureSize, true))" />
         </div>
     </div>
     <div class="upload-button-container">
@@ -85,7 +85,10 @@
                 endpoint: '@(Url.Content("~/Admin/Picture/AsyncUpload"))'
             },
             template: "@(clientId)-qq-template",
-            multiple: false
+            multiple: false,
+            validation: {
+                allowedExtensions: ['jpeg', 'jpg', 'gif', 'png']
+            }
         }).on("complete", function(event, id, name, responseJSON, xhr) {
             if (responseJSON.success) {
                 $("#@(clientId + "image")").html("<img src='" + responseJSON.imageUrl + "'/>");


### PR DESCRIPTION
Display more user-friendly error when uploading non-picture file as a picture 

#4919 

![Capture](https://user-images.githubusercontent.com/22330489/89188674-97e47880-d564-11ea-862e-d59475ec5d26.PNG)
