### PR TITLE
Updated missing DataTypes on Email Fields

### DIFF
--- a/src/Presentation/Nop.Web/Models/Catalog/ProductEmailAFriendModel.cs
+++ b/src/Presentation/Nop.Web/Models/Catalog/ProductEmailAFriendModel.cs
@@ -16,6 +16,7 @@ namespace Nop.Web.Models.Catalog
         [NopResourceDisplayName("Products.EmailAFriend.FriendEmail")]
         public string FriendEmail { get; set; }
 
+        [DataType(DataType.EmailAddress)]
         [NopResourceDisplayName("Products.EmailAFriend.YourEmailAddress")]
         public string YourEmailAddress { get; set; }
 

--- a/src/Presentation/Nop.Web/Models/Install/InstallModel.cs
+++ b/src/Presentation/Nop.Web/Models/Install/InstallModel.cs
@@ -14,6 +14,7 @@ namespace Nop.Web.Models.Install
             AvailableDataProviders = new List<SelectListItem>();
         }
 
+        [DataType(DataType.EmailAddress)]
         public string AdminEmail { get; set; }
         [NoTrim]
         [DataType(DataType.Password)]


### PR DESCRIPTION
Added DataType Attributes to the 2 instances I could find of it being missing. 

I was unable to locate any instances of PhoneNumber attributes being missing. 

