### PR TITLE
add XSS protection config

### DIFF
--- a/src/Libraries/Nop.Core/Configuration/XssProtectionConfig.cs
+++ b/src/Libraries/Nop.Core/Configuration/XssProtectionConfig.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using System.Text.Encodings.Web;
+using System.Text.Unicode;
+
+namespace Nop.Core.Configuration
+{
+    /// <summary>
+    /// Represents XSS protection parameters
+    /// </summary>
+    public partial class XssProtectionConfig : IConfig
+    {
+        /// <summary>
+        /// Gets or sets a value specifing which code points are allowed to be represented unescaped by the encoders.
+        /// </summary>
+        public string[] TextEncoderAllowedRanges { get; set; } = new[] { nameof(UnicodeRanges.BasicLatin) };
+
+        /// <summary>
+        /// Gets a value of TextEncoderSettings.
+        /// </summary>
+        public TextEncoderSettings TextEncoderSettings
+        { 
+            get 
+            {
+                var allowedRanges = TextEncoderAllowedRanges
+                    .Select(r => typeof(UnicodeRanges).GetProperty(r.Split('.').Last()).GetValue(null))
+                    .Cast<UnicodeRange>()
+                    .ToArray();
+
+                return new TextEncoderSettings(allowedRanges);
+            } 
+        }
+
+        /// <summary>
+        /// Get or set a value of HtmlSanitizer parameters
+        /// </summary>
+        public string HtmlSanitizerSettings { get; set; } = "for future use of mganss/HtmlSanitizer";
+    }
+}

--- a/src/Presentation/Nop.Web.Framework/Extensions/HtmlExtensions.cs
+++ b/src/Presentation/Nop.Web.Framework/Extensions/HtmlExtensions.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using Ganss.XSS;
 using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -279,6 +280,23 @@ namespace Nop.Web.Framework.Extensions
             await using var writer = new StringWriter();
             htmlContent.WriteTo(writer, HtmlEncoder.Default);
             return writer.ToString();
+        }
+
+        /// <summary>
+        /// Sanitize HTML fragment before writing it Raw (XSS protection)
+        /// </summary>
+        /// <typeparam name="TModel">Model type</typeparam>
+        /// <param name="helper">HTML helper</param>
+        /// <param name="html">HTML fragment</param>
+        /// <returns>
+        /// Sanitized Html content
+        /// </returns>
+        public static IHtmlContent SanitizedRaw<TModel>(this IHtmlHelper<TModel> helper, string html)
+        {
+            //get Sanitizer
+            var htmlSanitizer = EngineContext.Current.Resolve<IHtmlSanitizer>();
+            var sanitized = htmlSanitizer.Sanitize(html);
+            return helper.Raw(sanitized);
         }
 
         #endregion

--- a/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.WebEncoders;
 using Newtonsoft.Json.Serialization;
 using Nop.Core;
 using Nop.Core.Configuration;
@@ -123,6 +124,23 @@ namespace Nop.Web.Framework.Infrastructure.Extensions
             {
                 options.Cookie.Name = $"{NopCookieDefaults.Prefix}{NopCookieDefaults.AntiforgeryCookie}";
                 options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+            });
+        }
+
+        /// <summary>
+        /// Adds services required for XSS protection
+        /// </summary>
+        /// <param name="services">Collection of service descriptors</param>
+        /// <param name="configuration">Configuration of the application</param>
+        public static void AddXssProtection(this IServiceCollection services, IConfiguration configuration)
+        {
+            //gets XSS protection settings
+            var xssProtectionConfig = configuration.GetSection(nameof(XssProtectionConfig)).Get<XssProtectionConfig>();
+
+            //use it to allow not only BasicLatin chars to be unescaped by the encoders  
+            services.Configure<WebEncoderOptions>(options =>
+            {
+                options.TextEncoderSettings = xssProtectionConfig.TextEncoderSettings;
             });
         }
 

--- a/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using System.Net;
 using Azure.Identity;
 using Azure.Storage.Blobs;
 using FluentValidation.AspNetCore;
+using Ganss.XSS;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -142,6 +143,9 @@ namespace Nop.Web.Framework.Infrastructure.Extensions
             {
                 options.TextEncoderSettings = xssProtectionConfig.TextEncoderSettings;
             });
+
+            //add HtmlSanitizer
+            services.AddSingleton<IHtmlSanitizer>(_ => new HtmlSanitizer());
         }
 
         /// <summary>

--- a/src/Presentation/Nop.Web.Framework/Infrastructure/NopMvcStartup.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/NopMvcStartup.cs
@@ -18,6 +18,9 @@ namespace Nop.Web.Framework.Infrastructure
         /// <param name="configuration">Configuration of the application</param>
         public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
         {
+            //adds and turns up XSS protection services
+            services.AddXssProtection(configuration);
+
             //add MiniProfiler services
             services.AddNopMiniProfiler();
 

--- a/src/Presentation/Nop.Web.Framework/Nop.Web.Framework.csproj
+++ b/src/Presentation/Nop.Web.Framework/Nop.Web.Framework.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.5.1" />
     <PackageReference Include="WebMarkupMin.AspNetCore5" Version="2.9.2" />
     <PackageReference Include="WebMarkupMin.NUglify" Version="2.9.2" />
+    <PackageReference Include="HtmlSanitizer" Version="5.0.404" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Presentation/Nop.Web/Views/Product/ProductTemplate.Simple.cshtml
+++ b/src/Presentation/Nop.Web/Views/Product/ProductTemplate.Simple.cshtml
@@ -72,7 +72,7 @@
                         @if (!string.IsNullOrEmpty(Model.ShortDescription))
                         {
                             <div class="short-description">
-                                @Html.Raw(Model.ShortDescription)
+                                @Html.SanitizedRaw(Model.ShortDescription)
                             </div>
                         }
                         @await Component.InvokeAsync("Widget", new { widgetZone = PublicWidgetZones.ProductDetailsOverviewTop, additionalData = Model })
@@ -138,7 +138,7 @@
                     @if (!string.IsNullOrEmpty(Model.FullDescription))
                     {
                         <div class="full-description">
-                            @Html.Raw(Model.FullDescription)
+                            @Html.SanitizedRaw(Model.FullDescription)
                         </div>
                     }
                     @await Component.InvokeAsync("Widget", new { widgetZone = PublicWidgetZones.ProductDetailsEssentialBottom, additionalData = Model })


### PR DESCRIPTION
here is two points to consider
**1**
it is possible to configure Html.Encode so it will allow not only BasicLatin chars to be unescaped
will fix  #5675 if add to appsettings.json 
```
"XssProtectionConfig": {
    "TextEncoderAllowedRanges": [
      "UnicodeRanges.All"
    ]
  }
```
discussed here https://github.com/aspnet/HttpAbstractions/issues/315 
and the same fix here https://github.com/OrchardCMS/OrchardCore/issues/4041 

**2** 
it seems we should use HTML Sanitation for rich HTML Input in such places like this
`@Html.Raw(Model.FullDescription)`
cuz today it possible to save something like <script>alert('qqq')</script> and it will run
this one for example https://github.com/mganss/HtmlSanitizer