### PR TITLE
reformat, rename fields, remove partial from single part classes

### DIFF
--- a/src/Libraries/Nop.Services/Html/BBCodeHelper.cs
+++ b/src/Libraries/Nop.Services/Html/BBCodeHelper.cs
@@ -1,4 +1,4 @@
-﻿﻿using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using Nop.Core.Domain.Common;
 using Nop.Services.Html.CodeFormatter;
 
@@ -7,7 +7,7 @@ namespace Nop.Services.Html
     /// <summary>
     /// Represents a BBCode helper
     /// </summary>
-    public partial class BBCodeHelper : IBBCodeHelper
+    public class BBCodeHelper : IBBCodeHelper
     {
         #region Filds
 
@@ -26,13 +26,26 @@ namespace Nop.Services.Html
 
         #region Fields
 
-        private static readonly Regex regexBold = new(@"\[b\](.+?)\[/b\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex regexItalic = new(@"\[i\](.+?)\[/i\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex regexUnderLine = new(@"\[u\](.+?)\[/u\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex regexUrl1 = new(@"\[url\=([^\]]+)\]([^\]]+)\[/url\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex regexUrl2 = new(@"\[url\](.+?)\[/url\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex regexQuote = new(@"\[quote=(.+?)\](.+?)\[/quote\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-        private static readonly Regex regexImg = new(@"\[img\](.+?)\[/img\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex _regexBold =
+            new(@"\[b\](.+?)\[/b\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex _regexItalic =
+            new(@"\[i\](.+?)\[/i\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex _regexUnderLine =
+            new(@"\[u\](.+?)\[/u\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex _regexUrl1 =
+            new(@"\[url\=([^\]]+)\]([^\]]+)\[/url\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex _regexUrl2 =
+            new(@"\[url\](.+?)\[/url\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex _regexQuote =
+            new(@"\[quote=(.+?)\](.+?)\[/quote\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        private static readonly Regex _regexImg =
+            new(@"\[img\](.+?)\[/img\]", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         #endregion
 
@@ -60,21 +73,21 @@ namespace Nop.Services.Html
             {
                 // format the bold tags: [b][/b]
                 // becomes: <strong></strong>
-                text = regexBold.Replace(text, "<strong>$1</strong>");
+                text = _regexBold.Replace(text, "<strong>$1</strong>");
             }
 
             if (replaceItalic)
             {
                 // format the italic tags: [i][/i]
                 // becomes: <em></em>
-                text = regexItalic.Replace(text, "<em>$1</em>");
+                text = _regexItalic.Replace(text, "<em>$1</em>");
             }
 
             if (replaceUnderline)
             {
                 // format the underline tags: [u][/u]
                 // becomes: <u></u>
-                text = regexUnderLine.Replace(text, "<u>$1</u>");
+                text = _regexUnderLine.Replace(text, "<u>$1</u>");
             }
 
             if (replaceUrl)
@@ -82,17 +95,19 @@ namespace Nop.Services.Html
                 var newWindow = _commonSettings.BbcodeEditorOpenLinksInNewWindow;
                 // format the URL tags: [url=https://www.nopCommerce.com]my site[/url]
                 // becomes: <a href="https://www.nopCommerce.com">my site</a>
-                text = regexUrl1.Replace(text, $"<a href=\"$1\" rel=\"nofollow\"{(newWindow ? " target=_blank" : "")}>$2</a>");
+                text = _regexUrl1.Replace(text,
+                    $"<a href=\"$1\" rel=\"nofollow\"{(newWindow ? " target=_blank" : "")}>$2</a>");
 
                 // format the URL tags: [url]https://www.nopCommerce.com[/url]
                 // becomes: <a href="https://www.nopCommerce.com">https://www.nopCommerce.com</a>
-                text = regexUrl2.Replace(text, $"<a href=\"$1\" rel=\"nofollow\"{(newWindow ? " target=_blank" : "")}>$1</a>");
+                text = _regexUrl2.Replace(text,
+                    $"<a href=\"$1\" rel=\"nofollow\"{(newWindow ? " target=_blank" : "")}>$1</a>");
             }
 
             if (replaceQuote)
             {
-                while (regexQuote.IsMatch(text))
-                    text = regexQuote.Replace(text, "<b>$1 wrote:</b><div class=\"quote\">$2</div>");
+                while (_regexQuote.IsMatch(text))
+                    text = _regexQuote.Replace(text, "<b>$1 wrote:</b><div class=\"quote\">$2</div>");
             }
 
             if (replaceCode)
@@ -104,7 +119,7 @@ namespace Nop.Services.Html
             {
                 // format the img tags: [img]https://www.nopCommerce.com/Content/Images/Image.jpg[/img]
                 // becomes: <img src="https://www.nopCommerce.com/Content/Images/Image.jpg">
-                text = regexImg.Replace(text, "<img src=\"$1\" class=\"user-posted-image\" alt=\"\">");
+                text = _regexImg.Replace(text, "<img src=\"$1\" class=\"user-posted-image\" alt=\"\">");
             }
 
             return text;

--- a/src/Presentation/Nop.Web.Framework/UI/NopHtmlHelper.cs
+++ b/src/Presentation/Nop.Web.Framework/UI/NopHtmlHelper.cs
@@ -17,7 +17,7 @@ namespace Nop.Web.Framework.UI
     /// <summary>
     /// Represents the HTML helper implementation
     /// </summary>
-    public partial class NopHtmlHelper : INopHtmlHelper
+    public class NopHtmlHelper : INopHtmlHelper
     {
         #region Fields
 
@@ -96,7 +96,8 @@ namespace Nop.Web.Framework.UI
         {
             AppendTitleParts(part);
 
-            var specificTitle = string.Join(_seoSettings.PageTitleSeparator, _titleParts.AsEnumerable().Reverse().ToArray());
+            var specificTitle = string.Join(_seoSettings.PageTitleSeparator,
+                _titleParts.AsEnumerable().Reverse().ToArray());
             string result;
             if (!string.IsNullOrEmpty(specificTitle))
             {
@@ -106,15 +107,16 @@ namespace Nop.Web.Framework.UI
                     switch (_seoSettings.PageTitleSeoAdjustment)
                     {
                         case PageTitleSeoAdjustment.PagenameAfterStorename:
-                            {
-                                result = string.Join(_seoSettings.PageTitleSeparator, _seoSettings.DefaultTitle, specificTitle);
-                            }
+                        {
+                            result = string.Join(_seoSettings.PageTitleSeparator, _seoSettings.DefaultTitle,
+                                specificTitle);
+                        }
                             break;
-                        case PageTitleSeoAdjustment.StorenameAfterPagename:
                         default:
-                            {
-                                result = string.Join(_seoSettings.PageTitleSeparator, specificTitle, _seoSettings.DefaultTitle);
-                            }
+                        {
+                            result = string.Join(_seoSettings.PageTitleSeparator, specificTitle,
+                                _seoSettings.DefaultTitle);
+                        }
                             break;
                     }
                 }
@@ -129,6 +131,7 @@ namespace Nop.Web.Framework.UI
                 //store name only
                 result = _seoSettings.DefaultTitle;
             }
+
             return _htmlEncoder.Encode(result);
         }
 
@@ -217,7 +220,8 @@ namespace Nop.Web.Framework.UI
         /// <param name="src">Script path (minified version)</param>
         /// <param name="debugSrc">Script path (full debug version). If empty, then minified version will be used</param>
         /// <param name="isAsync">A value indicating whether to add an attribute "async" or not for js files</param>
-        public virtual void AddScriptParts(ResourceLocation location, string src, string debugSrc = "", bool isAsync = false)
+        public virtual void AddScriptParts(ResourceLocation location, string src, string debugSrc = "",
+            bool isAsync = false)
         {
             if (!_scriptParts.ContainsKey(location))
                 _scriptParts.Add(location, new List<ScriptReferenceMeta>());
@@ -228,12 +232,7 @@ namespace Nop.Web.Framework.UI
             if (string.IsNullOrEmpty(debugSrc))
                 debugSrc = src;
 
-            _scriptParts[location].Add(new ScriptReferenceMeta
-            {
-                IsAsync = isAsync,
-                Src = src,
-                DebugSrc = debugSrc
-            });
+            _scriptParts[location].Add(new ScriptReferenceMeta {IsAsync = isAsync, Src = src, DebugSrc = debugSrc});
         }
 
         /// <summary>
@@ -243,7 +242,8 @@ namespace Nop.Web.Framework.UI
         /// <param name="src">Script path (minified version)</param>
         /// <param name="debugSrc">Script path (full debug version). If empty, then minified version will be used</param>
         /// <param name="isAsync">A value indicating whether to add an attribute "async" or not for js files</param>
-        public virtual void AppendScriptParts(ResourceLocation location, string src, string debugSrc = "", bool isAsync = false)
+        public virtual void AppendScriptParts(ResourceLocation location, string src, string debugSrc = "",
+            bool isAsync = false)
         {
             if (!_scriptParts.ContainsKey(location))
                 _scriptParts.Add(location, new List<ScriptReferenceMeta>());
@@ -254,12 +254,8 @@ namespace Nop.Web.Framework.UI
             if (string.IsNullOrEmpty(debugSrc))
                 debugSrc = src;
 
-            _scriptParts[location].Insert(0, new ScriptReferenceMeta
-            {
-                IsAsync = isAsync,
-                Src = src,
-                DebugSrc = debugSrc
-            });
+            _scriptParts[location]
+                .Insert(0, new ScriptReferenceMeta {IsAsync = isAsync, Src = src, DebugSrc = debugSrc});
         }
 
         /// <summary>
@@ -283,7 +279,8 @@ namespace Nop.Web.Framework.UI
             foreach (var item in _scriptParts[location].Distinct())
             {
                 var src = debugModel ? item.DebugSrc : item.Src;
-                result.AppendFormat("<script {1}src=\"{0}\"></script>", urlHelper.Content(src), item.IsAsync ? "async " : "");
+                result.AppendFormat("<script {1}src=\"{0}\"></script>", urlHelper.Content(src),
+                    item.IsAsync ? "async " : "");
                 result.Append(Environment.NewLine);
             }
 
@@ -347,6 +344,7 @@ namespace Nop.Web.Framework.UI
                 result.Append(item);
                 result.Append(Environment.NewLine);
             }
+
             return new HtmlString(result.ToString());
         }
 
@@ -367,11 +365,7 @@ namespace Nop.Web.Framework.UI
             if (string.IsNullOrEmpty(debugSrc))
                 debugSrc = src;
 
-            _cssParts[location].Add(new CssReferenceMeta
-            {
-                Src = src,
-                DebugSrc = debugSrc
-            });
+            _cssParts[location].Add(new CssReferenceMeta {Src = src, DebugSrc = debugSrc});
         }
 
         /// <summary>
@@ -391,11 +385,7 @@ namespace Nop.Web.Framework.UI
             if (string.IsNullOrEmpty(debugSrc))
                 debugSrc = src;
 
-            _cssParts[location].Insert(0, new CssReferenceMeta
-            {
-                Src = src,
-                DebugSrc = debugSrc
-            });
+            _cssParts[location].Insert(0, new CssReferenceMeta {Src = src, DebugSrc = debugSrc});
         }
 
         /// <summary>
@@ -419,9 +409,11 @@ namespace Nop.Web.Framework.UI
             foreach (var item in _cssParts[location].Distinct())
             {
                 var src = debugModel ? item.DebugSrc : item.Src;
-                result.AppendFormat("<link href=\"{0}\" rel=\"stylesheet\" type=\"{1}\" />", urlHelper.Content(src), MimeTypes.TextCss);
+                result.AppendFormat("<link href=\"{0}\" rel=\"stylesheet\" type=\"{1}\" />", urlHelper.Content(src),
+                    MimeTypes.TextCss);
                 result.AppendLine();
             }
+
             return new HtmlString(result.ToString());
         }
 
@@ -438,7 +430,8 @@ namespace Nop.Web.Framework.UI
             if (withQueryString)
             {
                 //add ordered query string parameters
-                var queryParameters = _actionContextAccessor.ActionContext.HttpContext.Request.Query.OrderBy(parameter => parameter.Key)
+                var queryParameters = _actionContextAccessor.ActionContext.HttpContext.Request.Query
+                    .OrderBy(parameter => parameter.Key)
                     .ToDictionary(parameter => parameter.Key, parameter => parameter.Value.ToString());
                 part = QueryHelpers.AddQueryString(part, queryParameters);
             }
@@ -470,6 +463,7 @@ namespace Nop.Web.Framework.UI
                 result.AppendFormat("<link rel=\"canonical\" href=\"{0}\" />", canonicalUrl);
                 result.Append(Environment.NewLine);
             }
+
             return new HtmlString(result.ToString());
         }
 
@@ -514,6 +508,7 @@ namespace Nop.Web.Framework.UI
                 result.Append(path);
                 result.Append(Environment.NewLine);
             }
+
             return new HtmlString(result.ToString());
         }
 
@@ -629,6 +624,7 @@ namespace Nop.Web.Framework.UI
                     return false;
                 return Src.Equals(item.Src) && DebugSrc.Equals(item.DebugSrc);
             }
+
             /// <summary>
             /// Get hash code
             /// </summary>
@@ -665,6 +661,7 @@ namespace Nop.Web.Framework.UI
                     return false;
                 return Src.Equals(item.Src) && DebugSrc.Equals(item.DebugSrc);
             }
+
             /// <summary>
             /// Get hash code
             /// </summary>

--- a/src/Presentation/Nop.Web/Models/Common/PagerModel.cs
+++ b/src/Presentation/Nop.Web/Models/Common/PagerModel.cs
@@ -1,36 +1,35 @@
 ﻿using System.Threading.Tasks;
-using Nop.Core.Infrastructure;
 using Nop.Services.Localization;
 
 namespace Nop.Web.Models.Common
 {
-    public partial record PagerModel
+    public record PagerModel
     {
+        #region Fields
+
+        private readonly ILocalizationService _localizationService;
+        private int _individualPagesDisplayedCount;
+        private int _pageIndex = -2;
+        private int _pageSize;
+
+        private bool? _showFirst;
+        private bool? _showIndividualPages;
+        private bool? _showLast;
+        private bool? _showNext;
+        private bool? _showPagerItems;
+        private bool? _showPrevious;
+        private bool? _showTotalSummary;
+
+        #endregion Fields
+
         #region Ctor
-        
+
         public PagerModel(ILocalizationService localizationService)
         {
             _localizationService = localizationService;
         }
 
         #endregion Constructors
-
-        #region Fields
-
-        private readonly ILocalizationService _localizationService;
-        private int individualPagesDisplayedCount;
-        private int pageIndex = -2;
-        private int pageSize;
-
-        private bool? showFirst;
-        private bool? showIndividualPages;
-        private bool? showLast;
-        private bool? showNext;
-        private bool? showPagerItems;
-        private bool? showPrevious;
-        private bool? showTotalSummary;
-
-        #endregion Fields
 
         #region Properties
 
@@ -44,14 +43,8 @@ namespace Nop.Web.Models.Common
         /// </summary>
         public int IndividualPagesDisplayedCount
         {
-            get
-            {
-                if (individualPagesDisplayedCount <= 0)
-                    return 5;
-
-                return individualPagesDisplayedCount;
-            }
-            set => individualPagesDisplayedCount = value;
+            get => _individualPagesDisplayedCount <= 0 ? 5 : _individualPagesDisplayedCount;
+            set => _individualPagesDisplayedCount = value;
         }
 
         /// <summary>
@@ -59,15 +52,8 @@ namespace Nop.Web.Models.Common
         /// </summary>
         public int PageIndex
         {
-            get
-            {
-                if (pageIndex < 0)
-                {
-                    return 0;
-                }
-                return pageIndex;
-            }
-            set => pageIndex = value;
+            get => _pageIndex < 0 ? 0 : _pageIndex;
+            set => _pageIndex = value;
         }
 
         /// <summary>
@@ -75,8 +61,8 @@ namespace Nop.Web.Models.Common
         /// </summary>
         public int PageSize
         {
-            get => (pageSize <= 0) ? 10 : pageSize;
-            set => pageSize = value;
+            get => (_pageSize <= 0) ? 10 : _pageSize;
+            set => _pageSize = value;
         }
 
         /// <summary>
@@ -84,8 +70,8 @@ namespace Nop.Web.Models.Common
         /// </summary>
         public bool ShowFirst
         {
-            get => showFirst ?? true;
-            set => showFirst = value;
+            get => _showFirst ?? true;
+            set => _showFirst = value;
         }
 
         /// <summary>
@@ -93,8 +79,8 @@ namespace Nop.Web.Models.Common
         /// </summary>
         public bool ShowIndividualPages
         {
-            get => showIndividualPages ?? true;
-            set => showIndividualPages = value;
+            get => _showIndividualPages ?? true;
+            set => _showIndividualPages = value;
         }
 
         /// <summary>
@@ -102,8 +88,8 @@ namespace Nop.Web.Models.Common
         /// </summary>
         public bool ShowLast
         {
-            get => showLast ?? true;
-            set => showLast = value;
+            get => _showLast ?? true;
+            set => _showLast = value;
         }
 
         /// <summary>
@@ -111,8 +97,8 @@ namespace Nop.Web.Models.Common
         /// </summary>
         public bool ShowNext
         {
-            get => showNext ?? true;
-            set => showNext = value;
+            get => _showNext ?? true;
+            set => _showNext = value;
         }
 
         /// <summary>
@@ -120,8 +106,8 @@ namespace Nop.Web.Models.Common
         /// </summary>
         public bool ShowPagerItems
         {
-            get => showPagerItems ?? true;
-            set => showPagerItems = value;
+            get => _showPagerItems ?? true;
+            set => _showPagerItems = value;
         }
 
         /// <summary>
@@ -129,8 +115,8 @@ namespace Nop.Web.Models.Common
         /// </summary>
         public bool ShowPrevious
         {
-            get => showPrevious ?? true;
-            set => showPrevious = value;
+            get => _showPrevious ?? true;
+            set => _showPrevious = value;
         }
 
         /// <summary>
@@ -138,8 +124,8 @@ namespace Nop.Web.Models.Common
         /// </summary>
         public bool ShowTotalSummary
         {
-            get => showTotalSummary ?? false;
-            set => showTotalSummary = value;
+            get => _showTotalSummary ?? false;
+            set => _showTotalSummary = value;
         }
 
         /// <summary>
@@ -153,11 +139,13 @@ namespace Nop.Web.Models.Common
                 {
                     return 0;
                 }
+
                 var num = TotalRecords / PageSize;
                 if ((TotalRecords % PageSize) > 0)
                 {
                     num++;
                 }
+
                 return num;
             }
         }
@@ -173,7 +161,7 @@ namespace Nop.Web.Models.Common
         /// <returns>A task that represents the asynchronous operation</returns>
         public async Task<string> GetFirstButtonTextAsync()
         {
-           return await _localizationService.GetResourceAsync("Pager.First");
+            return await _localizationService.GetResourceAsync("Pager.First");
         }
 
         /// <summary>
@@ -200,7 +188,7 @@ namespace Nop.Web.Models.Common
         /// <returns>A task that represents the asynchronous operation</returns>
         public async Task<string> GetPreviousButtonTextAsync()
         {
-           return await _localizationService.GetResourceAsync("Pager.Previous");
+            return await _localizationService.GetResourceAsync("Pager.Previous");
         }
 
         /// <summary>
@@ -243,10 +231,12 @@ namespace Nop.Web.Models.Common
             {
                 return 0;
             }
+
             if ((PageIndex + (IndividualPagesDisplayedCount / 2)) >= TotalPages)
             {
                 return (TotalPages - IndividualPagesDisplayedCount);
             }
+
             return (PageIndex - (IndividualPagesDisplayedCount / 2));
         }
 
