### PR TITLE
Updated the ReOrderAsync method to handle price include tax

### DIFF
--- a/src/Libraries/Nop.Services/Orders/OrderProcessingService.cs
+++ b/src/Libraries/Nop.Services/Orders/OrderProcessingService.cs
@@ -3149,10 +3149,11 @@ namespace Nop.Services.Orders
                 var product = await _productService.GetProductByIdAsync(orderItem.ProductId);
 
                 await _shoppingCartService.AddToCartAsync(customer, product,
-                    ShoppingCartType.ShoppingCart, order.StoreId,
-                    orderItem.AttributesXml, orderItem.UnitPriceExclTax,
-                    orderItem.RentalStartDateUtc, orderItem.RentalEndDateUtc,
-                    orderItem.Quantity, false);
+                     ShoppingCartType.ShoppingCart, order.StoreId,
+                     orderItem.AttributesXml, _taxSettings.PricesIncludeTax ?
+                     orderItem.UnitPriceInclTax : orderItem.UnitPriceExclTax,
+                     orderItem.RentalStartDateUtc, orderItem.RentalEndDateUtc,
+                     orderItem.Quantity, false);
             }
 
             //set checkout attributes


### PR DESCRIPTION
this is the fix for #5826 

Steps to reproduce the problem:

I have a problem with my shopping cart total decreasing every time I reorder an order including products with CustomEredenteredPrice options enabled. It only happens when PricesIncludeTax is enabled in taxsettings.

Found out that the ReOrderAsync function in the OrderProcessingService is always using
orderItem.UnitPriceExclTax regardless of taxsettings.


source : : https://www.nopcommerce.com/en/boards/topic/91910/reorder-uses-prices-exluding-tax-for-customer-entered-prices-regardless-of-taxsettings