### PR TITLE
INopDataProvider ExecuteStoredProcedure custom timeouts

### DIFF
--- a/src/Libraries/Nop.Data/INopDataProvider.cs
+++ b/src/Libraries/Nop.Data/INopDataProvider.cs
@@ -189,9 +189,30 @@ namespace Nop.Data
         /// </summary>
         /// <typeparam name="T">Result record type</typeparam>
         /// <param name="procedureName">Procedure name</param>
+        /// <param name="timeout">Command timeout</param>
+        /// <param name="parameters">Command parameters</param>
+        /// <returns>Resulting value</returns>
+        T ExecuteStoredProcedure<T>(string procedureName, int timeout, params DataParameter[] parameters);
+
+        /// <summary>
+        /// Executes command using LinqToDB.Mapping.StoredProcedure command type and returns
+        /// single value
+        /// </summary>
+        /// <typeparam name="T">Result record type</typeparam>
+        /// <param name="procedureName">Procedure name</param>
         /// <param name="parameters">Command parameters</param>
         /// <returns>Resulting value</returns>
         T ExecuteStoredProcedure<T>(string procedureName, params DataParameter[] parameters);
+
+        /// <summary>
+        /// Executes command using LinqToDB.Mapping.StoredProcedure command type and returns
+        /// number of affected records.
+        /// </summary>
+        /// <param name="procedureName">Procedure name</param>
+        /// <param name="timeout">Command timeout</param>
+        /// <param name="parameters">Command parameters</param>
+        /// <returns>Returns collection of query result records</returns>
+        int ExecuteStoredProcedure(string procedureName, int timeout, params DataParameter[] parameters);
 
         /// <summary>
         /// Executes command using LinqToDB.Mapping.StoredProcedure command type and returns

--- a/src/Libraries/Nop.Data/MySqlDataProvider.cs
+++ b/src/Libraries/Nop.Data/MySqlDataProvider.cs
@@ -90,9 +90,9 @@ namespace Nop.Data
         /// <summary>
         /// Creates the database connection
         /// </summary>
-        protected override DataConnection CreateDataConnection()
+        protected override DataConnection CreateDataConnection(int timeout = 0)
         {
-            var dataContext = CreateDataConnection(LinqToDbDataProvider);
+            var dataContext = CreateDataConnection(LinqToDbDataProvider, timeout);
 
             ConfigureDataContext(dataContext);
 


### PR DESCRIPTION
In previous versions of NopCommerce, `IDBContext` allowed for setting custom timeouts for calls using ExecuteStoredProcedure(). This was removed in `INopDataProvider`, but I've had to custom add it into the codebase to allow for running a few client processes for some custom plugins.

I've set up this PR to be as minimally invasive as possible, to allow for previous usage, but allowing for setting a timeout on a particular stored procedure call that supersedes the `NopConfig` value.