### PR TITLE
Add Skip link/Bypass block

### DIFF
--- a/src/Presentation/Nop.Web/Themes/DefaultClean/Content/css/styles.css
+++ b/src/Presentation/Nop.Web/Themes/DefaultClean/Content/css/styles.css
@@ -80,6 +80,33 @@ a {
 a img {
 	opacity: 0.99; /*firefox scale bug fix*/
 }
+a.skip {
+    position: absolute;
+    top: -1000px;
+    left: -1000px;
+    height: 1px;
+    width: 1px;
+    text-align: left;
+    overflow: hidden;
+}
+a.skip:active, 
+a.skip:focus, 
+a.skip:hover {
+    position: initial;
+    top: 0;
+    left:0;
+    display: block;
+    height: auto;
+    margin: 3px 0;
+    overflow: visible; 
+    padding: 2px;
+    color: #444444;
+    background: #ffffff;
+    text-decoration: underline;
+    text-align: center;
+    width: 100%;
+    font-size: 16px;
+}
 table {
 	width: 100%;
 	border-collapse: collapse;

--- a/src/Presentation/Nop.Web/Themes/DefaultClean/Content/css/styles.rtl.css
+++ b/src/Presentation/Nop.Web/Themes/DefaultClean/Content/css/styles.rtl.css
@@ -80,6 +80,33 @@ a {
 a img {
 	opacity: 0.99; /*firefox scale bug fix*/
 }
+a.skip {
+    position: absolute;
+    top: -1000px;
+    left: -1000px;
+    height: 1px;
+    width: 1px;
+    text-align: left;
+    overflow: hidden;
+}
+a.skip:active, 
+a.skip:focus, 
+a.skip:hover {
+    position: initial;
+    top: 0;
+    left:0;
+    display: block;
+    height: auto;
+    margin: 3px 0;
+    overflow: visible; 
+    padding: 2px;
+    color: #444444;
+    background: #ffffff;
+    text-decoration: underline;
+    text-align: center;
+    width: 100%;
+    font-size: 16px;
+}
 table {
 	width: 100%;
 	border-collapse: collapse;

--- a/src/Presentation/Nop.Web/Views/Shared/_Header.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/_Header.cshtml
@@ -1,4 +1,5 @@
 ﻿<div class="header">
+    <a class="skip" href="#main">Skip Navigation</a>
     @await Component.InvokeAsync("Widget", new { widgetZone = PublicWidgetZones.HeaderBefore })
     <div class="header-upper">
         <div class="header-selectors-wrapper">

--- a/src/Presentation/Nop.Web/Views/Shared/_Root.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/_Root.cshtml
@@ -5,7 +5,7 @@
 @await Html.PartialAsync("_Notifications")
 @await Html.PartialAsync("_JavaScriptDisabledWarning")
 @await Html.PartialAsync("_OldInternetExplorerWarning")
-<div class="master-wrapper-page">
+<div class="master-wrapper-page" id="main" role="main">
     @await Component.InvokeAsync("AdminHeaderLinks")
     @await Html.PartialAsync("_Header")
     <script asp-location="Footer">


### PR DESCRIPTION
This resolves the missing skip link issue. If you navigate to any page, the link will be invisible. If you hit tab one time, you will see the below link. If you tab again, it will disappear. If you click or hit enter on the link, the focus will jump to the next focusable link in the main section.

![skiplink](https://user-images.githubusercontent.com/824168/93156002-dbd2ad80-f6cc-11ea-96e0-f0cdbeb21d64.jpg)
