### PR TITLE
Issue 6393 Customer Phone Number Validation Issue fix for when Phone …

### DIFF
--- a/src/Presentation/Nop.Web.Framework/Validators/PhoneNumberPropertyValidator.cs
+++ b/src/Presentation/Nop.Web.Framework/Validators/PhoneNumberPropertyValidator.cs
@@ -45,7 +45,9 @@ namespace Nop.Web.Framework.Validators
                 return true;
 
             if (string.IsNullOrEmpty(phoneNumber))
-                return false;
+            {
+                return !customerSettings.PhoneRequired;
+            }
 
             return customerSettings.PhoneNumberValidationUseRegex
                 ? Regex.IsMatch(phoneNumber, customerSettings.PhoneNumberValidationRule, RegexOptions.CultureInvariant | RegexOptions.IgnoreCase)


### PR DESCRIPTION
…Number Not Required

This is related to the issue reported here: 'https://github.com/nopSolutions/nopCommerce/issues/6393'

What we found is that our customer registration form fails with an error for invalid phone number, even if the customer phone number field is not required. In stepping through the code we found that the 'public static bool IsValid(string phoneNumber, CustomerSettings customerSettings)' method in '\Nop.Web.Framework\Validators\PhoneNumberPropertyValidator.cs' was failing it's validation. We applied a fix to our local version of this validator and now see it working as expected in our local repository.