### PR TITLE
Install additional required packages in the Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,8 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 # installs required packages
 RUN apk add libgdiplus --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted
 RUN apk add libc-dev --no-cache
+RUN apk add freetype-dev --no-cache 
+RUN apk add fontconfig-dev --no-cache 
 
 # copy entrypoint script
 COPY ./entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
When running the version `4.40.4` Docker container there are issues with `libSkiaSharp` library missing required dependencies. The issues are:
- Images not scaling properly (they are full-sized) in the shopping cart page/checkout
- Website crashing when trying to edit the product

Adding these packages solves the issues. 

We wanted to fix the issue for other users as well since it might be a problem for them too. We saw issues like [this](https://github.com/nopSolutions/nopCommerce/issues/5563). [This](https://github.com/nopSolutions/nopCommerce/pull/5754) also didn't resolve the issue in our case. 

Keep in mind that we are currently using version `4.40.4` with this fix implemented. Given that this is a development branch, and you are continuously developing new features and fixing bugs, this might not be an ideal solution for these problems in the future and the given state of the `develop` branch. We are just trying to help.