### PR TITLE
Build - ignore Plugins folder for linux

### DIFF
--- a/src/Build/src/ClearPluginAssemblies/Program.cs
+++ b/src/Build/src/ClearPluginAssemblies/Program.cs
@@ -88,8 +88,10 @@ namespace ClearPluginAssemblies
                 return;
 
             var di = new DirectoryInfo(outputPath);
+            var separator = Path.DirectorySeparatorChar;
+            var folderToIgnore = string.Concat(separator, "Plugins", separator);
             var fileNames = di.GetFiles("*.dll", SearchOption.AllDirectories)
-                .Where(fi => !fi.FullName.Contains(@"\Plugins\"))
+                .Where(fi => !fi.FullName.Contains(folderToIgnore))
                 .Select(fi => fi.Name.Replace(fi.Extension, "")).ToList();
            
             if (string.IsNullOrEmpty(pluginPaths) || !fileNames.Any())


### PR DESCRIPTION
Windows \Plugins\ is hardcoded in the initial dll scans.
When calling ClearPluginAssemblies from linux Plugins folder is not ignored.

Fixing this by replacing \ with Path.DirectorySeparatorChar