### PR TITLE
Fix container path for app data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,8 @@ RUN apk add tzdata --no-cache
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh
 
+WORKDIR /app
+
 COPY --from=build /app/published .
                             
 ENTRYPOINT "/entrypoint.sh"


### PR DESCRIPTION
When building the web application container, ensure it uses the proper path from documentation so that mounted paths work as expected.

See [forum post](https://www.nopcommerce.com/en/boards/topic/94314/docker-upgrade-installation-page#296108) by **giovannidebona**.