@@ -261,15 +251,18 @@ namespace Nop.Web.Models.Common
             {
                 num--;
             }
+
             if ((TotalPages < IndividualPagesDisplayedCount) ||
                 ((PageIndex + num) >= TotalPages))
             {
                 return (TotalPages - 1);
             }
+
             if ((PageIndex - (IndividualPagesDisplayedCount / 2)) < 0)
             {
                 return (IndividualPagesDisplayedCount - 1);
             }
+
             return (PageIndex + num);
         }
 
@@ -290,7 +283,7 @@ namespace Nop.Web.Models.Common
     /// record that has a slug and page for route values. Used for Topic (posts) and 
     /// Forum (topics) pagination
     /// </summary>
-    public partial record RouteValues : IRouteValues
+    public record RouteValues : IRouteValues
     {
         public int id { get; set; }
         public string slug { get; set; }
@@ -300,7 +293,7 @@ namespace Nop.Web.Models.Common
     /// <summary>
     /// record that has search options for route values. Used for Search result pagination
     /// </summary>
-    public partial record ForumSearchRouteValues : IRouteValues
+    public record ForumSearchRouteValues : IRouteValues
     {
         public string searchterms { get; set; }
         public string advs { get; set; }
@@ -313,7 +306,7 @@ namespace Nop.Web.Models.Common
     /// <summary>
     /// record that has a slug and page for route values. Used for Private Messages pagination
     /// </summary>
-    public partial record PrivateMessageRouteValues : IRouteValues
+    public record PrivateMessageRouteValues : IRouteValues
     {
         public string tab { get; set; }
         public int pageNumber { get; set; }
@@ -322,7 +315,7 @@ namespace Nop.Web.Models.Common
     /// <summary>
     /// record that has only page for route value. Used for Active Discussions (forums) pagination
     /// </summary>
-    public partial record ForumActiveDiscussionsRouteValues : IRouteValues
+    public record ForumActiveDiscussionsRouteValues : IRouteValues
     {
         public int pageNumber { get; set; }
     }
@@ -330,15 +323,15 @@ namespace Nop.Web.Models.Common
     /// <summary>
     /// record that has only page for route value. Used for (My Account) Forum Subscriptions pagination
     /// </summary>
-    public partial record ForumSubscriptionsRouteValues : IRouteValues
-    {        
+    public record ForumSubscriptionsRouteValues : IRouteValues
+    {
         public int pageNumber { get; set; }
     }
 
     /// <summary>
     /// record that has only page for route value. Used for (My Account) Back in stock subscriptions pagination
     /// </summary>
-    public partial record BackInStockSubscriptionsRouteValues : IRouteValues
+    public record BackInStockSubscriptionsRouteValues : IRouteValues
     {
         public int pageNumber { get; set; }
     }
@@ -346,7 +339,7 @@ namespace Nop.Web.Models.Common
     /// <summary>
     /// record that has only page for route value. Used for (My Account) Reward Points pagination
     /// </summary>
-    public partial record RewardPointsRouteValues : IRouteValues
+    public record RewardPointsRouteValues : IRouteValues
     {
         public int pageNumber { get; set; }
     }


### PR DESCRIPTION
This is my very first contribution to open source, so I apologize if I did something wrong. Please let me know.

Changes:
1. Renamed private fields with a _ prefix.
2. Ran auto formatter which I believe respects .editorconfig
3. Removed redundant "partial" from single-part classes/records. If this is an problem, happy to revert.
4. I wanted to rename the properties too but some of them have many usages outside of the 3 files mentioned in the issue. Happy to go ahead with the rename if you like.
5. Removed unused imports.
6. Shortened some if statements in some getters.