### PR TITLE
Add decimal values to OrderDetailsModel

### DIFF
--- a/src/Presentation/Nop.Web/Factories/OrderModelFactory.cs
+++ b/src/Presentation/Nop.Web/Factories/OrderModelFactory.cs
@@ -301,10 +301,14 @@ namespace Nop.Web.Factories
                 //order subtotal
                 var orderSubtotalInclTaxInCustomerCurrency = _currencyService.ConvertCurrency(order.OrderSubtotalInclTax, order.CurrencyRate);
                 model.OrderSubtotal = await _priceFormatter.FormatPriceAsync(orderSubtotalInclTaxInCustomerCurrency, true, order.CustomerCurrencyCode, languageId, true);
+                model.OrderSubtotalValue = orderSubtotalInclTaxInCustomerCurrency;
                 //discount (applied to order subtotal)
                 var orderSubTotalDiscountInclTaxInCustomerCurrency = _currencyService.ConvertCurrency(order.OrderSubTotalDiscountInclTax, order.CurrencyRate);
                 if (orderSubTotalDiscountInclTaxInCustomerCurrency > decimal.Zero)
+                {
                     model.OrderSubTotalDiscount = await _priceFormatter.FormatPriceAsync(-orderSubTotalDiscountInclTaxInCustomerCurrency, true, order.CustomerCurrencyCode, languageId, true);
+                    model.OrderSubTotalDiscountValue = -orderSubTotalDiscountInclTaxInCustomerCurrency;
+                }
             }
             else
             {
@@ -313,10 +317,14 @@ namespace Nop.Web.Factories
                 //order subtotal
                 var orderSubtotalExclTaxInCustomerCurrency = _currencyService.ConvertCurrency(order.OrderSubtotalExclTax, order.CurrencyRate);
                 model.OrderSubtotal = await _priceFormatter.FormatPriceAsync(orderSubtotalExclTaxInCustomerCurrency, true, order.CustomerCurrencyCode, languageId, false);
+                model.OrderSubtotalValue = orderSubtotalExclTaxInCustomerCurrency;
                 //discount (applied to order subtotal)
                 var orderSubTotalDiscountExclTaxInCustomerCurrency = _currencyService.ConvertCurrency(order.OrderSubTotalDiscountExclTax, order.CurrencyRate);
                 if (orderSubTotalDiscountExclTaxInCustomerCurrency > decimal.Zero)
+                {
                     model.OrderSubTotalDiscount = await _priceFormatter.FormatPriceAsync(-orderSubTotalDiscountExclTaxInCustomerCurrency, true, order.CustomerCurrencyCode, languageId, false);
+                    model.OrderSubTotalDiscountValue = -orderSubTotalDiscountExclTaxInCustomerCurrency;
+                }
             }
 
             if (order.CustomerTaxDisplayType == TaxDisplayType.IncludingTax)
@@ -326,10 +334,14 @@ namespace Nop.Web.Factories
                 //order shipping
                 var orderShippingInclTaxInCustomerCurrency = _currencyService.ConvertCurrency(order.OrderShippingInclTax, order.CurrencyRate);
                 model.OrderShipping = await _priceFormatter.FormatShippingPriceAsync(orderShippingInclTaxInCustomerCurrency, true, order.CustomerCurrencyCode, languageId, true);
+                model.OrderShippingValue = orderShippingInclTaxInCustomerCurrency;
                 //payment method additional fee
                 var paymentMethodAdditionalFeeInclTaxInCustomerCurrency = _currencyService.ConvertCurrency(order.PaymentMethodAdditionalFeeInclTax, order.CurrencyRate);
                 if (paymentMethodAdditionalFeeInclTaxInCustomerCurrency > decimal.Zero)
+                {
                     model.PaymentMethodAdditionalFee = await _priceFormatter.FormatPaymentMethodAdditionalFeeAsync(paymentMethodAdditionalFeeInclTaxInCustomerCurrency, true, order.CustomerCurrencyCode, languageId, true);
+                    model.PaymentMethodAdditionalFeeValue = paymentMethodAdditionalFeeInclTaxInCustomerCurrency;
+                }
             }
             else
             {
@@ -338,10 +350,14 @@ namespace Nop.Web.Factories
                 //order shipping
                 var orderShippingExclTaxInCustomerCurrency = _currencyService.ConvertCurrency(order.OrderShippingExclTax, order.CurrencyRate);
                 model.OrderShipping = await _priceFormatter.FormatShippingPriceAsync(orderShippingExclTaxInCustomerCurrency, true, order.CustomerCurrencyCode, languageId, false);
+                model.OrderShippingValue = orderShippingExclTaxInCustomerCurrency;
                 //payment method additional fee
                 var paymentMethodAdditionalFeeExclTaxInCustomerCurrency = _currencyService.ConvertCurrency(order.PaymentMethodAdditionalFeeExclTax, order.CurrencyRate);
                 if (paymentMethodAdditionalFeeExclTaxInCustomerCurrency > decimal.Zero)
+                {
                     model.PaymentMethodAdditionalFee = await _priceFormatter.FormatPaymentMethodAdditionalFeeAsync(paymentMethodAdditionalFeeExclTaxInCustomerCurrency, true, order.CustomerCurrencyCode, languageId, false);
+                    model.PaymentMethodAdditionalFeeValue = paymentMethodAdditionalFeeExclTaxInCustomerCurrency;
+                }
             }
 
             //tax
