### PR TITLE
Issues 3946 & 6033 - Fix URL encoding in RouteUrlAsync

### DIFF
--- a/src/Libraries/Nop.Services/Messages/MessageTokenProvider.cs
+++ b/src/Libraries/Nop.Services/Messages/MessageTokenProvider.cs
@@ -902,16 +902,12 @@ namespace Nop.Services.Messages
             if (string.IsNullOrEmpty(store.Url))
                 throw new Exception("URL cannot be null");
 
-            //generate a URL with an absolute path
+            //generate the relative URL
             var urlHelper = _urlHelperFactory.GetUrlHelper(_actionContextAccessor.ActionContext);
-            var url = new PathString(urlHelper.RouteUrl(routeName, routeValues));
-
-            //remove the application path from the generated URL if exists
-            var pathBase = _actionContextAccessor.ActionContext?.HttpContext?.Request?.PathBase ?? PathString.Empty;
-            url.StartsWithSegments(pathBase, out url);
+            var url = urlHelper.RouteUrl(routeName, routeValues);
 
             //compose the result
-            return new Uri(WebUtility.UrlDecode($"{store.Url.TrimEnd('/')}{url}"), UriKind.Absolute).AbsoluteUri;
+            return new Uri(new Uri(store.Url), url).AbsoluteUri;
         }
 
         #endregion


### PR DESCRIPTION
Fixes #3946 and #6033.

I don't know why this method is doing what it is doing nor what impact this change will have on the consuming services (ex: do any services expect the badly encoded URL that was previously provided). Feedback is appreciated. This fixes the email reset / activation issue but what other test cases need run?