### PR TITLE
remove unnecessary dash in front of blog post-date

### DIFF
--- a/src/Presentation/Nop.Web/Views/Blog/List.cshtml
+++ b/src/Presentation/Nop.Web/Views/Blog/List.cshtml
@@ -44,7 +44,7 @@
                 <div class="post">
                     <div class="post-head">
                         <a class="post-title" href="@Url.RouteUrl("BlogPost", new {SeName = item.SeName})">@item.Title</a>
-                        <span class="post-date">-@item.CreatedOn.ToString("D")</span>
+                        <span class="post-date">@item.CreatedOn.ToString("D")</span>
                     </div>
                     @await Component.InvokeAsync("Widget", new { widgetZone = PublicWidgetZones.BlogListPageBeforePostBody, additionalData = item })
                     <div class="post-body">


### PR DESCRIPTION
I don't see any reason why there should be a leading dash in front of the blog post date