### PR TITLE
remove-blocking-call-to-session-cache-from-facebookpixel-plugin

### DIFF
--- a/src/Libraries/Nop.Core/Http/Extensions/SessionExtensions.cs
+++ b/src/Libraries/Nop.Core/Http/Extensions/SessionExtensions.cs
@@ -36,6 +36,27 @@ namespace Nop.Core.Http.Extensions
             return value == null ? default : JsonConvert.DeserializeObject<T>(value);
         }
 
+        /// <summary>
+        /// Remove the given key from session if present.
+        /// </summary>
+        /// <param name="session">Session</param>
+        /// <param name="key">Key</param>
+        public static async Task RemoveAsync(this ISession session, string key)
+        {
+            await LoadAsync(session);
+            session.Remove(key);
+        }
+
+        /// <summary>
+        /// Remove all entries from the current session, if any. The session cookie is not removed.
+        /// </summary>
+        /// <param name="session">Session</param>
+        public static async Task ClearAsync(this ISession session)
+        {
+            await LoadAsync(session);
+            session.Clear();
+        }
+
         private static async Task LoadAsync(ISession session)
         {
             if (!session.IsAvailable)

--- a/src/Libraries/Nop.Core/Http/Extensions/SessionExtensions.cs
+++ b/src/Libraries/Nop.Core/Http/Extensions/SessionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
 
 namespace Nop.Core.Http.Extensions
@@ -15,8 +16,9 @@ namespace Nop.Core.Http.Extensions
         /// <param name="session">Session</param>
         /// <param name="key">Key</param>
         /// <param name="value">Value</param>
-        public static void Set<T>(this ISession session, string key, T value)
+        public static async Task SetAsync<T>(this ISession session, string key, T value)
         {
+            await LoadAsync(session);
             session.SetString(key, JsonConvert.SerializeObject(value));
         }
 
@@ -27,13 +29,26 @@ namespace Nop.Core.Http.Extensions
         /// <param name="session">Session</param>
         /// <param name="key">Key</param>
         /// <returns>Value</returns>
-        public static T Get<T>(this ISession session, string key)
+        public static async Task<T> GetAsync<T>(this ISession session, string key)
         {
+            await LoadAsync(session);
             var value = session.GetString(key);
-            if (value == null)
-                return default;
+            return value == null ? default : JsonConvert.DeserializeObject<T>(value);
+        }
 
-            return JsonConvert.DeserializeObject<T>(value);
+        private static async Task LoadAsync(ISession session)
+        {
+            if (!session.IsAvailable)
+            {
+                try
+                {
+                    await session.LoadAsync();
+                }
+                catch
+                {
+                    // fallback to synchronous handling
+                }
+            }
         }
     }
 }

--- a/src/Libraries/Nop.Services/Payments/IPaymentService.cs
+++ b/src/Libraries/Nop.Services/Payments/IPaymentService.cs
@@ -172,6 +172,6 @@ namespace Nop.Services.Payments
         /// Generate an order GUID
         /// </summary>
         /// <param name="processPaymentRequest">Process payment request</param>
-        void GenerateOrderGuid(ProcessPaymentRequest processPaymentRequest);
+        Task GenerateOrderGuidAsync(ProcessPaymentRequest processPaymentRequest);
     }
 }

--- a/src/Libraries/Nop.Services/Payments/PaymentService.cs
+++ b/src/Libraries/Nop.Services/Payments/PaymentService.cs
@@ -427,7 +427,7 @@ namespace Nop.Services.Payments
         /// Generate an order GUID
         /// </summary>
         /// <param name="processPaymentRequest">Process payment request</param>