@@ -386,8 +402,11 @@ namespace Nop.Web.Factories
             //discount (applied to order total)
             var orderDiscountInCustomerCurrency = _currencyService.ConvertCurrency(order.OrderDiscount, order.CurrencyRate);
             if (orderDiscountInCustomerCurrency > decimal.Zero)
+            {
                 model.OrderTotalDiscount = await _priceFormatter.FormatPriceAsync(-orderDiscountInCustomerCurrency, true, order.CustomerCurrencyCode, false, languageId);
-
+                model.OrderTotalDiscountValue = -orderDiscountInCustomerCurrency;
+            }
+            
             //gift cards
             foreach (var gcuh in await _giftCardService.GetGiftCardUsageHistoryAsync(order))
             {
@@ -408,6 +427,7 @@ namespace Nop.Web.Factories
             //total
             var orderTotalInCustomerCurrency = _currencyService.ConvertCurrency(order.OrderTotal, order.CurrencyRate);
             model.OrderTotal = await _priceFormatter.FormatPriceAsync(orderTotalInCustomerCurrency, true, order.CustomerCurrencyCode, false, languageId);
+            model.OrderTotalValue = orderTotalInCustomerCurrency;
 
             //checkout attributes
             model.CheckoutAttributeInfo = order.CheckoutAttributeDescription;
@@ -466,18 +486,22 @@ namespace Nop.Web.Factories
                     //including tax
                     var unitPriceInclTaxInCustomerCurrency = _currencyService.ConvertCurrency(orderItem.UnitPriceInclTax, order.CurrencyRate);
                     orderItemModel.UnitPrice = await _priceFormatter.FormatPriceAsync(unitPriceInclTaxInCustomerCurrency, true, order.CustomerCurrencyCode, languageId, true);
+                    orderItemModel.UnitPriceValue = unitPriceInclTaxInCustomerCurrency;
 
                     var priceInclTaxInCustomerCurrency = _currencyService.ConvertCurrency(orderItem.PriceInclTax, order.CurrencyRate);
                     orderItemModel.SubTotal = await _priceFormatter.FormatPriceAsync(priceInclTaxInCustomerCurrency, true, order.CustomerCurrencyCode, languageId, true);
+                    orderItemModel.SubTotalValue = priceInclTaxInCustomerCurrency;
                 }
                 else
                 {
                     //excluding tax
                     var unitPriceExclTaxInCustomerCurrency = _currencyService.ConvertCurrency(orderItem.UnitPriceExclTax, order.CurrencyRate);
                     orderItemModel.UnitPrice = await _priceFormatter.FormatPriceAsync(unitPriceExclTaxInCustomerCurrency, true, order.CustomerCurrencyCode, languageId, false);
+                    orderItemModel.UnitPriceValue = unitPriceExclTaxInCustomerCurrency;
 
                     var priceExclTaxInCustomerCurrency = _currencyService.ConvertCurrency(orderItem.PriceExclTax, order.CurrencyRate);
                     orderItemModel.SubTotal = await _priceFormatter.FormatPriceAsync(priceExclTaxInCustomerCurrency, true, order.CustomerCurrencyCode, languageId, false);
+                    orderItemModel.SubTotalValue = priceExclTaxInCustomerCurrency;
                 }
 
                 //downloadable products

--- a/src/Presentation/Nop.Web/Models/Order/OrderDetailsModel.cs
+++ b/src/Presentation/Nop.Web/Models/Order/OrderDetailsModel.cs
@@ -53,9 +53,13 @@ namespace Nop.Web.Models.Order
         public Dictionary<string, object> CustomValues { get; set; }
 
         public string OrderSubtotal { get; set; }
+        public decimal OrderSubtotalValue { get; set; }
         public string OrderSubTotalDiscount { get; set; }
+        public decimal OrderSubTotalDiscountValue { get; set; }
         public string OrderShipping { get; set; }
+        public decimal OrderShippingValue { get; set; }
         public string PaymentMethodAdditionalFee { get; set; }
+        public decimal PaymentMethodAdditionalFeeValue { get; set; }
         public string CheckoutAttributeInfo { get; set; }
 
         public bool PricesIncludeTax { get; set; }
@@ -66,9 +70,11 @@ namespace Nop.Web.Models.Order
         public bool DisplayTaxRates { get; set; }
 
         public string OrderTotalDiscount { get; set; }
+        public decimal OrderTotalDiscountValue { get; set; }
         public int RedeemedRewardPoints { get; set; }
         public string RedeemedRewardPointsAmount { get; set; }
         public string OrderTotal { get; set; }
+        public decimal OrderTotalValue { get; set; }
         
         public IList<GiftCard> GiftCards { get; set; }
 
@@ -90,7 +96,9 @@ namespace Nop.Web.Models.Order
             public string ProductName { get; set; }
             public string ProductSeName { get; set; }
             public string UnitPrice { get; set; }
+            public decimal UnitPriceValue { get; set; }
             public string SubTotal { get; set; }
+            public decimal SubTotalValue { get; set; }
             public int Quantity { get; set; }
             public string AttributeInfo { get; set; }
             public string RentalInfo { get; set; }


### PR DESCRIPTION
It would be very handy to get the decimal values of `OrderSubtotal`, `OrderTotal`, `OrderTotalDiscount` in [OrderDetailsModel](https://github.com/nopSolutions/nopCommerce/blob/develop/src/Presentation/Nop.Web/Models/Order/OrderDetailsModel.cs). Also this is needed to include the values in the WebApi plugin models.