### PR TITLE
Edited Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
 # installs required packages
 RUN apk add tiff --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/main/ --allow-untrusted
-RUN apk add libgdiplus --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted
+RUN apk add libgdiplus --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/community/ --allow-untrusted
 RUN apk add libc-dev --no-cache
 RUN apk add tzdata --no-cache
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,7 @@ RUN apk add --no-cache icu-libs
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 
 # installs required packages
+RUN apk add tiff --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/main/ --allow-untrusted
 RUN apk add libgdiplus --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted
 RUN apk add libc-dev --no-cache
 RUN apk add tzdata --no-cache


### PR DESCRIPTION
After the last alpine Linux packages build (build date 16.12.2022), Dockerfile got an error in my ci/cd pipeline. The reason for this error, the tiff package is no longer in the "testing" repository. I added the required Package (tiff) from the "main" Repository. After that, my ci/cd pipeline worked.

**Error Details**

![image](https://user-images.githubusercontent.com/3836562/208113265-f7f642bc-cee9-4e8c-87ac-2a05e8ad1093.png)

Step 69/76 : RUN apk add libgdiplus --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted
 ---> Running in d5c40e0b4b5c
fetch http://dl-3.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
ERROR: unable to select packages:
  so:libtiff.so.6 (no such package):
    required by: libgdiplus-6.1-r1[so:libtiff.so.6]
The command '/bin/sh -c apk add libgdiplus --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted' returned a non-zero code: 2
