### PR TITLE
Fixing typo in ExternalAuthenticationSettings.cs

### DIFF
--- a/src/Libraries/Nop.Core/Domain/Customers/ExternalAuthenticationSettings.cs
+++ b/src/Libraries/Nop.Core/Domain/Customers/ExternalAuthenticationSettings.cs
@@ -33,7 +33,7 @@ namespace Nop.Core.Domain.Customers
         public bool AllowCustomersToRemoveAssociations { get; set; }
 
         /// <summary>
-        /// Gets or sets system names of active payment methods
+        /// Gets or sets system names of active authentication methods
         /// </summary>
         public List<string> ActiveAuthenticationMethodSystemNames { get; set; }
     }


### PR DESCRIPTION
Just correcting a minor typo for the MAML of the ActiveAuthenticationMethodSystemNames property. Let me know if this needs a better branch name as I just created this PR from the web UI.