-        public virtual void GenerateOrderGuid(ProcessPaymentRequest processPaymentRequest)
+        public virtual async Task GenerateOrderGuidAsync(ProcessPaymentRequest processPaymentRequest)
         {
             if (processPaymentRequest == null)
                 return;
@@ -435,7 +435,7 @@ namespace Nop.Services.Payments
             //we should use the same GUID for multiple payment attempts
             //this way a payment gateway can prevent security issues such as credit card brute-force attacks
             //in order to avoid any possible limitations by payment gateway we reset GUID periodically
-            var previousPaymentRequest = _httpContextAccessor.HttpContext.Session.Get<ProcessPaymentRequest>("OrderPaymentInfo");
+            var previousPaymentRequest = await _httpContextAccessor.HttpContext.Session.GetAsync<ProcessPaymentRequest>("OrderPaymentInfo");
             if (_paymentSettings.RegenerateOrderGuidInterval > 0 &&
                 previousPaymentRequest != null &&
                 previousPaymentRequest.OrderGuidGeneratedOnUtc.HasValue)

--- a/src/Plugins/Nop.Plugin.MultiFactorAuth.GoogleAuthenticator/Controllers/AuthenticationController.cs
+++ b/src/Plugins/Nop.Plugin.MultiFactorAuth.GoogleAuthenticator/Controllers/AuthenticationController.cs
@@ -81,7 +81,7 @@ namespace Nop.Plugin.MultiFactorAuth.GoogleAuthenticator.Controllers
         [HttpPost]
         public async Task<IActionResult> VerifyGoogleAuthenticator(TokenModel model)
         {
-            var customerMultiFactorAuthenticationInfo = HttpContext.Session.Get<CustomerMultiFactorAuthenticationInfo>(NopCustomerDefaults.CustomerMultiFactorAuthenticationInfo);
+            var customerMultiFactorAuthenticationInfo = await HttpContext.Session.GetAsync<CustomerMultiFactorAuthenticationInfo>(NopCustomerDefaults.CustomerMultiFactorAuthenticationInfo);
             var username = customerMultiFactorAuthenticationInfo.UserName;
             var returnUrl = customerMultiFactorAuthenticationInfo.ReturnUrl;
             var isPersist = customerMultiFactorAuthenticationInfo.RememberMe;
@@ -96,7 +96,7 @@ namespace Nop.Plugin.MultiFactorAuth.GoogleAuthenticator.Controllers
                 var isValidToken = _googleAuthenticatorService.ValidateTwoFactorToken(record.SecretKey, model.Token);
                 if (isValidToken)
                 {
-                    HttpContext.Session.Set<CustomerMultiFactorAuthenticationInfo>(NopCustomerDefaults.CustomerMultiFactorAuthenticationInfo, null);
+                    await HttpContext.Session.SetAsync<CustomerMultiFactorAuthenticationInfo>(NopCustomerDefaults.CustomerMultiFactorAuthenticationInfo, null);
 
                     return await _customerRegistrationService.SignInCustomerAsync(customer, returnUrl, isPersist);
                 }

--- a/src/Plugins/Nop.Plugin.Payments.CyberSource/CyberSourcePaymentMethod.cs
+++ b/src/Plugins/Nop.Plugin.Payments.CyberSource/CyberSourcePaymentMethod.cs
@@ -264,7 +264,7 @@ namespace Nop.Plugin.Payments.CyberSource
                     var paymentStatus = result.NewPaymentStatus;
                     result.NewPaymentStatus = PaymentStatus.Pending;
                     var key = string.Format(CyberSourceDefaults.OrderStatusesSessionKey, processPaymentRequest.OrderGuid);
-                    _httpContextAccessor.HttpContext.Session.Set(key, (orderStatus, paymentStatus));
+                    await _httpContextAccessor.HttpContext.Session.SetAsync(key, (orderStatus, paymentStatus));
                 }
             }
 

--- a/src/Plugins/Nop.Plugin.Payments.CyberSource/Services/EventConsumer.cs
+++ b/src/Plugins/Nop.Plugin.Payments.CyberSource/Services/EventConsumer.cs
@@ -199,7 +199,7 @@ namespace Nop.Plugin.Payments.CyberSource.Services
                 return;
 
             //remove value from session
