### PR TITLE
Fix orderby issue with linq2db 3.0.1

### DIFF
--- a/src/Libraries/Nop.Services/Catalog/CategoryService.cs
+++ b/src/Libraries/Nop.Services/Catalog/CategoryService.cs
@@ -557,7 +557,6 @@ namespace Nop.Services.Catalog
                         where pc.CategoryId == categoryId &&
                               !p.Deleted &&
                               (showHidden || p.Published)
-                        orderby pc.DisplayOrder, pc.Id
                         select pc;
 
             if (!showHidden && (!_catalogSettings.IgnoreAcl || !_catalogSettings.IgnoreStoreLimitations))
@@ -609,6 +608,9 @@ namespace Nop.Services.Catalog
                 }
 
                 query = query.Distinct().OrderBy(pc => pc.DisplayOrder).ThenBy(pc => pc.Id);
+            }
+            else {
+                query = query.OrderBy(pc => pc.DisplayOrder).ThenBy(pc => pc.Id);
             }
 
             var productCategories = new PagedList<ProductCategory>(query, pageIndex, pageSize);

--- a/src/Libraries/Nop.Services/Catalog/CategoryService.cs
+++ b/src/Libraries/Nop.Services/Catalog/CategoryService.cs
@@ -184,7 +184,6 @@ namespace Nop.Services.Catalog
             if (!string.IsNullOrWhiteSpace(categoryName))
                 query = query.Where(c => c.Name.Contains(categoryName));
             query = query.Where(c => !c.Deleted);
-            query = query.OrderBy(c => c.ParentCategoryId).ThenBy(c => c.DisplayOrder).ThenBy(c => c.Id);
             if (overridePublished.HasValue)
                 query = query.Where(c => c.Published == overridePublished.Value);
 
@@ -215,6 +214,9 @@ namespace Nop.Services.Catalog
 
                 query = query.Distinct().OrderBy(c => c.ParentCategoryId).ThenBy(c => c.DisplayOrder).ThenBy(c => c.Id);
             }
+            else {
+                query = query.OrderBy(c => c.ParentCategoryId).ThenBy(c => c.DisplayOrder).ThenBy(c => c.Id);
+            }
 
             var unsortedCategories = query.ToList();
 
@@ -244,7 +246,6 @@ namespace Nop.Services.Catalog
 
             query = query.Where(c => c.ParentCategoryId == parentCategoryId);
             query = query.Where(c => !c.Deleted);
-            query = query.OrderBy(c => c.DisplayOrder).ThenBy(c => c.Id);
 
             if (!showHidden && (!_catalogSettings.IgnoreAcl || !_catalogSettings.IgnoreStoreLimitations))
             {
@@ -293,6 +294,9 @@ namespace Nop.Services.Catalog
                 }
 
                 query = query.Distinct().OrderBy(c => c.DisplayOrder).ThenBy(c => c.Id);
+            }
+            else {
+                query = query.OrderBy(c => c.DisplayOrder).ThenBy(c => c.Id);
             }
 
             var categories = query.ToCachedList(key);

--- a/src/Libraries/Nop.Services/Catalog/ManufacturerService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ManufacturerService.cs
@@ -405,7 +405,6 @@ namespace Nop.Services.Catalog
                 where pm.ProductId == productId &&
                       !m.Deleted &&
                       (showHidden || m.Published)
-                orderby pm.DisplayOrder, pm.Id
                 select pm;
 
             if (!showHidden && (!_catalogSettings.IgnoreAcl || !_catalogSettings.IgnoreStoreLimitations))
@@ -457,6 +456,9 @@ namespace Nop.Services.Catalog
                 }
 
                 query = query.Distinct().OrderBy(pm => pm.DisplayOrder).ThenBy(pm => pm.Id);
+            }
+            else {
+                query = query.OrderBy(pm => pm.DisplayOrder).ThenBy(pm => pm.Id);
             }
 
             var productManufacturers = query.ToCachedList(key);

--- a/src/Libraries/Nop.Services/Catalog/ManufacturerService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ManufacturerService.cs
@@ -148,10 +148,12 @@ namespace Nop.Services.Catalog
             query = query.Where(m => !m.Deleted);
             if (overridePublished.HasValue)
                 query = query.Where(m => m.Published == overridePublished.Value);
-            query = query.OrderBy(m => m.DisplayOrder).ThenBy(m => m.Id);
 
             if ((storeId <= 0 || _catalogSettings.IgnoreStoreLimitations) && (showHidden || _catalogSettings.IgnoreAcl))
+            {
+                query = query.OrderBy(m => m.DisplayOrder).ThenBy(m => m.Id);
                 return new PagedList<Manufacturer>(query, pageIndex, pageSize);
+            }
 
             if (!showHidden && !_catalogSettings.IgnoreAcl)
             {

--- a/src/Libraries/Nop.Services/Directory/CountryService.cs
+++ b/src/Libraries/Nop.Services/Directory/CountryService.cs
@@ -88,7 +88,6 @@ namespace Nop.Services.Directory
                 var query = _countryRepository.Table;
                 if (!showHidden)
                     query = query.Where(c => c.Published);
-                query = query.OrderBy(c => c.DisplayOrder).ThenBy(c => c.Name);
 
                 if (!showHidden && !_catalogSettings.IgnoreStoreLimitations)
                 {
@@ -102,6 +101,9 @@ namespace Nop.Services.Directory
                             select c;
 
                     query = query.Distinct().OrderBy(c => c.DisplayOrder).ThenBy(c => c.Name);
+                }
+                else {
+                    query = query.OrderBy(c => c.DisplayOrder).ThenBy(c => c.Name);
                 }
 
                 var countries = query.ToList();

--- a/src/Libraries/Nop.Services/Messages/MessageTemplateService.cs
+++ b/src/Libraries/Nop.Services/Messages/MessageTemplateService.cs
@@ -159,10 +159,12 @@ namespace Nop.Services.Messages
             var key = _cacheKeyService.PrepareKeyForDefaultCache(NopMessageDefaults.MessageTemplatesAllCacheKey, storeId);
 
             var query = _messageTemplateRepository.Table;
-            query = query.OrderBy(t => t.Name);
 
             if (storeId <= 0 || _catalogSettings.IgnoreStoreLimitations)
+            {
+                query = query.OrderBy(t => t.Name);
                 return query.ToCachedList(key);
+            }
 
             //store mapping
             query = from t in query

--- a/src/Libraries/Nop.Services/Topics/TopicService.cs
+++ b/src/Libraries/Nop.Services/Topics/TopicService.cs
@@ -156,7 +156,6 @@ namespace Nop.Services.Topics
                     _customerService.GetCustomerRoleIds(_workContext.CurrentCustomer));
 
             var query = _topicRepository.Table;
-            query = query.OrderBy(t => t.DisplayOrder).ThenBy(t => t.SystemName);
 
             if (!showHidden)
                 query = query.Where(t => t.Published);
@@ -211,6 +210,9 @@ namespace Nop.Services.Topics
                 }
 
                 query = query.Distinct().OrderBy(t => t.DisplayOrder).ThenBy(t => t.SystemName);
+            }
+            else {
+                query = query.OrderBy(t => t.DisplayOrder).ThenBy(t => t.SystemName);
             }
 
             return query.ToCachedList(key);


### PR DESCRIPTION
This patch fixes the following error when nopcommerce is used with linq2db 3.0.1:
```
A column has been specified more than once in the order by list. Columns in the order by list must be unique.
```
I searched Nop.Services for uses of `OrderBy`, but there may be similar issues elsewhere.

There should be no ill effects for prior versions of linq2db