### PR TITLE
Issue 6520, add async version of Get, Set and Remove methods for SessionExtensions

### DIFF
--- a/src/Libraries/Nop.Core/Http/Extensions/SessionExtensions.cs
+++ b/src/Libraries/Nop.Core/Http/Extensions/SessionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json;
 
 namespace Nop.Core.Http.Extensions
@@ -34,6 +35,62 @@ namespace Nop.Core.Http.Extensions
                 return default;
 
             return JsonConvert.DeserializeObject<T>(value);
+        }
+
+        /// <summary>
+        /// Remove value from Session
+        /// </summary>
+        /// <param name="session">Session</param>
+        /// <param name="key">Key</param>
+        public static void Remove(this ISession session, string key)
+        {
+            if (session.TryGetValue(key, out var _))
+                session.Remove(key);
+        }
+
+        /// <summary>
+        /// Set value to Session
+        /// </summary>
+        /// <typeparam name="T">Type of value</typeparam>
+        /// <param name="session">Session</param>
+        /// <param name="key">Key</param>
+        /// <param name="value">Value</param>
+        /// <returns>A task that represents the asynchronous operation</returns>
+        public static Task SetAsync<T>(this ISession session, string key, T value)
+        {
+            session.SetString(key, JsonConvert.SerializeObject(value));
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Get value from session
+        /// </summary>
+        /// <typeparam name="T">Type of value</typeparam>
+        /// <param name="session">Session</param>
+        /// <param name="key">Key</param>
+        /// <returns>Value</returns>
+        /// <returns>A task that represents the asynchronous operation</returns>
+        public static Task<T> GetAsync<T>(this ISession session, string key)
+        {
+            var value = session.GetString(key);
+            if (value == null)
+                return default;
+
+            return Task.FromResult(JsonConvert.DeserializeObject<T>(value));
+        }
+
+        /// <summary>
+        /// Remove value from Session
+        /// </summary>
+        /// <param name="session">Session</param>
+        /// <param name="key">Key</param>
+        /// <returns>A task that represents the asynchronous operation</returns>
+        public static Task RemoveAsync(this ISession session, string key)
+        {
+            if (session.TryGetValue(key, out var _))
+                session.Remove(key);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Libraries/Nop.Core/Http/NopDistributedSession.cs
+++ b/src/Libraries/Nop.Core/Http/NopDistributedSession.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Session;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+
+namespace Nop.Core.Http
+{
+    /// <summary>
+    /// An <see cref="ISession"/> backed by an <see cref="IDistributedCache"/>.
+    /// </summary>
+    public class NopDistributedSession : DistributedSession, ISession
+    {
+        private bool _loaded = false;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="NopDistributedSession"/>.
+        /// </summary>
+        /// <param name="cache">The <see cref="IDistributedCache"/> used to store the session data.</param>
+        /// <param name="sessionKey">A unique key used to lookup the session.</param>
+        /// <param name="idleTimeout">How long the session can be inactive (e.g. not accessed) before it will expire.</param>
+        /// <param name="ioTimeout">
+        /// The maximum amount of time <see cref="LoadAsync(CancellationToken)"/> and <see cref="CommitAsync(CancellationToken)"/> are allowed take.
+        /// </param>
+        /// <param name="tryEstablishSession">
+        /// A callback invoked during <see cref="Set(string, byte[])"/> to verify that modifying the session is currently valid.
+        /// If the callback returns <see langword="false"/>, <see cref="Set(string, byte[])"/> throws an <see cref="InvalidOperationException"/>.
+        /// <see cref="SessionMiddleware"/> provides a callback that returns <see langword="false"/> if the session was not established
+        /// prior to sending the response.
+        /// </param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
+        /// <param name="isNewSessionKey"><see langword="true"/> if establishing a new session; <see langword="false"/> if resuming a session.</param>
+        public NopDistributedSession(
+            IDistributedCache cache, string sessionKey, TimeSpan idleTimeout, TimeSpan ioTimeout,
+            Func<bool> tryEstablishSession, ILoggerFactory loggerFactory, bool isNewSessionKey)
+            : base(cache, sessionKey, idleTimeout, ioTimeout, tryEstablishSession, loggerFactory, isNewSessionKey)
+        {
+        }
+
+        /// <inheritdoc />
+        public new bool TryGetValue(string key, [NotNullWhen(true)] out byte[] value)
+        {
+            EnsureAsyncLoaded();
+            return base.TryGetValue(key, out value);
+        }
+
+        /// <inheritdoc />
+        public new void Set(string key, byte[] value)
+        {
+            EnsureAsyncLoaded();
+            base.Set(key, value);
+        }
+
+        /// <inheritdoc />
+        public new void Remove(string key)
+        {
+            EnsureAsyncLoaded();
+            base.Remove(key);
+        }
+
+        /// <summary>
+        /// Try to load session state asynchronously
+        /// </summary>
+        /// <see href="https://learn.microsoft.com/en-us/aspnet/core/fundamentals/app-state?view=aspnetcore-7.0#load-session-state-asynchronously"/>
+        private void EnsureAsyncLoaded()
+        {
+            if (!_loaded)
+            {
+                try
+                {
+                    LoadAsync().Wait();
+                }
+                catch
+                {
+                    //session will be loaded synchronously.
+                }
+
+                _loaded = true;
+            }
+        }
+    }
+}

--- a/src/Libraries/Nop.Core/Http/NopDistributedSessionStore.cs
+++ b/src/Libraries/Nop.Core/Http/NopDistributedSessionStore.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Session;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+
+namespace Nop.Core.Http
+{
+    /// <summary>
+    /// An <see cref="ISessionStore"/> backed by an <see cref="IDistributedCache"/>.
+    /// </summary>
+    public class NopDistributedSessionStore: ISessionStore
+    {
+        private readonly IDistributedCache _cache;
+        private readonly ILoggerFactory _loggerFactory;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="NopDistributedSessionStore"/>.
+        /// </summary>
+        /// <param name="cache">The <see cref="IDistributedCache"/> used to store the session data.</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
+        public NopDistributedSessionStore(IDistributedCache cache, ILoggerFactory loggerFactory)
+        {
+            if (cache == null)
+            {
+                throw new ArgumentNullException(nameof(cache));
+            }
+
+            if (loggerFactory == null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _cache = cache;
+            _loggerFactory = loggerFactory;
+        }
+
+        ///<inheritdoc/>
+        public ISession Create(
+            string sessionKey, TimeSpan idleTimeout, TimeSpan ioTimeout, 
+            Func<bool> tryEstablishSession, bool isNewSessionKey)
+        {
+            if (string.IsNullOrEmpty(sessionKey))
+            {
+                throw new ArgumentException("The session key is invalid.", nameof(sessionKey));
+            }
+
+            if (tryEstablishSession == null)
+            {
+                throw new ArgumentNullException(nameof(tryEstablishSession));
+            }
+
+            return new NopDistributedSession(
+                _cache, sessionKey, idleTimeout, ioTimeout, 
+                tryEstablishSession, _loggerFactory, isNewSessionKey);
+        }
+    }
+}

--- a/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.AspNetCore.Session;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Serialization;
@@ -130,6 +131,7 @@ namespace Nop.Web.Framework.Infrastructure.Extensions
         /// <param name="services">Collection of service descriptors</param>
         public static void AddHttpSession(this IServiceCollection services)
         {
+            services.AddTransient<ISessionStore, NopDistributedSessionStore>();
             services.AddSession(options =>
             {
                 options.Cookie.Name = $"{NopCookieDefaults.Prefix}{NopCookieDefaults.SessionCookie}";


### PR DESCRIPTION
This is the fix for [issue #6520](https://github.com/nopSolutions/nopCommerce/issues/6520)

When calling HttpContext.Session.Get you have to perform the load beforehand explicitly using LoadAsync(), otherwise the call to the session cache will be synchronous, if you're using a distributed cache (for example Redis) this can create big bottlenecks and performance issues.