-            _httpContextAccessor.HttpContext.Session.Remove(key);
+            await _httpContextAccessor.HttpContext.Session.RemoveAsync(key);
 
             var note = $"Order status has been changed to {orderStatus.Value} by CyberSource AVS/CVN/decision profile results";
             await _orderService.InsertOrderNoteAsync(new OrderNote

--- a/src/Plugins/Nop.Plugin.Payments.CyberSource/Services/EventConsumer.cs
+++ b/src/Plugins/Nop.Plugin.Payments.CyberSource/Services/EventConsumer.cs
@@ -194,7 +194,7 @@ namespace Nop.Plugin.Payments.CyberSource.Services
                 return;
 
             var key = string.Format(CyberSourceDefaults.OrderStatusesSessionKey, order.OrderGuid);
-            var (orderStatus, paymentStatus) = _httpContextAccessor.HttpContext.Session.Get<(OrderStatus?, PaymentStatus?)>(key);
+            var (orderStatus, paymentStatus) = await _httpContextAccessor.HttpContext.Session.GetAsync<(OrderStatus?, PaymentStatus?)>(key);
             if (!orderStatus.HasValue || !paymentStatus.HasValue)
                 return;
 

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Components/PaymentInfoViewComponent.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Components/PaymentInfoViewComponent.cs
@@ -64,7 +64,7 @@ namespace Nop.Plugin.Payments.PayPalCommerce.Components
 
             //prepare order GUID
             var paymentRequest = new ProcessPaymentRequest();
-            _paymentService.GenerateOrderGuid(paymentRequest);
+            await _paymentService.GenerateOrderGuidAsync(paymentRequest);
 
             //try to create an order
             var (order, error) = await _serviceManager.CreateOrderAsync(_settings, paymentRequest.OrderGuid);
@@ -86,7 +86,7 @@ namespace Nop.Plugin.Payments.PayPalCommerce.Components
                     _notificationService.ErrorNotification(error);
             }
 
-            HttpContext.Session.Set(PayPalCommerceDefaults.PaymentRequestSessionKey, paymentRequest);
+            await HttpContext.Session.SetAsync(PayPalCommerceDefaults.PaymentRequestSessionKey, paymentRequest);
 
             return View("~/Plugins/Payments.PayPalCommerce/Views/PaymentInfo.cshtml", model);
         }

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/PayPalCommercePaymentMethod.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/PayPalCommercePaymentMethod.cs
@@ -354,14 +354,14 @@ namespace Nop.Plugin.Payments.PayPalCommerce
         /// A task that represents the asynchronous operation
         /// The task result contains the payment info holder
         /// </returns>
-        public Task<ProcessPaymentRequest> GetPaymentInfoAsync(IFormCollection form)
+        public async Task<ProcessPaymentRequest> GetPaymentInfoAsync(IFormCollection form)
         {
             if (form == null)
                 throw new ArgumentNullException(nameof(form));
 
             //already set
-            return Task.FromResult(_actionContextAccessor.ActionContext.HttpContext.Session
-                .Get<ProcessPaymentRequest>(PayPalCommerceDefaults.PaymentRequestSessionKey));
+            return await _actionContextAccessor.ActionContext.HttpContext.Session
+                .GetAsync<ProcessPaymentRequest>(PayPalCommerceDefaults.PaymentRequestSessionKey);
         }
 
         /// <summary>

