### PR TITLE
Removing redundant cast

### DIFF
--- a/src/Libraries/Nop.Services/Media/RoxyFileman/RoxyFilemanProvider.cs
+++ b/src/Libraries/Nop.Services/Media/RoxyFileman/RoxyFilemanProvider.cs
@@ -50,7 +50,7 @@ namespace Nop.Services.Media.RoxyFileman
             if (_physicalFileProvider.GetFileInfo(subpath).Exists || !pictureService.IsStoreInDbAsync().Result)
                 return _physicalFileProvider.GetFileInfo(subpath);
 
-            var fileProvider = EngineContext.Current.Resolve<INopFileProvider>() as NopFileProvider;
+            var fileProvider = EngineContext.Current.Resolve<INopFileProvider>();
             var roxyFilemanService = EngineContext.Current.Resolve<IRoxyFilemanService>();
             var virtualPath = fileProvider?.GetVirtualPath(fileProvider.GetDirectoryName(_physicalFileProvider.GetFileInfo(subpath).PhysicalPath));
             roxyFilemanService.FlushImagesOnDiskAsync(virtualPath).Wait();


### PR DESCRIPTION
If this needs to be a specific implementation of `INopFileProvider`, that specific implementation should be fetched instead of assuming the type returned from the IoC container.
The cast appears to be redundant as `GetVirtualPath(...)` and `GetDirectoryName(...)` are available on `INopFileProvider` anyways.