### PR TITLE
Fix store mapping authorization check on multi-store setups

### DIFF
--- a/src/Libraries/Nop.Services/Orders/ShoppingCartService.cs
+++ b/src/Libraries/Nop.Services/Orders/ShoppingCartService.cs
@@ -338,10 +338,8 @@ namespace Nop.Services.Orders
                 warnings.Add(await _localizationService.GetResourceAsync("ShoppingCart.ProductUnpublished"));
             }
 
-            var store = await _storeContext.GetCurrentStoreAsync();
-
             //Store mapping
-            if (!await _storeMappingService.AuthorizeAsync(product, store.Id))
+            if (!await _storeMappingService.AuthorizeAsync(product, storeId))
             {
                 warnings.Add(await _localizationService.GetResourceAsync("ShoppingCart.ProductUnpublished"));
             }


### PR DESCRIPTION
In a multi-store/single-store setup, we must rely on `storeId` param not `_storeContext.GetCurrentStoreAsync()`.