### PR TITLE
Fix products search with multiple warehouses

### DIFF
--- a/src/Libraries/Nop.Services/Catalog/ProductService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ProductService.cs
@@ -833,7 +833,7 @@ namespace Nop.Services.Catalog
                         warehouseId == 0 ||
                         (
                             !p.UseMultipleWarehouses ? p.WarehouseId == warehouseId :
-                                _productWarehouseInventoryRepository.Table.Any(pwi => pwi.Id == warehouseId && pwi.ProductId == p.Id)
+                                _productWarehouseInventoryRepository.Table.Any(pwi => pwi.WarehouseId == warehouseId && pwi.ProductId == p.Id)
                         )
                     ) &&
                     (productType == null || p.ProductTypeId == (int)productType) &&


### PR DESCRIPTION
In SearchProductsAsync, when a product use multiple warehouses, the search was being done on ProductWarehouseInventory.Id instead of ProductWarehouseInventory.WarehouseId