### PR TITLE
add ability to select Admin area language independently of the public (store) language

### DIFF
--- a/src/Libraries/Nop.Core/Domain/Customers/NopCustomerDefaults.cs
+++ b/src/Libraries/Nop.Core/Domain/Customers/NopCustomerDefaults.cs
@@ -211,6 +211,11 @@
         public static string LanguageIdAttribute => "LanguageId";
 
         /// <summary>
+        /// Gets a name of generic attribute to store the value of the Admin Area language Id 'AdminAreaLanguageId'
+        /// </summary>
+        public static string AdminAreaLanguageIdAttribute => "AdminAreaLanguageId";
+
+        /// <summary>
         /// Gets a name of generic attribute to store the value of 'LanguageAutomaticallyDetected'
         /// </summary>
         public static string LanguageAutomaticallyDetectedAttribute => "LanguageAutomaticallyDetected";


### PR DESCRIPTION
@DmitriyKulagin please review

implemented idea just allows customer to select languages independently.
public (store) site has language selector and it works like it was implemented 
admin area has its own selector and now it use
   - public value (if there is no its value selected)
   - its own if it is
 
#3914