### PR TITLE
fixed gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,7 +193,7 @@ src/Presentation/Nop.Web/wwwroot/images/uploaded/*
 !src/Presentation/Nop.Web/wwwroot/images/uploaded/placeholder.txt
 src/Presentation/Nop.Web/wwwroot/files/exportimport/*
 !src/Presentation/Nop.Web/wwwroot/files/exportimport/Index.htm
-src/Presentation/Nop.Web/wwwroot/lib_npm/cldr-data/main*
+src/Presentation/Nop.Web/wwwroot/lib_npm/cldr-data/main/*
 !src/Presentation/Nop.Web/wwwroot/lib_npm/cldr-data/main/en/*
 !src/Presentation/Nop.Web/wwwroot/lib_npm/cldr-data/main/main.zip
 src/packages/*


### PR DESCRIPTION
main.zip is not included in source control which may lead to an error during installation.
![imgpsh_mobile_save](https://user-images.githubusercontent.com/1305151/109302949-5128d980-783a-11eb-95a3-9aefd02d2267.jpg)

gitignore documentation mentions the following: 

> An optional prefix "!" which negates the pattern; any matching file excluded by a previous pattern will become included again. **It is not possible to re-include a file if a parent directory of that file is excluded.** 

Therefore the folder "main" has to be included.