### PR TITLE
Update vulnerable packages

### DIFF
--- a/src/Libraries/Nop.Services/Nop.Services.csproj
+++ b/src/Libraries/Nop.Services/Nop.Services.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="ClosedXML" Version="0.95.4" />
     <PackageReference Include="iTextSharp.LGPLv2.Core" Version="1.7.0" />
     <PackageReference Include="MailKit" Version="2.15.0" />

--- a/src/Presentation/Nop.Web/package-lock.json
+++ b/src/Presentation/Nop.Web/package-lock.json
@@ -222,7 +222,7 @@
       }
     },
     "ajv": {
-      "version": "5.5.2",
+      "version": "6.12.3",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
@@ -675,7 +675,7 @@
       }
     },
     "bl": {
-      "version": "1.2.2",
+      "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "dev": true,
@@ -1184,7 +1184,7 @@
       "dev": true
     },
     "copy-props": {
-      "version": "2.0.4",
+      "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.4.tgz",
       "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
       "dev": true,
@@ -1822,7 +1822,7 @@
       }
     },
     "deep-extend": {
-      "version": "0.3.3",
+      "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.3.3.tgz",
       "integrity": "sha1-Lorf5p7VgOoBnOLvqfpfUQbqOcc=",
       "dev": true
@@ -2377,7 +2377,7 @@
           }
         },
         "glob-parent": {
-          "version": "5.1.1",
+          "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
           "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
           "dev": true,
@@ -3156,7 +3156,7 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.8",
+      "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
@@ -3224,7 +3224,7 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
+      "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
@@ -3558,7 +3558,7 @@
       "integrity": "sha1-7tgiQnM7okP0az6HwYQbMIGR2mg="
     },
     "jquery-validation": {
-      "version": "1.19.3",
+      "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.19.3.tgz",
       "integrity": "sha512-iXxCS5W7STthSTMFX/NDZfWHBLbJ1behVK3eAgHXAV8/0vRa9M4tiqHvJMr39VGWHMGdlkhrtrkBuaL2UlE8yw=="
     },