--- a/src/Plugins/Nop.Plugin.Widgets.FacebookPixel/Services/FacebookPixelService.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.FacebookPixel/Services/FacebookPixelService.cs
@@ -326,15 +326,17 @@ namespace Nop.Plugin.Widgets.FacebookPixel.Services
         private async Task<string> PrepareTrackedEventsScriptAsync(IList<FacebookPixelConfiguration> configurations)
         {
             //get previously stored events and remove them from the session data
-            await _httpContextAccessor.HttpContext.Session.LoadAsync();
-            var events = _httpContextAccessor.HttpContext.Session
-                .Get<IList<TrackedEvent>>(FacebookPixelDefaults.TrackedEventsSessionValue) ?? new List<TrackedEvent>();
+            var events = (await _httpContextAccessor.HttpContext.Session
+                .GetAsync<IList<TrackedEvent>>(FacebookPixelDefaults.TrackedEventsSessionValue))
+                ?? new List<TrackedEvent>();
             var store = await _storeContext.GetCurrentStoreAsync();
             var customer = await _workContext.GetCurrentCustomerAsync();
             var activeEvents = events.Where(trackedEvent =>
                 trackedEvent.CustomerId == customer.Id && trackedEvent.StoreId == store.Id)
                 .ToList();
-            _httpContextAccessor.HttpContext.Session.Set(FacebookPixelDefaults.TrackedEventsSessionValue, events.Except(activeEvents).ToList());
+            await _httpContextAccessor.HttpContext.Session.SetAsync(
+                FacebookPixelDefaults.TrackedEventsSessionValue,
+                events.Except(activeEvents).ToList());
 
             if (!activeEvents.Any())
                 return string.Empty;
@@ -396,9 +398,9 @@ namespace Nop.Plugin.Widgets.FacebookPixel.Services
             customerId ??= customer.Id;
             var store = await _storeContext.GetCurrentStoreAsync();
             storeId ??= store.Id;
-            await _httpContextAccessor.HttpContext.Session.LoadAsync();
-            var events = _httpContextAccessor.HttpContext.Session
-                .Get<IList<TrackedEvent>>(FacebookPixelDefaults.TrackedEventsSessionValue) ?? new List<TrackedEvent>();
+            var events = await _httpContextAccessor.HttpContext.Session
+                .GetAsync<IList<TrackedEvent>>(FacebookPixelDefaults.TrackedEventsSessionValue)
+                ?? new List<TrackedEvent>();
             var activeEvent = events.FirstOrDefault(trackedEvent =>
                 trackedEvent.EventName == eventName && trackedEvent.CustomerId == customerId && trackedEvent.StoreId == storeId);
             if (activeEvent == null)
@@ -413,7 +415,7 @@ namespace Nop.Plugin.Widgets.FacebookPixel.Services
                 events.Add(activeEvent);
             }
             activeEvent.EventObjects.Add(eventObject);
-            _httpContextAccessor.HttpContext.Session.Set(FacebookPixelDefaults.TrackedEventsSessionValue, events);
+            await _httpContextAccessor.HttpContext.Session.SetAsync(FacebookPixelDefaults.TrackedEventsSessionValue, events);
         }
 
         /// <summary>
