### PR TITLE
Added Errored enum to PaymentStatus

### DIFF
--- a/src/Libraries/Nop.Core/Domain/Payments/PaymentStatus.cs
+++ b/src/Libraries/Nop.Core/Domain/Payments/PaymentStatus.cs
@@ -1,4 +1,4 @@
-namespace Nop.Core.Domain.Payments
+﻿namespace Nop.Core.Domain.Payments
 {
     /// <summary>
     /// Represents a payment status enumeration
@@ -33,6 +33,11 @@ namespace Nop.Core.Domain.Payments
         /// <summary>
         /// Voided
         /// </summary>
-        Voided = 50
+        Voided = 50,
+
+        /// <summary>
+        /// Errored
+        /// </summary>
+        Errored = 60
     }
 }

--- a/src/Libraries/Nop.Services/Orders/OrderProcessingService.cs
+++ b/src/Libraries/Nop.Services/Orders/OrderProcessingService.cs
@@ -2335,7 +2335,7 @@ namespace Nop.Services.Orders
             if (order.OrderStatus == OrderStatus.Cancelled)
                 return false;
 
-            if (order.PaymentStatus == PaymentStatus.Pending)
+            if (order.PaymentStatus == PaymentStatus.Pending || order.PaymentStatus == PaymentStatus.Errored)
                 return true;
 
             return false;

--- a/src/Libraries/Nop.Services/Payments/PaymentService.cs
+++ b/src/Libraries/Nop.Services/Payments/PaymentService.cs
@@ -126,7 +126,7 @@ namespace Nop.Services.Payments
             if (order.OrderStatus == OrderStatus.Cancelled)
                 return false;  //do not allow for cancelled orders
 
-            if (order.PaymentStatus != PaymentStatus.Pending)
+            if (order.PaymentStatus != PaymentStatus.Pending || order.PaymentStatus != PaymentStatus.Errored)
                 return false;  //payment status should be Pending
 
             return paymentMethod.CanRePostProcessPayment(order);

--- a/src/Tests/Nop.Services.Tests/Orders/OrderProcessingServiceTests.cs
+++ b/src/Tests/Nop.Services.Tests/Orders/OrderProcessingServiceTests.cs
@@ -64,7 +64,7 @@ namespace Nop.Services.Tests.Orders
                         order.OrderStatus = os;
                         order.PaymentStatus = ps;
                         order.ShippingStatus = ss;
-                        if (os != OrderStatus.Cancelled && ps == PaymentStatus.Pending)
+                        if (os != OrderStatus.Cancelled && (ps == PaymentStatus.Pending || ps == PaymentStatus.Errored))
                             _orderProcessingService.CanMarkOrderAsAuthorized(order).Should().BeTrue();
                         else
                             _orderProcessingService.CanMarkOrderAsAuthorized(order).Should().BeFalse();


### PR DESCRIPTION
PaymentStatus does not currently have an option for Errored. This will be used when the payment gateway returns an error, and the user needs to be redirected to an error specific page.