@@ -3590,7 +3590,7 @@
       "integrity": "sha1-sV/EJkgxU77itrVnMS9nXZKDSg0="
     },
     "json-schema": {
-      "version": "0.2.3",
+      "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
@@ -3866,7 +3866,7 @@
       "dev": true
     },
     "lodash.template": {
-      "version": "3.6.2",
+      "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
       "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
       "dev": true,
@@ -4021,7 +4021,7 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
+      "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
@@ -4047,7 +4047,7 @@
       }
     },
     "moment": {
-      "version": "2.29.1",
+      "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
@@ -4433,7 +4433,7 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {
-      "version": "1.0.6",
+      "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
@@ -5389,7 +5389,7 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
     },
     "tinymce": {
-      "version": "5.6.2",
+      "version": "5.10.0",
       "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.6.2.tgz",
       "integrity": "sha512-z7zvM5seOPiW86/vqf08kStwW5Zs5U9oQfuqh2rTj4jEcT2QzxT0v72i2zw3W6rbTLldkAej6edFZphj5ee5zg=="
     },
@@ -5858,7 +5858,7 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
-      "version": "3.2.1",
+      "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
@@ -5885,7 +5885,7 @@
       }
     },
     "yargs-parser": {
-      "version": "5.0.0-security.0",
+      "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0-security.0.tgz",
       "integrity": "sha512-T69y4Ps64LNesYxeYGYPvfoMTt/7y1XtfpIslUeK4um+9Hu7hlGoRtaDLvdXb7+/tfq4opVa2HRY5xGip022rQ==",
       "dev": true,


### PR DESCRIPTION
Our local copy of nopCommerce raised several flags for security vulnerabilities. I have listed a report of these vulnerabilities and the mitigations below. This PR updates the vulnerable packages to safe versions. The report includes a check for breaking changes in the upgrade. Some of the upgrades may introduce breaking changes. With the upgrades, the project builds and runs, but we have not yet extensively tested it.

> Azure.Storage.Blobs:
>     vulnerability: CVE-22-30187
>     current: 12.10.0
>     required: 12.13.0
>     breaking changes: no
> 
> jquery-validation:
>     vulnerability: CVE-2022-31147
>     current: 1.19.3
>     required: 1.19.5
>     breaking changes: no
> 
> minimist:
>     vulnerability: CVE-2021-44906
>     current: 1.2.5
>     required: 1.2.6
>     breaking changes: no
>     remarks: Minimist does not publish a changelog. After manual audit, it looks safe to upgrade.
> 
> moment:
>     vulnerability: CVE-2022-31129
>     current: 2.29.1
>     required: 2.29.4
>     breaking changes: no
> 
> json-schema:
>     vulnerability: CVE-2021-3918
>     current: 0.2.3
>     required: 0.4.0
>     breaking changes: no
>     remarks: json-schema does not publish a changelog. After manual audit, it looks safe to upgrade.
> 
> path-parse:
>     vulnerability: CVE-2021-23343
>     current: 1.0.6
>     required: 1.0.7
>     breaking changes: no
>     remarks: path-parse does not publish a changelog. After manual audit, it looks safe to upgrade.
> 
> glob-parent:
>     vulnerability: CVE-2021-35065
>     current: 5.1.1
>     required: 5.1.2
>     breaking changes: no
> 
> tinymce:
>     vulnerability: GHSA-r8hm-w5f7-wj39
>     current: 5.6.2
>     required: 5.10.0
>     breaking changes: no
>     remarks: There are many changes between version 5.6.2 and version 5.10.0. After manually auditing nopCommerce itself, it looks like none of these changes affect it.
> 
> ajv:
>     vulnerability: CVE-2020-15366
>     current: 5.5.2
>     required: 6.12.3
>     breaking changes: no
>     remarks: So long as nopCommerce is following json schema standards, there should be no conflicts with this version of ajv
> 
> hosted-git-info:
>     vulnerability: CVE-2021-23362
>     current: 2.8.8
>     required: 2.8.9
>     breaking changes: no
> 
> copy-props:
>     vulnerability: CVE-2022-28503
>     current: 2.0.4
>     required: 2.0.5
>     breaking changes: no
> 
> y18n:
>     vulnerability: CVE-2022-7774
>     current: 3.2.1
>     required: 3.2.2
>     breaking changes: UNKNOWN
>     remarks: y18n does not publish a changelog, and the source for version 3.2.2 is not available. The most recent versions (5.X.x) have potentially breaking changes.
> 
> ini:
>     vulnerability: CVE-2020-7788
>     current: 1.3.5
>     required: 1.3.6
>     breaking changes: no
>     remarks: ini does not publish a changelog for these versions. After manual audit, it looks safe to upgrade.
> 
> yargs-parser:
>     vulnerability: CVE-2020-7608
>     current: 5.0.0-security.0
>     required: 5.0.1
>     breaking changes: UNKNOWN
>     remarks: yargs-parser does not publish a changelog for these versions, and the source for these versions is not available.
> 
> bl:
>     vulnerability: CVE-2020-8244
>     current: 1.2.2
>     required: 1.2.3
>     breaking changes: no
>     remarks: bl does not publish a changelog for these versions. After manual audit, it looks safe to upgrade.
> 
> lodash.template:
> vulnerability: CVE-2019-10744
>     current: 3.6.2
>     required: 4.5.0
>     breaking changes: no
>     remarks: There are many breaking changes between these versions. However, the codebase does not appear to directly use any lodash functions. The packages which require lodash.template should be investigated and upgraded if possible.
> 
> deep-extend:
>     vulnerability: CVE-2018-3750
>     current: 0.3.3
>     required: 0.5.1
>     breaking changes: yes
>     remarks: The changelog for deep-extend explicitly states that version 0.4.0 breaks backwards compatability with 0.3.x.