@@ -982,7 +984,9 @@ namespace Nop.Plugin.Widgets.FacebookPixel.Services
         {
             await HandleFunctionAsync(async() =>
             {
-                var events = _httpContextAccessor.HttpContext.Session.Get<IList<TrackedEvent>>(FacebookPixelDefaults.TrackedEventsSessionValue) ?? new List<TrackedEvent>();
+                var events = await _httpContextAccessor.HttpContext.Session
+                    .GetAsync<IList<TrackedEvent>>(FacebookPixelDefaults.TrackedEventsSessionValue)
+                    ?? new List<TrackedEvent>();
                 foreach (var conversionsEventData in conversionsEvent.Data)
                 {
                     conversionsEventData.StoreId ??= (await _storeContext.GetCurrentStoreAsync()).Id;
@@ -1001,7 +1005,7 @@ namespace Nop.Plugin.Widgets.FacebookPixel.Services
                     }
 
                     activeEvent.EventObjects.Add(FormatCustomData(conversionsEventData.CustomData));
-                    _httpContextAccessor.HttpContext.Session.Set(FacebookPixelDefaults.TrackedEventsSessionValue, events);
+                    await _httpContextAccessor.HttpContext.Session.SetAsync(FacebookPixelDefaults.TrackedEventsSessionValue, events);
                 }
 
                 return Task.FromResult(true);

--- a/src/Plugins/Nop.Plugin.Widgets.FacebookPixel/Services/FacebookPixelService.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.FacebookPixel/Services/FacebookPixelService.cs
@@ -326,6 +326,7 @@ namespace Nop.Plugin.Widgets.FacebookPixel.Services
         private async Task<string> PrepareTrackedEventsScriptAsync(IList<FacebookPixelConfiguration> configurations)
         {
             //get previously stored events and remove them from the session data
+            await _httpContextAccessor.HttpContext.Session.LoadAsync();
             var events = _httpContextAccessor.HttpContext.Session
                 .Get<IList<TrackedEvent>>(FacebookPixelDefaults.TrackedEventsSessionValue) ?? new List<TrackedEvent>();
             var store = await _storeContext.GetCurrentStoreAsync();
@@ -395,6 +396,7 @@ namespace Nop.Plugin.Widgets.FacebookPixel.Services
             customerId ??= customer.Id;
             var store = await _storeContext.GetCurrentStoreAsync();
             storeId ??= store.Id;
+            await _httpContextAccessor.HttpContext.Session.LoadAsync();
             var events = _httpContextAccessor.HttpContext.Session
                 .Get<IList<TrackedEvent>>(FacebookPixelDefaults.TrackedEventsSessionValue) ?? new List<TrackedEvent>();
             var activeEvent = events.FirstOrDefault(trackedEvent =>

--- a/src/Presentation/Nop.Web/Controllers/CheckoutController.cs
+++ b/src/Presentation/Nop.Web/Controllers/CheckoutController.cs
@@ -1165,7 +1165,7 @@ namespace Nop.Web.Controllers
                 var paymentInfo = new ProcessPaymentRequest();
 
                 //session save
-                HttpContext.Session.Set("OrderPaymentInfo", paymentInfo);
+                await HttpContext.Session.SetAsync("OrderPaymentInfo", paymentInfo);
 
                 return RedirectToRoute("CheckoutConfirm");
             }
@@ -1219,10 +1219,10 @@ namespace Nop.Web.Controllers
                 //get payment info
                 var paymentInfo = await paymentMethod.GetPaymentInfoAsync(form);
                 //set previous order GUID (if exists)
-                _paymentService.GenerateOrderGuid(paymentInfo);
+                await _paymentService.GenerateOrderGuidAsync(paymentInfo);
 
                 //session save
-                HttpContext.Session.Set("OrderPaymentInfo", paymentInfo);
+                await HttpContext.Session.SetAsync("OrderPaymentInfo", paymentInfo);
                 return RedirectToRoute("CheckoutConfirm");
             }
 
@@ -1297,7 +1297,7 @@ namespace Nop.Web.Controllers
                     throw new Exception(await _localizationService.GetResourceAsync("Checkout.MinOrderPlacementInterval"));
 
                 //place order
-                var processPaymentRequest = HttpContext.Session.Get<ProcessPaymentRequest>("OrderPaymentInfo");
+                var processPaymentRequest = await HttpContext.Session.GetAsync<ProcessPaymentRequest>("OrderPaymentInfo");
                 if (processPaymentRequest == null)
                 {
                     //Check whether payment workflow is required
@@ -1306,16 +1306,16 @@ namespace Nop.Web.Controllers
 
                     processPaymentRequest = new ProcessPaymentRequest();
                 }
-                _paymentService.GenerateOrderGuid(processPaymentRequest);
+                await _paymentService.GenerateOrderGuidAsync(processPaymentRequest);
                 processPaymentRequest.StoreId = store.Id;
                 processPaymentRequest.CustomerId = customer.Id;
                 processPaymentRequest.PaymentMethodSystemName = await _genericAttributeService.GetAttributeAsync<string>(customer,
                     NopCustomerDefaults.SelectedPaymentMethodAttribute, store.Id);
-                HttpContext.Session.Set<ProcessPaymentRequest>("OrderPaymentInfo", processPaymentRequest);
+                await HttpContext.Session.SetAsync("OrderPaymentInfo", processPaymentRequest);
                 var placeOrderResult = await _orderProcessingService.PlaceOrderAsync(processPaymentRequest);
                 if (placeOrderResult.Success)
                 {
-                    HttpContext.Session.Set<ProcessPaymentRequest>("OrderPaymentInfo", null);
+                    await HttpContext.Session.SetAsync<ProcessPaymentRequest>("OrderPaymentInfo", null);
                     var postProcessPaymentRequest = new PostProcessPaymentRequest
                     {
                         Order = placeOrderResult.PlacedOrder
@@ -1452,7 +1452,7 @@ namespace Nop.Web.Controllers
                 var paymentInfo = new ProcessPaymentRequest();
 
                 //session save
-                HttpContext.Session.Set("OrderPaymentInfo", paymentInfo);
+                await HttpContext.Session.SetAsync("OrderPaymentInfo", paymentInfo);
 
                 var confirmOrderModel = await _checkoutModelFactory.PrepareConfirmOrderModelAsync(cart);
                 return Json(new
@@ -1962,10 +1962,10 @@ namespace Nop.Web.Controllers
                     //get payment info
                     var paymentInfo = await paymentMethod.GetPaymentInfoAsync(form);
                     //set previous order GUID (if exists)
-                    _paymentService.GenerateOrderGuid(paymentInfo);
+                    await _paymentService.GenerateOrderGuidAsync(paymentInfo);
 
                     //session save
-                    HttpContext.Session.Set("OrderPaymentInfo", paymentInfo);
+                    await HttpContext.Session.SetAsync("OrderPaymentInfo", paymentInfo);
 
                     var confirmOrderModel = await _checkoutModelFactory.PrepareConfirmOrderModelAsync(cart);
                     return Json(new
@@ -2037,7 +2037,7 @@ namespace Nop.Web.Controllers
                         throw new Exception(await _localizationService.GetResourceAsync("Checkout.MinOrderPlacementInterval"));
 
                     //place order
-                    var processPaymentRequest = HttpContext.Session.Get<ProcessPaymentRequest>("OrderPaymentInfo");
+                    var processPaymentRequest = await HttpContext.Session.GetAsync<ProcessPaymentRequest>("OrderPaymentInfo");
                     if (processPaymentRequest == null)
                     {
                         //Check whether payment workflow is required
@@ -2048,16 +2048,16 @@ namespace Nop.Web.Controllers
 
                         processPaymentRequest = new ProcessPaymentRequest();
                     }
-                    _paymentService.GenerateOrderGuid(processPaymentRequest);
+                    await _paymentService.GenerateOrderGuidAsync(processPaymentRequest);
                     processPaymentRequest.StoreId = store.Id;
                     processPaymentRequest.CustomerId = customer.Id;
                     processPaymentRequest.PaymentMethodSystemName = await _genericAttributeService.GetAttributeAsync<string>(customer,
                         NopCustomerDefaults.SelectedPaymentMethodAttribute, store.Id);
-                    HttpContext.Session.Set<ProcessPaymentRequest>("OrderPaymentInfo", processPaymentRequest);
+                    await HttpContext.Session.SetAsync("OrderPaymentInfo", processPaymentRequest);
                     var placeOrderResult = await _orderProcessingService.PlaceOrderAsync(processPaymentRequest);
                     if (placeOrderResult.Success)
                     {
-                        HttpContext.Session.Set<ProcessPaymentRequest>("OrderPaymentInfo", null);
+                        await HttpContext.Session.SetAsync<ProcessPaymentRequest>("OrderPaymentInfo", null);
                         var postProcessPaymentRequest = new PostProcessPaymentRequest
                         {
                             Order = placeOrderResult.PlacedOrder

--- a/src/Presentation/Nop.Web/Controllers/CustomerController.cs
+++ b/src/Presentation/Nop.Web/Controllers/CustomerController.cs
@@ -478,7 +478,9 @@ namespace Nop.Web.Controllers
                                 RememberMe = model.RememberMe,
                                 ReturnUrl = returnUrl
                             };
-                            HttpContext.Session.Set(NopCustomerDefaults.CustomerMultiFactorAuthenticationInfo, customerMultiFactorAuthenticationInfo);
+                            await HttpContext.Session.SetAsync(
+                                NopCustomerDefaults.CustomerMultiFactorAuthenticationInfo,
+                                customerMultiFactorAuthenticationInfo);
                             return RedirectToRoute("MultiFactorVerification");
                         }
                     case CustomerLoginResults.CustomerNotExist:
@@ -520,7 +522,8 @@ namespace Nop.Web.Controllers
             if (!await _multiFactorAuthenticationPluginManager.HasActivePluginsAsync())
                 return RedirectToRoute("Login");
 
-            var customerMultiFactorAuthenticationInfo = HttpContext.Session.Get<CustomerMultiFactorAuthenticationInfo>(NopCustomerDefaults.CustomerMultiFactorAuthenticationInfo);
+            var customerMultiFactorAuthenticationInfo = await HttpContext.Session.GetAsync<CustomerMultiFactorAuthenticationInfo>(
+                NopCustomerDefaults.CustomerMultiFactorAuthenticationInfo);
             var userName = customerMultiFactorAuthenticationInfo?.UserName;
             if (string.IsNullOrEmpty(userName))
                 return RedirectToRoute("Homepage");

--- a/src/Presentation/Nop.Web/Factories/ShoppingCartModelFactory.cs
+++ b/src/Presentation/Nop.Web/Factories/ShoppingCartModelFactory.cs
@@ -731,9 +731,9 @@ namespace Nop.Web.Factories
                 : string.Empty;
 
             //custom values
-            var processPaymentRequest = _httpContextAccessor.HttpContext?.Session?.Get<ProcessPaymentRequest>("OrderPaymentInfo");
-            if (processPaymentRequest != null)
-                model.CustomValues = processPaymentRequest.CustomValues;
+            var processPaymentRequestTask = _httpContextAccessor.HttpContext?.Session?.GetAsync<ProcessPaymentRequest>("OrderPaymentInfo");
+            if (processPaymentRequestTask != null)
+                model.CustomValues = (await processPaymentRequestTask).CustomValues;
 
             return model;
         }

--- a/src/Presentation/Nop.Web/Views/Customer/_ExternalAuthentication.Errors.cshtml
+++ b/src/Presentation/Nop.Web/Views/Customer/_ExternalAuthentication.Errors.cshtml
@@ -5,7 +5,7 @@
 
     var session = Context.Session;
 
-    var errors = session.Get<IList<string>>(NopAuthenticationDefaults.ExternalAuthenticationErrorsSessionKey);
+    var errors = await session.GetAsync<IList<string>>(NopAuthenticationDefaults.ExternalAuthenticationErrorsSessionKey);
 
     if (errors != null)
         session.Remove(NopAuthenticationDefaults.ExternalAuthenticationErrorsSessionKey);


### PR DESCRIPTION
This change removes a blocking call to the session cache in facebook pixel plugin.

When calling `HttpContext.Session.Get` you have to perform the load beforehand explicitly using `LoadAsync()`, otherwise the call to the session cache will be synchronous, if you're using a distributed cache (for example Redis) this can create big bottlenecks and performance issues.

As described in this article: [Session and state management in ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/app-state?view=aspnetcore-7.0).

Blocking this call will cause thread starvation. This is what happened to our customers website if Redis response times temporarily increased.

Thread Count:
![image](https://user-images.githubusercontent.com/526098/210245119-0070e209-2c71-4816-a71e-d8df613d19bb.png)

Page responsetime:
![image](https://user-images.githubusercontent.com/526098/210245489-c7488586-0ea9-4d20-85d7-f5655e36f606.png)

There are some more places where the session cache is called synchronously (Checkout, for example), but the impact is low. However, facebook pixel loads on every page and has massive impact on performance.

It might be advisable to wrap this functionality to enforce an async pattern globally in nopCommerce.

Cheers,
Emil Einarsson
CTO & senior developer, Majako
Web: [www.majako.se](https://www.majako.se/)

![image](https://user-images.githubusercontent.com/526098/210245854-5190843d-fa15-4fc7-8743-74d7eec6789c.png)
