### PR TITLE
Adding duplicate items to order should increment quantity

### DIFF
--- a/src/Libraries/Nop.Services/Orders/IOrderService.cs
+++ b/src/Libraries/Nop.Services/Orders/IOrderService.cs
@@ -148,6 +148,29 @@ namespace Nop.Services.Orders
         OrderItem GetOrderItemById(int orderItemId);
 
         /// <summary>
+        /// Finds a matching order item in the order
+        /// </summary>
+        /// <param name="order">order</param>
+        /// <param name="product">Product</param>
+        /// <param name="unitPriceInclTax">Unit price including tax</param>
+        /// <param name="unitPriceExclTax">Unit price excluding tax</param>
+        /// <param name="priceInclTax">Price including tax</param>
+        /// <param name="priceExclTax">Price excluding tax</param>
+        /// <param name="attributesXml">Attributes in XML format</param>
+        /// <param name="rentalStartDate">Rental start date</param>
+        /// <param name="rentalEndDate">Rental end date</param>
+        /// <returns>Found order item</returns>
+        OrderItem FindOrderItemInOrder(Order order,
+            Product product,
+            decimal unitPriceInclTax,
+            decimal unitPriceExclTax,
+            decimal priceInclTax,
+            decimal priceExclTax,
+            string attributesXml = "",
+            DateTime? rentalStartDate = null,
+            DateTime? rentalEndDate = null);
+        
+        /// <summary>
         /// Gets a product of specify order item
         /// </summary>
         /// <param name="orderItemId">Order item identifier</param>

--- a/src/Presentation/Nop.Web/Areas/Admin/Controllers/OrderController.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Controllers/OrderController.cs
@@ -1713,8 +1713,22 @@ namespace Nop.Web.Areas.Admin.Controllers
                     RentalStartDateUtc = rentalStartDate,
                     RentalEndDateUtc = rentalEndDate
                 };
-
-                _orderService.InsertOrderItem(orderItem);                
+                
+                //check for existing order item
+                var existingOrderItem =
+                    _orderService.FindOrderItemInOrder(order, product, unitPriceInclTax, unitPriceExclTax, priceInclTax, priceExclTax, attributesXml);
+                if (existingOrderItem != null)
+                {
+                    //update quantity for existing item
+                    existingOrderItem.Quantity += quantity;
+                    orderItem.Id = existingOrderItem.Id;
+                    _orderService.UpdateOrderItem(existingOrderItem);
+                }
+                else
+                {
+                    //add new item
+                    _orderService.InsertOrderItem(orderItem);
+                }
 
                 //adjust inventory
                 _productService.AdjustInventory(product, -orderItem.Quantity, orderItem.AttributesXml,


### PR DESCRIPTION
This should resolve issue #4669. 

These changes tested OK for me with `ordersettings.autoupdateordertotalsoneditingorder` both set and unset.

I followed the pattern used to prevent duplicate items in the shopping cart, but I'm happy to get feedback if there is a better approach.

