### PR TITLE
Standardize customer use in GetProductAttributeValuePriceAdjustment

### DIFF
--- a/src/Libraries/Nop.Services/Catalog/PriceCalculationService.cs
+++ b/src/Libraries/Nop.Services/Catalog/PriceCalculationService.cs
@@ -481,7 +481,7 @@ namespace Nop.Services.Catalog
                     var associatedProduct = _productService.GetProductById(value.AssociatedProductId);
                     if (associatedProduct != null)
                     {
-                        adjustment = GetFinalPrice(associatedProduct, _workContext.CurrentCustomer) * value.Quantity;
+                        adjustment = GetFinalPrice(associatedProduct, customer) * value.Quantity;
                     }
 
                     break;


### PR DESCRIPTION
GetProductAttributeValuePriceAdjustment should use the passed in Customer instead of the _workContext.Customer. This method calls GetFinalPrice two ways (lines 469 and 484) but is not consistent. It should use the Customer parameter so it can be used in plugins to get the price adjustment for a specific customer.