### PR TITLE
Fix Select Shipping Options Params Ajax Call

### DIFF
--- a/src/Presentation/Nop.Web/Views/Shared/Components/ShoppingCartEstimateShipping/Default.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/Components/ShoppingCartEstimateShipping/Default.cshtml
@@ -54,7 +54,7 @@
 
                     $.ajax({
                         cache: false,
-                        url: '@Html.Raw(Url.Action("selectshippingoption", "shoppingcart"))' + (params ? '?$' + params : ''),
+                        url: '@Html.Raw(Url.Action("selectshippingoption", "shoppingcart"))' + (params ? '?' + params : ''),
                         data: $('#shopping-cart-form').serialize(),
                         type: 'POST',
                         beforeSend: function () {


### PR DESCRIPTION
Remove "$" symbol in query string url to pass "name" to controller "public virtual async Task<IActionResult> SelectShippingOption([FromQuery] string name, [FromQuery] EstimateShippingModel model, IFormCollection form)"

With $, name is getting null in controller parameter and return "No select shipping options" in ajax call.

As a result, the orderTotal is not updated with the selected and applied shipping value.