### PR TITLE
Caching improvements

### DIFF
--- a/src/Libraries/Nop.Core/Caching/CacheKeyManager.cs
+++ b/src/Libraries/Nop.Core/Caching/CacheKeyManager.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Nop.Core.Infrastructure;
+
+namespace Nop.Core.Caching
+{
+    public class CacheKeyManager
+    {
+        private readonly ConcurrentTrie<byte> _keys = new();
+
+        public void AddKey(string key)
+        {
+            _keys.Add(key, default);
+        }
+
+        public void RemoveKey(string key)
+        {
+            _keys.Remove(key);
+        }
+
+        public void Clear()
+        {
+            _keys.Clear();
+        }
+
+        public IEnumerable<string> RemoveByPrefix(string prefix)
+        {
+            return _keys.Prune(prefix, out var subtree)
+                ? subtree.Keys
+                : Enumerable.Empty<string>();
+        }
+
+        public IEnumerable<string> Keys => _keys.Keys;
+    }
+}

--- a/src/Libraries/Nop.Core/Caching/CachingExtensions.cs
+++ b/src/Libraries/Nop.Core/Caching/CachingExtensions.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Nop.Core.Caching
+{
+    public static class CachingExtensions
+    {
+        /// <summary>
+        /// Get a cached item. If it's not in the cache yet, then load and cache it.
+        /// NOTE: this method is only kept for backwards compatibility: the async overload is preferred!
+        /// </summary>
+        /// <typeparam name="T">Type of cached item</typeparam>
+        /// <param name="key">Cache key</param>
+        /// <param name="acquire">Function to load item if it's not in the cache yet</param>
+        /// <returns>The cached value associated with the specified key</returns>
+        public static T Get<T>(this IStaticCacheManager cacheManager,CacheKey key, Func<T> acquire)
+        {
+            return cacheManager.GetAsync(key, acquire).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Remove items by cache key prefix
+        /// </summary>
+        /// <param name="prefix">Cache key prefix</param>
+        /// <param name="prefixParameters">Parameters to create cache key prefix</param>
+        public static void RemoveByPrefix(this IStaticCacheManager cacheManager, string prefix, params object[] prefixParameters)
+        {
+            cacheManager.RemoveByPrefixAsync(prefix, prefixParameters).Wait();
+        }
+    }
+}

--- a/src/Libraries/Nop.Core/Caching/CachingExtensions.cs
+++ b/src/Libraries/Nop.Core/Caching/CachingExtensions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 
 namespace Nop.Core.Caching
 {

--- a/src/Libraries/Nop.Core/Caching/DistributedCacheLocker.cs
+++ b/src/Libraries/Nop.Core/Caching/DistributedCacheLocker.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+using Newtonsoft.Json;
+
+namespace Nop.Core.Caching
+{
+    public partial class DistributedCacheLocker : ILocker
+    {
+        #region Fields
+
+        private static readonly string _running = JsonConvert.SerializeObject(TaskStatus.Running);
+        private readonly IDistributedCache _distributedCache;
+
+        #endregion
+
+        #region Ctor
+
+        public DistributedCacheLocker(IDistributedCache distributedCache)
+        {
+            _distributedCache = distributedCache;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public async Task<bool> PerformActionWithLockAsync(string resource, TimeSpan expirationTime, Func<Task> action)
+        {
+            //ensure that lock is acquired
+            if (!string.IsNullOrEmpty(await _distributedCache.GetStringAsync(resource)))
+                return false;
+
+            try
+            {
+                await _distributedCache.SetStringAsync(resource, resource, new DistributedCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = expirationTime
+                });
+
+                await action();
+
+                return true;
+            }
+            finally
+            {
+                //release lock even if action fails
+                await _distributedCache.RemoveAsync(resource);
+            }
+        }
+
+        public async Task RunWithHeartbeatAsync(string key, TimeSpan expirationTime, TimeSpan heartbeatInterval, Func<CancellationToken, Task> action, CancellationTokenSource cancellationTokenSource = default)
+        {
+            if (!string.IsNullOrEmpty(await _distributedCache.GetStringAsync(key)))
+                return;
+
+
+            async Task heartbeat(CancellationToken token) => await _distributedCache.SetStringAsync(
+                key,
+                _running,
+                new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = expirationTime },
+                token: token);
+
+            var tokenSource = cancellationTokenSource ?? new();
+            var heartbeatTokenSource = CancellationTokenSource.CreateLinkedTokenSource(tokenSource.Token);
+            try
+            {
+                // run heartbeat early to minimise risk of multiple execution
+                await heartbeat(heartbeatTokenSource.Token);
+
+                using var timer = new Timer(
+                    callback: async state =>
+                    {
+                        try
+                        {
+                            heartbeatTokenSource.Token.ThrowIfCancellationRequested();
+                            var status = await _distributedCache.GetStringAsync(key, tokenSource.Token);
+                            if (!string.IsNullOrEmpty(status) && JsonConvert.DeserializeObject<TaskStatus>(status) == TaskStatus.Canceled)
+                            {
+                                tokenSource.Cancel();
+                                return;
+                            }
+                            await heartbeat(heartbeatTokenSource.Token);
+                        }
+                        catch (OperationCanceledException) { }
+                    },
+                    state: null,
+                    dueTime: 0,
+                    period: (int)heartbeatInterval.TotalMilliseconds);
+
+                await action(tokenSource.Token);
+            }
+            catch (OperationCanceledException) { }
+            finally
+            {
+                // Because the heartbeat is called as an async void callback by the timer, it is not awaited or cancelled on disposal.
+                // Since this may lead to heartbeat being called after the key is removed, we cancel it before removing the key.
+                heartbeatTokenSource.Cancel();
+                await _distributedCache.RemoveAsync(key);
+            }
+        }
+
+        public async Task CancelTaskAsync(string key, TimeSpan expirationTime)
+        {
+            var status = await _distributedCache.GetStringAsync(key);
+            if (!string.IsNullOrEmpty(status) && JsonConvert.DeserializeObject<TaskStatus>(status) != TaskStatus.Canceled)
+            {
+                await _distributedCache.SetStringAsync(
+                    key,
+                    JsonConvert.SerializeObject(TaskStatus.Canceled),
+                    new DistributedCacheEntryOptions
+                    {
+                        AbsoluteExpirationRelativeToNow = expirationTime
+                    });
+            }
+        }
+
+        public async Task<bool> IsTaskRunningAsync(string key)
+        {
+            return !string.IsNullOrEmpty(await _distributedCache.GetStringAsync(key));
+        }
+
+        #endregion
+    }
+}

--- a/src/Libraries/Nop.Core/Caching/DistributedCacheManager.cs
+++ b/src/Libraries/Nop.Core/Caching/DistributedCacheManager.cs
@@ -179,6 +179,14 @@ namespace Nop.Core.Caching
             return GetAsync(key, () => Task.FromResult(acquire()));
         }
 
+        public async Task<T> GetAsync<T>(CacheKey key, T defaultValue = default)
+        {
+            var value = await _distributedCache.GetStringAsync(key.Key);
+            return value != null
+                ? JsonConvert.DeserializeObject<T>(value)
+                : defaultValue;
+        }
+
         /// <summary>
         /// Add the specified key and object to the cache
         /// </summary>

--- a/src/Libraries/Nop.Core/Caching/ILocker.cs
+++ b/src/Libraries/Nop.Core/Caching/ILocker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Nop.Core.Caching
@@ -6,12 +7,42 @@ namespace Nop.Core.Caching
     public interface ILocker
     {
         /// <summary>
-        /// Perform asynchronous action with exclusive in-memory lock
+        /// Performs some asynchronous task with exclusive lock
         /// </summary>
         /// <param name="resource">The key we are locking on</param>
         /// <param name="expirationTime">The time after which the lock will automatically be expired</param>
-        /// <param name="action">Action to be performed with locking</param>
-        /// <returns>True if lock was acquired and action was performed; otherwise false</returns>
+        /// <param name="action">Asynchronous task to be performed with locking</param>
+        /// <returns>A task that resolves true if lock was acquired and action was performed; otherwise false</returns>
         Task<bool> PerformActionWithLockAsync(string resource, TimeSpan expirationTime, Func<Task> action);
+
+        /// <summary>
+        /// Starts a background task with "heartbeat": a status flag that will be periodically updated to signal to
+        /// others that the task is running and stop them from starting the same task.
+        /// </summary>
+        /// <param name="key">The key of the background task</param>
+        /// <param name="expirationTime">The time after which the heartbeat key will automatically be expired. Should be longer than <paramref name="heartbeatInterval"/></param>
+        /// <param name="heartbeatInterval">The interval at which to update the heartbeat, if required by the implementation</param>
+        /// <param name="action">Asynchronous background task to be performed</param>
+        /// <param name="cancellationTokenSource">A CancellationTokenSource for manually cancelling the task</param>
+        /// <returns>A task that resolves true if lock was acquired and action was performed; otherwise false</returns>
+        Task RunWithHeartbeatAsync(string key, TimeSpan expirationTime, TimeSpan heartbeatInterval, Func<CancellationToken, Task> action, CancellationTokenSource cancellationTokenSource = default);
+
+        /// <summary>
+        /// Tries to cancel a background task by flagging it for cancellation on the next heartbeat.
+        /// </summary>
+        /// <param name="key">The task's key</param>
+        /// <param name="expirationTime">The time after which the task will be considered stopped due to system shutdown or other causes,
+        /// even if not explicitly cancelled.</param>
+        /// <returns>A task that represents requesting cancellation of the task. Note that the completion of this task does not
+        /// necessarily imply that the task has been cancelled, only that cancellation has been requested.</returns>
+
+        Task CancelTaskAsync(string key, TimeSpan expirationTime);
+
+        /// <summary>
+        /// Check if a background task is running.
+        /// </summary>
+        /// <param name="key">The task's key</param>
+        /// <returns>A task that resolves to true if the background task is running; otherwise false</returns>
+        Task<bool> IsTaskRunningAsync(string key);
     }
 }

--- a/src/Libraries/Nop.Core/Caching/IStaticCacheManager.cs
+++ b/src/Libraries/Nop.Core/Caching/IStaticCacheManager.cs
@@ -33,6 +33,18 @@ namespace Nop.Core.Caching
         Task<T> GetAsync<T>(CacheKey key, Func<T> acquire);
 
         /// <summary>
+        /// Get a cached item. If it's not in the cache yet, return a default value
+        /// </summary>
+        /// <typeparam name="T">Type of cached item</typeparam>
+        /// <param name="key">Cache key</param>
+        /// <param name="defaultValue">A default value to return if the key is not present in the cache</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation
+        /// The task result contains the cached value associated with the specified key, or the default value if none was found
+        /// </returns>
+        Task<T> GetAsync<T>(CacheKey key, T defaultValue = default);
+
+        /// <summary>
         /// Remove the value with the specified key from the cache
         /// </summary>
         /// <param name="cacheKey">Cache key</param>

--- a/src/Libraries/Nop.Core/Caching/IStaticCacheManager.cs
+++ b/src/Libraries/Nop.Core/Caching/IStaticCacheManager.cs
@@ -33,15 +33,6 @@ namespace Nop.Core.Caching
         Task<T> GetAsync<T>(CacheKey key, Func<T> acquire);
 
         /// <summary>
-        /// Get a cached item. If it's not in the cache yet, then load and cache it
-        /// </summary>
-        /// <typeparam name="T">Type of cached item</typeparam>
-        /// <param name="key">Cache key</param>
-        /// <param name="acquire">Function to load item if it's not in the cache yet</param>
-        /// <returns>The cached value associated with the specified key</returns>
-        T Get<T>(CacheKey key, Func<T> acquire);
-
-        /// <summary>
         /// Remove the value with the specified key from the cache
         /// </summary>
         /// <param name="cacheKey">Cache key</param>
@@ -55,7 +46,7 @@ namespace Nop.Core.Caching
         /// <param name="key">Key of cached item</param>
         /// <param name="data">Value for caching</param>
         /// <returns>A task that represents the asynchronous operation</returns>
-        Task SetAsync(CacheKey key, object data);
+        Task SetAsync<T>(CacheKey key, T data);
         
         /// <summary>
         /// Remove items by cache key prefix
@@ -64,13 +55,6 @@ namespace Nop.Core.Caching
         /// <param name="prefixParameters">Parameters to create cache key prefix</param>
         /// <returns>A task that represents the asynchronous operation</returns>
         Task RemoveByPrefixAsync(string prefix, params object[] prefixParameters);
-
-        /// <summary>
-        /// Remove items by cache key prefix
-        /// </summary>
-        /// <param name="prefix">Cache key prefix</param>
-        /// <param name="prefixParameters">Parameters to create cache key prefix</param>
-        void RemoveByPrefix(string prefix, params object[] prefixParameters);
 
         /// <summary>
         /// Clear all cache data

--- a/src/Libraries/Nop.Core/Caching/MemoryCacheLocker.cs
+++ b/src/Libraries/Nop.Core/Caching/MemoryCacheLocker.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Nop.Core.Caching
+{
+    /// <summary>
+    /// A distributed cache manager that locks the acquisition task
+    /// </summary>
+    public partial class MemoryCacheLocker : ILocker
+    {
+        #region Fields
+
+        private readonly IMemoryCache _memoryCache;
+
+        #endregion
+
+        #region Ctor
+
+        public MemoryCacheLocker(IMemoryCache memoryCache)
+        {
+            _memoryCache = memoryCache;
+        }
+
+        #endregion
+
+        #region Utilities
+
+        private async Task<bool> RunAsync(string key, TimeSpan? expirationTime, Func<CancellationToken, Task> action, CancellationTokenSource cancellationTokenSource = default)
+        {
+            var started = false;
+            try
+            {
+                var tokenSource = _memoryCache.GetOrCreate(key, entry => new Lazy<CancellationTokenSource>(() =>
+                {
+                    entry.AbsoluteExpirationRelativeToNow = expirationTime;
+                    entry.SetPriority(CacheItemPriority.NeverRemove);
+                    started = true;
+                    return cancellationTokenSource ?? new();
+                }, true)).Value;
+
+                if (started)
+                    await action(tokenSource.Token);
+            }
+            catch (OperationCanceledException) { }
+            finally
+            {
+                if (started)
+                    _memoryCache.Remove(key);
+            }
+            return started;
+        }
+
+        #endregion
+
+        #region Methods
+
+        public async Task<bool> PerformActionWithLockAsync(string resource, TimeSpan expirationTime, Func<Task> action)
+        {
+            return await RunAsync(resource, expirationTime, _ => action());
+        }
+
+        public async Task RunWithHeartbeatAsync(string key, TimeSpan expirationTime, TimeSpan heartbeatInterval, Func<CancellationToken, Task> action, CancellationTokenSource cancellationTokenSource = default)
+        {
+            // We ignore expirationTime and heartbeatInterval here, as the cache is not shared with other instances,
+            // and will be cleared on system failure anyway. The task is guaranteed to still be running as long as it is in the cache.
+            await RunAsync(key, null, action, cancellationTokenSource);
+        }
+
+        public Task CancelTaskAsync(string key, TimeSpan expirationTime)
+        {
+            if (_memoryCache.TryGetValue(key, out Lazy<CancellationTokenSource> tokenSource))
+                tokenSource.Value.Cancel();
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> IsTaskRunningAsync(string key)
+        {
+            return Task.FromResult(_memoryCache.TryGetValue(key, out _));
+        }
+
+        #endregion
+    }
+}

--- a/src/Libraries/Nop.Core/Caching/MemoryCacheManager.cs
+++ b/src/Libraries/Nop.Core/Caching/MemoryCacheManager.cs
@@ -1,18 +1,17 @@
 ﻿using System;
-using System.Collections.Concurrent;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Primitives;
 using Nop.Core.Configuration;
+using Nop.Core.Infrastructure;
 
 namespace Nop.Core.Caching
 {
     /// <summary>
     /// Represents a memory cache manager 
     /// </summary>
-    public partial class MemoryCacheManager : CacheKeyService, ILocker, IStaticCacheManager
+    public partial class MemoryCacheManager : CacheKeyService, IStaticCacheManager
     {
         #region Fields
 
@@ -20,8 +19,7 @@ namespace Nop.Core.Caching
         private bool _disposed;
 
         private readonly IMemoryCache _memoryCache;
-
-        private static readonly ConcurrentDictionary<string, CancellationTokenSource> _prefixes = new();
+        private static readonly ConcurrentTrie<byte> _keys = new();
         private static CancellationTokenSource _clearToken = new();
 
         #endregion
@@ -42,7 +40,7 @@ namespace Nop.Core.Caching
         /// </summary>
         /// <param name="key">Cache key</param>
         /// <returns>Cache entry options</returns>
-        private MemoryCacheEntryOptions PrepareEntryOptions(CacheKey key)
+        private static MemoryCacheEntryOptions PrepareEntryOptions(CacheKey key)
         {
             //set expiration time for the passed cache key
             var options = new MemoryCacheEntryOptions
@@ -50,39 +48,28 @@ namespace Nop.Core.Caching
                 AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(key.CacheTime)
             };
 
-            //add tokens to clear cache entries
+            //add token to clear cache entries
             options.AddExpirationToken(new CancellationChangeToken(_clearToken.Token));
-            foreach (var keyPrefix in key.Prefixes.ToList())
-            {
-                var tokenSource = _prefixes.GetOrAdd(keyPrefix, new CancellationTokenSource());
-                options.AddExpirationToken(new CancellationChangeToken(tokenSource.Token));
-            }
+            options.RegisterPostEvictionCallback(OnEviction);
+            _keys.Add(key.Key, default);
 
             return options;
         }
 
-        /// <summary>
-        /// Remove the value with the specified key from the cache
-        /// </summary>
-        /// <param name="cacheKey">Cache key</param>
-        /// <param name="cacheKeyParameters">Parameters to create cache key</param>
-        private void Remove(CacheKey cacheKey, params object[] cacheKeyParameters)
+        private static void OnEviction(object key, object value, EvictionReason reason, object state)
         {
-            cacheKey = PrepareKey(cacheKey, cacheKeyParameters);
-            _memoryCache.Remove(cacheKey.Key);
-        }
-
-        /// <summary>
-        /// Add the specified key and object to the cache
-        /// </summary>
-        /// <param name="key">Key of cached item</param>
-        /// <param name="data">Value for caching</param>
-        private void Set(CacheKey key, object data)
-        {
-            if ((key?.CacheTime ?? 0) <= 0 || data == null)
-                return;
-
-            _memoryCache.Set(key.Key, data, PrepareEntryOptions(key));
+            switch (reason)
+            {
+                // we clean up after ourselves elsewhere
+                case EvictionReason.Removed:
+                case EvictionReason.Replaced:
+                case EvictionReason.TokenExpired:
+                    break;
+                // if the entry was evicted by the cache itself, we remove the key
+                default:
+                    _keys.Remove(key as string);
+                    break;
+            }
         }
 
         #endregion
@@ -97,8 +84,9 @@ namespace Nop.Core.Caching
         /// <returns>A task that represents the asynchronous operation</returns>
         public Task RemoveAsync(CacheKey cacheKey, params object[] cacheKeyParameters)
         {
-            Remove(cacheKey, cacheKeyParameters);
-
+            var key = PrepareKey(cacheKey, cacheKeyParameters).Key;
+            _memoryCache.Remove(key);
+            _keys.Remove(key);
             return Task.CompletedTask;
         }
 
@@ -117,15 +105,16 @@ namespace Nop.Core.Caching
             if ((key?.CacheTime ?? 0) <= 0)
                 return await acquire();
 
-            if (_memoryCache.TryGetValue(key.Key, out T result))
-                return result;
-
-            result = await acquire();
-
-            if (result != null)
-                await SetAsync(key, result);
-
-            return result;
+            var value = await _memoryCache.GetOrCreate(
+                key.Key,
+                entry =>
+                {
+                    entry.SetOptions(PrepareEntryOptions(key));
+                    return new Lazy<Task<T>>(acquire, true);
+                }).Value;
+            if (value == null)
+                await RemoveAsync(key);
+            return value;
         }
 
         /// <summary>
@@ -140,44 +129,7 @@ namespace Nop.Core.Caching
         /// </returns>
         public async Task<T> GetAsync<T>(CacheKey key, Func<T> acquire)
         {
-            if ((key?.CacheTime ?? 0) <= 0)
-                return acquire();
-
-            var result = _memoryCache.GetOrCreate(key.Key, entry =>
-            {
-                entry.SetOptions(PrepareEntryOptions(key));
-
-                return acquire();
-            });
-
-            //do not cache null value
-            if (result == null)
-                await RemoveAsync(key);
-
-            return result;
-        }
-
-        /// <summary>
-        /// Get a cached item. If it's not in the cache yet, then load and cache it
-        /// </summary>
-        /// <typeparam name="T">Type of cached item</typeparam>
-        /// <param name="key">Cache key</param>
-        /// <param name="acquire">Function to load item if it's not in the cache yet</param>
-        /// <returns>The cached value associated with the specified key</returns>
-        public T Get<T>(CacheKey key, Func<T> acquire)
-        {
-            if ((key?.CacheTime ?? 0) <= 0)
-                return acquire();
-
-            if (_memoryCache.TryGetValue(key.Key, out T result))
-                return result;
-
-            result = acquire();
-
-            if (result != null)
-                Set(key, result);
-
-            return result;
+            return await GetAsync(key, () => Task.FromResult(acquire()));
         }
 
         /// <summary>
@@ -186,79 +138,16 @@ namespace Nop.Core.Caching
         /// <param name="key">Key of cached item</param>
         /// <param name="data">Value for caching</param>
         /// <returns>A task that represents the asynchronous operation</returns>
-        public Task SetAsync(CacheKey key, object data)
+        public Task SetAsync<T>(CacheKey key, T data)
         {
-            Set(key, data);
-
+            if (data != null && (key?.CacheTime ?? 0) > 0)
+            {
+                _memoryCache.Set(
+                    key.Key,
+                    new Lazy<Task<T>>(() => Task.FromResult(data), true),
+                    PrepareEntryOptions(key));
+            }
             return Task.CompletedTask;
-        }
-
-        /// <summary>
-        /// Perform some action with exclusive in-memory lock
-        /// </summary>
-        /// <param name="key">The key we are locking on</param>
-        /// <param name="expirationTime">The time after which the lock will automatically be expired</param>
-        /// <param name="action">Action to be performed with locking</param>
-        /// <returns>True if lock was acquired and action was performed; otherwise false</returns>
-        public bool PerformActionWithLock(string key, TimeSpan expirationTime, Action action)
-        {
-            //ensure that lock is acquired
-            if (_memoryCache.TryGetValue(key, out _))
-                return false;
-
-            try
-            {
-                _memoryCache.Set(key, key, expirationTime);
-
-                //perform action
-                action();
-
-                return true;
-            }
-            finally
-            {
-                //release lock even if action fails
-                _memoryCache.Remove(key);
-            }
-        }
-
-        /// <summary>
-        /// Perform asynchronous action with exclusive in-memory lock
-        /// </summary>
-        /// <param name="resource">The key we are locking on</param>
-        /// <param name="expirationTime">The time after which the lock will automatically be expired</param>
-        /// <param name="action">Action to be performed with locking</param>
-        /// <returns>True if lock was acquired and action was performed; otherwise false</returns>
-        public async Task<bool> PerformActionWithLockAsync(string resource, TimeSpan expirationTime, Func<Task> action)
-        {
-            //ensure that lock is acquired
-            var isSet = await _memoryCache.GetOrCreateAsync(resource, cacheEntry =>
-                {
-                    cacheEntry.AbsoluteExpiration = DateTimeOffset.Now;
-                    return Task.FromResult(false);
-                });
-
-            if (isSet)
-                return false;
-
-            try
-            {
-                await _memoryCache.GetOrCreateAsync(resource, cacheEntry =>
-                {
-                    cacheEntry.AbsoluteExpirationRelativeToNow = expirationTime;
-                    return Task.FromResult(true);
-                });
-
-                //perform action
-                await action();
-
-                return true;
-            }
-            finally
-            {
-                //release lock even if action fails
-                _memoryCache.Remove(resource);
-            }
         }
 
         /// <summary>
@@ -269,23 +158,13 @@ namespace Nop.Core.Caching
         /// <returns>A task that represents the asynchronous operation</returns>
         public Task RemoveByPrefixAsync(string prefix, params object[] prefixParameters)
         {
-            RemoveByPrefix(prefix, prefixParameters);
+            if (_keys.Prune(PrepareKeyPrefix(prefix, prefixParameters), out var subtree))
+            {
+                foreach (var key in subtree.Keys)
+                    _memoryCache.Remove(key);
+            }
 
             return Task.CompletedTask;
-        }
-
-        /// <summary>
-        /// Remove items by cache key prefix
-        /// </summary>
-        /// <param name="prefix">Cache key prefix</param>
-        /// <param name="prefixParameters">Parameters to create cache key prefix</param>
-        public void RemoveByPrefix(string prefix, params object[] prefixParameters)
-        {
-            prefix = PrepareKeyPrefix(prefix, prefixParameters);
-
-            _prefixes.TryRemove(prefix, out var tokenSource);
-            tokenSource?.Cancel();
-            tokenSource?.Dispose();
         }
 
         /// <summary>
@@ -296,21 +175,11 @@ namespace Nop.Core.Caching
         {
             _clearToken.Cancel();
             _clearToken.Dispose();
-
             _clearToken = new CancellationTokenSource();
-
-            foreach (var prefix in _prefixes.Keys.ToList())
-            {
-                _prefixes.TryRemove(prefix, out var tokenSource);
-                tokenSource?.Dispose();
-            }
-
+            _keys.Clear();
             return Task.CompletedTask;
         }
 
-        /// <summary>
-        /// Dispose cache manager
-        /// </summary>
         public void Dispose()
         {
             Dispose(true);
@@ -324,7 +193,10 @@ namespace Nop.Core.Caching
                 return;
 
             if (disposing)
-                _memoryCache.Dispose();
+            {
+                _clearToken.Dispose();
+                // don't dispose of the MemoryCache, as it is injected
+            }
 
             _disposed = true;
         }

--- a/src/Libraries/Nop.Core/Caching/MemoryCacheManager.cs
+++ b/src/Libraries/Nop.Core/Caching/MemoryCacheManager.cs
@@ -107,16 +107,19 @@ namespace Nop.Core.Caching
             if ((key?.CacheTime ?? 0) <= 0)
                 return await acquire();
 
-            var value = await _memoryCache.GetOrCreate(
+            return await _memoryCache.GetOrCreate(
                 key.Key,
                 entry =>
                 {
                     entry.SetOptions(PrepareEntryOptions(key));
                     return new Lazy<Task<T>>(acquire, true);
                 }).Value;
-            if (value == null)
-                await RemoveAsync(key);
-            return value;
+        }
+
+        public async Task<T> GetAsync<T>(CacheKey key, T defaultValue = default)
+        {
+            var value = _memoryCache.Get<Lazy<Task<T>>>(key.Key)?.Value;
+            return value != null ? await value : defaultValue;
         }
 
         /// <summary>

--- a/src/Libraries/Nop.Core/Configuration/DistributedCacheConfig.cs
+++ b/src/Libraries/Nop.Core/Configuration/DistributedCacheConfig.cs
@@ -12,7 +12,7 @@ namespace Nop.Core.Configuration
         /// Gets or sets a distributed cache type
         /// </summary>
         [JsonConverter(typeof(StringEnumConverter))]
-        public DistributedCacheType DistributedCacheType { get; private set; } = DistributedCacheType.Redis;
+        public DistributedCacheType DistributedCacheType { get; private set; } = DistributedCacheType.RedisSynchronizedMemory;
 
         /// <summary>
         /// Gets or sets a value indicating whether we should use distributed cache
@@ -33,5 +33,11 @@ namespace Nop.Core.Configuration
         /// Gets or sets table name. Used when distributed cache is enabled and DistributedCacheType property is set as SqlServer
         /// </summary>
         public string TableName { get; private set; } = "DistributedCache";
+
+        /// <summary>
+        /// Gets or sets instance name. Used when distributed cache is enabled and DistributedCacheType property is set as Redis or RedisSynchronizedMemory.
+        /// Useful when one wants to partition a single Redis server for use with multiple apps, e.g. by setting InstanceName to "development" and "production".
+        /// </summary>
+        public string InstanceName { get; private set; } = "nopCommerce";
     }
 }

--- a/src/Libraries/Nop.Core/Configuration/DistributedCacheType.cs
+++ b/src/Libraries/Nop.Core/Configuration/DistributedCacheType.cs
@@ -12,6 +12,8 @@ namespace Nop.Core.Configuration
         [EnumMember(Value = "sqlserver")]
         SqlServer,
         [EnumMember(Value = "redis")]
-        Redis
+        Redis,
+        [EnumMember(Value = "redissynchronizedmemory")]
+        RedisSynchronizedMemory
     }
 }

--- a/src/Libraries/Nop.Core/Infrastructure/ConcurrentTrie.cs
+++ b/src/Libraries/Nop.Core/Infrastructure/ConcurrentTrie.cs
@@ -1,0 +1,234 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Nop.Core.Infrastructure
+{
+    /// <summary>
+    /// A thread-safe implementation of a trie, or prefix tree
+    /// </summary>
+    public class ConcurrentTrie<TValue>
+    {
+        private class TrieNode
+        {
+            private readonly ReaderWriterLockSlim _lock = new();
+            private (bool hasValue, TValue value) _value;
+            public readonly ConcurrentDictionary<char, TrieNode> Children = new();
+
+            public bool GetValue(out TValue value)
+            {
+                _lock.EnterReadLock();
+                try
+                {
+                    (var hasValue, value) = _value;
+                    return hasValue;
+                }
+                finally
+                {
+                    _lock.ExitReadLock();
+                }
+            }
+
+            public void SetValue(TValue value)
+            {
+                SetValue(value, true);
+            }
+
+            public void RemoveValue()
+            {
+                SetValue(default, false);
+            }
+
+            private void SetValue(TValue value, bool hasValue)
+            {
+                _lock.EnterWriteLock();
+                try
+                {
+                    _value = (hasValue, value);
+                }
+                finally
+                {
+                    _lock.ExitWriteLock();
+                }
+            }
+        }
+
+        private readonly TrieNode _root;
+        private readonly string _prefix;
+
+        public IEnumerable<string> Keys => Search(string.Empty).Select(kv => kv.Key);
+        public IEnumerable<TValue> Values => Search(string.Empty).Select(kv => kv.Value);
+
+
+        public ConcurrentTrie() : this(new(), string.Empty)
+        {
+        }
+
+        private ConcurrentTrie(TrieNode root, string prefix)
+        {
+            _root = root;
+            _prefix = prefix;
+        }
+
+        /// <summary>
+        /// Attempts to get the value associated with the specified key
+        /// </summary>
+        /// <param name="key">The key of the item to get (case-insensitive)</param>
+        /// <param name="value">The value associated with <paramref name="key"/>, if found</param>
+        /// <returns>
+        /// True if the key was found, otherwise false
+        /// </returns>
+        public bool TryGetValue(string key, out TValue value)
+        {
+            if (key is null)
+                throw new ArgumentNullException(nameof(key));
+
+            value = default;
+            return Find(key, out var node) && node.GetValue(out value);
+        }
+
+        /// <summary>
+        /// Adds a key-value pair to the trie
+        /// </summary>
+        /// <param name="key">The key of the new item (case-insensitive)</param>
+        /// <param name="value">The value to be associated with <paramref name="key"/></param>
+        public void Add(string key, TValue value)
+        {
+            if (string.IsNullOrEmpty(key))
+                throw new ArgumentException($"'{nameof(key)}' cannot be null or empty.", nameof(key));
+
+            GetOrAddNode(key).SetValue(value);
+        }
+
+        /// <summary>
+        /// Clears the trie
+        /// </summary>
+        public void Clear()
+        {
+            _root.Children.Clear();
+        }
+
+        /// <summary>
+        /// Gets all key-value pairs for keys starting with the given prefix
+        /// </summary>
+        /// <param name="prefix">The prefix to search for (case-insensitive)</param>
+        /// <returns>
+        /// All key-value pairs for keys starting with <paramref name="prefix"/>
+        /// </returns>
+        public IEnumerable<KeyValuePair<string, TValue>> Search(string prefix)
+        {
+            if (prefix is null)
+                throw new ArgumentNullException(nameof(prefix));
+
+            if (!Find(prefix, out var node))
+                return Enumerable.Empty<KeyValuePair<string, TValue>>();
+
+            // depth-first traversal
+            IEnumerable<KeyValuePair<string, TValue>> traverse(TrieNode n, string s)
+            {
+                if (n.GetValue(out var value))
+                    yield return new KeyValuePair<string, TValue>(_prefix + s, value);
+                foreach (var (c, child) in n.Children)
+                {
+                    foreach (var kv in traverse(child, s + c))
+                        yield return kv;
+                }
+            }
+            return traverse(node, prefix);
+        }
+
+        /// <summary>
+        /// Removes the item with the given key, if present
+        /// </summary>
+        /// <param name="key">The key of the item to be removed (case-insensitive)</param>
+        public void Remove(string key)
+        {
+            Remove(_root, key);
+        }
+
+        /// <summary>
+        /// Gets the value with the specified key, adding a new item if one does not exist
+        /// </summary>
+        /// <param name="key">The key of the item to be deleted (case-insensitive)</param>
+        /// <param name="valueFactory">A function for producing a new value if one was not found</param>
+        /// <returns>
+        /// The existing value for the given key, if found, otherwise the newly inserted value
+        /// </returns>
+        public TValue GetOrAdd(string key, Func<TValue> valueFactory)
+        {
+            var node = GetOrAddNode(key);
+            if (node.GetValue(out var value))
+                return value;
+            value = valueFactory();
+            node.SetValue(value);
+            return value;
+        }
+
+        /// <summary>
+        /// Attempts to remove all items with keys starting with the specified prefix
+        /// </summary>
+        /// <param name="prefix">The prefix of the items to be deleted (case-insensitive)</param>
+        /// <param name="subtree">The subtree containing all deleted items, if found</param>
+        /// <returns>
+        /// True if the prefix was successfully removed from the trie, otherwise false
+        /// </returns>
+        public bool Prune(string prefix, out ConcurrentTrie<TValue> subtree)
+        {
+            if (string.IsNullOrEmpty(prefix))
+                throw new ArgumentException($"'{nameof(prefix)}' cannot be null or empty.", nameof(prefix));
+
+            subtree = default;
+            var node = _root;
+            TrieNode parent = null;
+            char last = default;
+            foreach (var c in prefix)
+            {
+                parent = node;
+                if (!node.Children.TryGetValue(c, out node))
+                    return false;
+                last = c;
+            }
+            if (parent?.Children.TryRemove(last, out var subtreeRoot) == true)
+                subtree = new ConcurrentTrie<TValue>(subtreeRoot, prefix);
+            return true;
+        }
+
+        private TrieNode GetOrAddNode(string key)
+        {
+            var node = _root;
+            foreach (var c in key)
+                node = node.Children.GetOrAdd(c, _ => new());
+            return node;
+        }
+
+        private bool Find(string key, out TrieNode node)
+        {
+            node = _root;
+            foreach (var c in key)
+            {
+                if (!node.Children.TryGetValue(c, out node))
+                    return false;
+            }
+            return true;
+        }
+
+        private bool Remove(TrieNode node, string key)
+        {
+            if (key.Length == 0)
+            {
+                if (node.GetValue(out _))
+                    node.RemoveValue();
+                return !node.Children.IsEmpty;
+            }
+            var c = key[0];
+            if (node.Children.TryGetValue(c, out var child))
+            {
+                if (!Remove(child, key[1..]))
+                    node.Children.TryRemove(new(c, child));
+            }
+            return true;
+        }
+    }
+}

--- a/src/Libraries/Nop.Services/Caching/MemoryDistributedCacheManager.cs
+++ b/src/Libraries/Nop.Services/Caching/MemoryDistributedCacheManager.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
 using Nop.Core.Caching;
 using Nop.Core.Configuration;
@@ -10,102 +7,27 @@ namespace Nop.Services.Caching
 {
     public class MemoryDistributedCacheManager : DistributedCacheManager
     {
-        #region Fields
-
-        private static readonly List<string> _keysList = new();
-
-        #endregion
-
         #region Ctor
 
-        public MemoryDistributedCacheManager(AppSettings appSettings, IDistributedCache distributedCache) : base(
-            appSettings, distributedCache)
+        public MemoryDistributedCacheManager(AppSettings appSettings, IDistributedCache distributedCache)
+        : base(appSettings, distributedCache)
         {
-            _onKeyAdded += key =>
-            {
-                using var _ = _locker.Lock();
-
-                if (!_keysList.Contains(key.Key))
-                    _keysList.Add(key.Key);
-            };
-
-            _onKeyRemoved += key =>
-            {
-                using var _ = _locker.Lock();
-
-                if (_keysList.Contains(key.Key))
-                    _keysList.Remove(key.Key);
-            };
         }
 
         #endregion
 
-        #region Methods
-
-        /// <summary>
-        /// Remove items by cache key prefix
-        /// </summary>
-        /// <param name="prefix">Cache key prefix</param>
-        /// <param name="prefixParameters">Parameters to create cache key prefix</param>
-        /// <returns>A task that represents the asynchronous operation</returns>
-        public override async Task RemoveByPrefixAsync(string prefix, params object[] prefixParameters)
-        {
-            using (var _ = _locker.Lock())
-            {
-                prefix = PrepareKeyPrefix(prefix, prefixParameters);
-
-                foreach (var key in _keysList
-                             .Where(key => key.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase))
-                             .ToList())
-                {
-                    await _distributedCache.RemoveAsync(key);
-                    _keysList.Remove(key);
-                }
-            }
-
-            await RemoveByPrefixInstanceDataAsync(prefix);
-        }
-
-        /// <summary>
-        /// Remove items by cache key prefix
-        /// </summary>
-        /// <param name="prefix">Cache key prefix</param>
-        /// <param name="prefixParameters">Parameters to create cache key prefix</param>
-        public override void RemoveByPrefix(string prefix, params object[] prefixParameters)
-        {
-            using (var _ = _locker.Lock())
-            {
-                prefix = PrepareKeyPrefix(prefix, prefixParameters);
-
-                foreach (var key in _keysList
-                             .Where(key => key.StartsWith(prefix, StringComparison.InvariantCultureIgnoreCase))
-                             .ToList())
-                {
-                    _distributedCache.Remove(key);
-                    _keysList.Remove(key);
-                }
-            }
-
-            RemoveByPrefixInstanceData(prefix);
-        }
-
-        /// <summary>
-        /// Clear all cache data
-        /// </summary>
-        /// <returns>A task that represents the asynchronous operation</returns>
         public override async Task ClearAsync()
         {
-            using (var _ = _locker.Lock())
-            {
-                foreach (var key in _keysList)
-                    await _distributedCache.RemoveAsync(key);
-
-                _keysList.Clear();
-            }
-
+            foreach (var key in _localKeys.Keys)
+                await RemoveAsync(key, false);
             ClearInstanceData();
         }
 
-        #endregion
+        public override async Task RemoveByPrefixAsync(string prefix, params object[] prefixParameters)
+        {
+            var prefix_ = PrepareKeyPrefix(prefix, prefixParameters);
+            foreach (var key in RemoveByPrefixInstanceData(prefix_))
+                await RemoveAsync(key, false);
+        }
     }
 }

--- a/src/Libraries/Nop.Services/Caching/MemoryDistributedCacheManager.cs
+++ b/src/Libraries/Nop.Services/Caching/MemoryDistributedCacheManager.cs
@@ -9,8 +9,10 @@ namespace Nop.Services.Caching
     {
         #region Ctor
 
-        public MemoryDistributedCacheManager(AppSettings appSettings, IDistributedCache distributedCache)
-        : base(appSettings, distributedCache)
+        public MemoryDistributedCacheManager(AppSettings appSettings,
+            IDistributedCache distributedCache,
+            CacheKeyManager cacheKeyManager)
+            : base(appSettings, distributedCache, cacheKeyManager)
         {
         }
 
@@ -18,7 +20,7 @@ namespace Nop.Services.Caching
 
         public override async Task ClearAsync()
         {
-            foreach (var key in _localKeys.Keys)
+            foreach (var key in _localKeyManager.Keys)
                 await RemoveAsync(key, false);
             ClearInstanceData();
         }

--- a/src/Libraries/Nop.Services/Caching/MsSqlServerCacheManager.cs
+++ b/src/Libraries/Nop.Services/Caching/MsSqlServerCacheManager.cs
@@ -21,8 +21,8 @@ namespace Nop.Services.Caching
 
         #region Ctor
 
-        public MsSqlServerCacheManager(AppSettings appSettings, IDistributedCache distributedCache) : base(appSettings,
-            distributedCache)
+        public MsSqlServerCacheManager(AppSettings appSettings, IDistributedCache distributedCache)
+        : base(appSettings, distributedCache)
         {
             _distributedCacheConfig = appSettings.Get<DistributedCacheConfig>();
         }
@@ -36,7 +36,7 @@ namespace Nop.Services.Caching
             var conn = new SqlConnection(_distributedCacheConfig.ConnectionString);
             try
             {
-                conn.Open();
+                await conn.OpenAsync();
                 command.Connection = conn;
                 if (parameters.Any())
                     command.Parameters.AddRange(parameters);
@@ -45,25 +45,7 @@ namespace Nop.Services.Caching
             }
             finally
             {
-                conn.Close();
-            }
-        }
-
-        protected void PerformAction(SqlCommand command, params SqlParameter[] parameters)
-        {
-            var conn = new SqlConnection(_distributedCacheConfig.ConnectionString);
-            try
-            {
-                conn.Open();
-                command.Connection = conn;
-                if (parameters.Any())
-                    command.Parameters.AddRange(parameters);
-
-                command.ExecuteNonQuery();
-            }
-            finally
-            {
-                conn.Close();
+                await conn.CloseAsync();
             }
         }
 
@@ -86,24 +68,6 @@ namespace Nop.Services.Caching
                     $"DELETE FROM {_distributedCacheConfig.SchemaName}.{_distributedCacheConfig.TableName} WHERE Id LIKE @Prefix + '%'");
 
             await PerformActionAsync(command, new SqlParameter("Prefix", SqlDbType.NVarChar) { Value = prefix });
-
-            await RemoveByPrefixInstanceDataAsync(prefix);
-        }
-
-        /// <summary>
-        /// Remove items by cache key prefix
-        /// </summary>
-        /// <param name="prefix">Cache key prefix</param>
-        /// <param name="prefixParameters">Parameters to create cache key prefix</param>
-        public override void RemoveByPrefix(string prefix, params object[] prefixParameters)
-        {
-            prefix = PrepareKeyPrefix(prefix, prefixParameters);
-
-            var command =
-                new SqlCommand(
-                    $"DELETE FROM {_distributedCacheConfig.SchemaName}.{_distributedCacheConfig.TableName} WHERE Id LIKE @Prefix + '%'");
-
-            PerformAction(command, new SqlParameter("Prefix", SqlDbType.NVarChar) { Value = prefix });
 
             RemoveByPrefixInstanceData(prefix);
         }

--- a/src/Libraries/Nop.Services/Caching/MsSqlServerCacheManager.cs
+++ b/src/Libraries/Nop.Services/Caching/MsSqlServerCacheManager.cs
@@ -21,8 +21,10 @@ namespace Nop.Services.Caching
 
         #region Ctor
 
-        public MsSqlServerCacheManager(AppSettings appSettings, IDistributedCache distributedCache)
-        : base(appSettings, distributedCache)
+        public MsSqlServerCacheManager(AppSettings appSettings,
+            IDistributedCache distributedCache,
+            CacheKeyManager cacheKeyManager)
+            : base(appSettings, distributedCache, cacheKeyManager)
         {
             _distributedCacheConfig = appSettings.Get<DistributedCacheConfig>();
         }

--- a/src/Libraries/Nop.Services/Caching/RedisCacheManager.cs
+++ b/src/Libraries/Nop.Services/Caching/RedisCacheManager.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
@@ -17,19 +16,16 @@ namespace Nop.Services.Caching
     {
         #region Fields
 
-        private static RedisConnectionWrapper _connectionWrapper;
-        private readonly IDatabase _db;
+        private RedisConnectionWrapper _connectionWrapper;
 
         #endregion
 
         #region Ctor
 
-        public RedisCacheManager(AppSettings appSettings, IDistributedCache distributedCache) : base(appSettings,
-            distributedCache)
+        public RedisCacheManager(AppSettings appSettings, IDistributedCache distributedCache, RedisConnectionWrapper connectionWrapper)
+        : base(appSettings, distributedCache)
         {
-            _connectionWrapper ??=
-                new RedisConnectionWrapper(appSettings.Get<DistributedCacheConfig>().ConnectionString);
-            _db = _connectionWrapper.GetDatabase();
+            _connectionWrapper = connectionWrapper;
         }
 
         #endregion
@@ -42,13 +38,11 @@ namespace Nop.Services.Caching
         /// <param name="endPoint">Network address</param>
         /// <param name="prefix">String key pattern</param>
         /// <returns>List of cache keys</returns>
-        protected virtual IEnumerable<RedisKey> GetKeys(EndPoint endPoint, string prefix = null)
+        protected virtual async Task<IEnumerable<RedisKey>> GetKeysAsync(EndPoint endPoint, string prefix = null)
         {
-            var server = _connectionWrapper.GetServer(endPoint);
-
-            var keys = server.Keys(_db.Database, string.IsNullOrEmpty(prefix) ? null : $"{prefix}*");
-
-            return keys;
+            return await (await _connectionWrapper.GetServerAsync(endPoint))
+                .KeysAsync((await _connectionWrapper.GetDatabaseAsync()).Database, string.IsNullOrEmpty(prefix) ? null : $"{prefix}*")
+                .ToListAsync();
         }
 
         #endregion
@@ -64,31 +58,12 @@ namespace Nop.Services.Caching
         public override async Task RemoveByPrefixAsync(string prefix, params object[] prefixParameters)
         {
             prefix = PrepareKeyPrefix(prefix, prefixParameters);
+            var db = await _connectionWrapper.GetDatabaseAsync();
 
-            foreach (var endPoint in _connectionWrapper.GetEndPoints())
+            foreach (var endPoint in await _connectionWrapper.GetEndPointsAsync())
             {
-                var keys = GetKeys(endPoint, prefix);
-
-                _db.KeyDelete(keys.ToArray());
-            }
-
-            await RemoveByPrefixInstanceDataAsync(prefix);
-        }
-
-        /// <summary>
-        /// Remove items by cache key prefix
-        /// </summary>
-        /// <param name="prefix">Cache key prefix</param>
-        /// <param name="prefixParameters">Parameters to create cache key prefix</param>
-        public override void RemoveByPrefix(string prefix, params object[] prefixParameters)
-        {
-            prefix = PrepareKeyPrefix(prefix, prefixParameters);
-
-            foreach (var endPoint in _connectionWrapper.GetEndPoints())
-            {
-                var keys = GetKeys(endPoint, prefix);
-
-                _db.KeyDelete(keys.ToArray());
+                var keys = await GetKeysAsync(endPoint, prefix);
+                db.KeyDelete(keys.ToArray());
             }
 
             RemoveByPrefixInstanceData(prefix);
@@ -103,114 +78,6 @@ namespace Nop.Services.Caching
             await _connectionWrapper.FlushDatabaseAsync();
 
             ClearInstanceData();
-        }
-
-        #endregion
-
-        #region Nested classes
-
-        /// <summary>
-        /// Represents Redis connection wrapper implementation
-        /// </summary>
-        protected class RedisConnectionWrapper
-        {
-            #region Fields
-
-            private readonly object _lock = new();
-            private volatile ConnectionMultiplexer _connection;
-            private readonly Lazy<string> _connectionString;
-
-            #endregion
-
-            #region Ctor
-
-            public RedisConnectionWrapper(string connectionString)
-            {
-                _connectionString = new Lazy<string>(connectionString);
-            }
-
-            #endregion
-
-            #region Utilities
-
-            /// <summary>
-            /// Get connection to Redis servers
-            /// </summary>
-            /// <returns></returns>
-            protected ConnectionMultiplexer GetConnection()
-            {
-                if (_connection != null && _connection.IsConnected)
-                    return _connection;
-
-                lock (_lock)
-                {
-                    if (_connection != null && _connection.IsConnected)
-                        return _connection;
-
-                    //Connection disconnected. Disposing connection...
-                    _connection?.Dispose();
-
-                    //Creating new instance of Redis Connection
-                    _connection = ConnectionMultiplexer.Connect(_connectionString.Value);
-                }
-
-                return _connection;
-            }
-
-            #endregion
-
-            #region Methods
-
-            /// <summary>
-            /// Obtain an interactive connection to a database inside Redis
-            /// </summary>
-            /// <returns>Redis cache database</returns>
-            public IDatabase GetDatabase()
-            {
-                return GetConnection().GetDatabase();
-            }
-
-            /// <summary>
-            /// Obtain a configuration API for an individual server
-            /// </summary>
-            /// <param name="endPoint">The network endpoint</param>
-            /// <returns>Redis server</returns>
-            public IServer GetServer(EndPoint endPoint)
-            {
-                return GetConnection().GetServer(endPoint);
-            }
-
-            /// <summary>
-            /// Gets all endpoints defined on the server
-            /// </summary>
-            /// <returns>Array of endpoints</returns>
-            public EndPoint[] GetEndPoints()
-            {
-                return GetConnection().GetEndPoints();
-            }
-
-            /// <summary>
-            /// Delete all the keys of the database
-            /// </summary>
-            public async Task FlushDatabaseAsync()
-            {
-                var endPoints = GetEndPoints();
-
-                foreach (var endPoint in endPoints)
-                    await GetServer(endPoint).FlushDatabaseAsync();
-            }
-
-
-            /// <summary>
-            /// Release all resources associated with this object
-            /// </summary>
-            public void Dispose()
-            {
-                //dispose ConnectionMultiplexer
-                _connection?.Dispose();
-            }
-
-            #endregion
         }
 
         #endregion

--- a/src/Libraries/Nop.Services/Caching/RedisCacheManager.cs
+++ b/src/Libraries/Nop.Services/Caching/RedisCacheManager.cs
@@ -22,8 +22,11 @@ namespace Nop.Services.Caching
 
         #region Ctor
 
-        public RedisCacheManager(AppSettings appSettings, IDistributedCache distributedCache, RedisConnectionWrapper connectionWrapper)
-        : base(appSettings, distributedCache)
+        public RedisCacheManager(AppSettings appSettings,
+            IDistributedCache distributedCache,
+            RedisConnectionWrapper connectionWrapper,
+            CacheKeyManager cacheKeyManager)
+            : base(appSettings, distributedCache, cacheKeyManager)
         {
             _connectionWrapper = connectionWrapper;
         }

--- a/src/Libraries/Nop.Services/Caching/RedisConnectionWrapper.cs
+++ b/src/Libraries/Nop.Services/Caching/RedisConnectionWrapper.cs
@@ -1,0 +1,153 @@
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+
+namespace Nop.Services.Caching
+{
+    /// <summary>
+    /// Represents Redis connection wrapper implementation
+    /// </summary>
+    public class RedisConnectionWrapper
+    {
+        #region Fields
+
+        private readonly SemaphoreSlim _connectionLock = new(1, 1);
+        private volatile IConnectionMultiplexer _connection;
+        private readonly RedisCacheOptions _options;
+
+        #endregion
+
+        #region Properties
+
+        public string Instance => _options.InstanceName ?? string.Empty;
+
+        #endregion
+
+        #region Ctor
+
+        public RedisConnectionWrapper(IOptions<RedisCacheOptions> optionsAccessor)
+        {
+            _options = optionsAccessor.Value;
+        }
+
+        #endregion
+
+        #region Utilities
+
+        private async Task<IConnectionMultiplexer> ConnectAsync()
+        {
+            IConnectionMultiplexer connection;
+            if (_options.ConnectionMultiplexerFactory is null)
+            {
+                if (_options.ConfigurationOptions is not null)
+                    connection = await ConnectionMultiplexer.ConnectAsync(_options.ConfigurationOptions);
+                else
+                    connection = await ConnectionMultiplexer.ConnectAsync(_options.Configuration);
+            }
+            else
+            {
+                connection = await _options.ConnectionMultiplexerFactory();
+            }
+
+            if (_options.ProfilingSession != null)
+                connection.RegisterProfiler(_options.ProfilingSession);
+            return connection;
+        }
+
+        /// <summary>
+        /// Get connection to Redis servers, and reconnects if necessary
+        /// </summary>
+        /// <returns></returns>
+        protected async Task<IConnectionMultiplexer> GetConnectionAsync()
+        {
+            if (_connection?.IsConnected == true)
+                return _connection;
+
+            await _connectionLock.WaitAsync();
+            try
+            {
+                if (_connection?.IsConnected == true)
+                    return _connection;
+
+                //Connection disconnected. Disposing connection...
+                _connection?.Dispose();
+
+                //Creating new instance of Redis Connection
+                _connection = await ConnectAsync();
+            }
+            finally
+            {
+                _connectionLock.Release();
+            }
+
+            return _connection;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Obtain an interactive connection to a database inside Redis
+        /// </summary>
+        /// <returns>Redis cache database</returns>
+        public async Task<IDatabase> GetDatabaseAsync()
+        {
+            return (await GetConnectionAsync()).GetDatabase();
+        }
+
+        /// <summary>
+        /// Obtain a configuration API for an individual server
+        /// </summary>
+        /// <param name="endPoint">The network endpoint</param>
+        /// <returns>Redis server</returns>
+        public async Task<IServer> GetServerAsync(EndPoint endPoint)
+        {
+            return (await GetConnectionAsync()).GetServer(endPoint);
+        }
+
+        /// <summary>
+        /// Gets all endpoints defined on the server
+        /// </summary>
+        /// <returns>Array of endpoints</returns>
+        public async Task<EndPoint[]> GetEndPointsAsync()
+        {
+            return (await GetConnectionAsync()).GetEndPoints();
+        }
+
+        /// <summary>
+        /// Gets a subscriber for the server
+        /// </summary>
+        /// <returns>Array of endpoints</returns>
+        public async Task<ISubscriber> GetSubscriberAsync()
+        {
+            return (await GetConnectionAsync()).GetSubscriber();
+        }
+
+        /// <summary>
+        /// Delete all the keys of the database
+        /// </summary>
+        public async Task FlushDatabaseAsync()
+        {
+            var endPoints = await GetEndPointsAsync();
+            await Task.WhenAll(endPoints.Select(async endPoint =>
+                await (await GetServerAsync(endPoint)).FlushDatabaseAsync()));
+        }
+
+
+        /// <summary>
+        /// Release all resources associated with this object
+        /// </summary>
+        public void Dispose()
+        {
+            //dispose ConnectionMultiplexer
+            _connection?.Dispose();
+        }
+
+        #endregion
+    }
+}

--- a/src/Libraries/Nop.Services/Caching/RedisSynchronizedMemoryCache.cs
+++ b/src/Libraries/Nop.Services/Caching/RedisSynchronizedMemoryCache.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Linq;
+using System.Net.NetworkInformation;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using StackExchange.Redis;
+
+namespace Nop.Services.Caching
+{
+    public class RedisSynchronizedMemoryCache : IMemoryCache
+    {
+        private static readonly string _processId;
+
+        private RedisConnectionWrapper _connection;
+
+        private bool _disposed;
+        private readonly IMemoryCache _memoryCache;
+        private readonly string _ignorePrefix;
+
+
+        static RedisSynchronizedMemoryCache()
+        {
+            var machineId = NetworkInterface.GetAllNetworkInterfaces()
+                .Where(nic => nic.OperationalStatus == OperationalStatus.Up)
+                .Select(nic => nic.GetPhysicalAddress().ToString()).FirstOrDefault();
+
+            if (string.IsNullOrEmpty(machineId))
+                machineId = Environment.MachineName;
+
+            _processId = machineId + Environment.ProcessId.ToString();
+        }
+
+
+        public RedisSynchronizedMemoryCache(IMemoryCache memoryCache, RedisConnectionWrapper connectionWrapper, string ignorePrefix = null)
+        {
+            _memoryCache = memoryCache;
+            _ignorePrefix = ignorePrefix;
+            _connection = connectionWrapper;
+            SubscribeAsync().Wait();
+        }
+
+        private async Task<string> GetChannelAsync()
+        {
+            var db = await _connection.GetDatabaseAsync();
+            return $"__change@{db.Database}__{_connection.Instance}__:";
+        }
+
+        private async Task SubscribeAsync()
+        {
+            var channel = await GetChannelAsync();
+            (await _connection.GetSubscriberAsync()).Subscribe(channel + "*", (redisChannel, value) =>
+            {
+                if (value != _processId)
+                    _memoryCache.Remove(((string)redisChannel).Replace(channel, ""));
+            });
+        }
+
+        private async Task PublishChangeEventAsync(object key)
+        {
+            var channel = await GetChannelAsync();
+            var stringKey = key.ToString();
+            if (string.IsNullOrEmpty(_ignorePrefix) || !stringKey.StartsWith(_ignorePrefix))
+                await (await _connection.GetSubscriberAsync()).PublishAsync($"{channel}{stringKey}", _processId, CommandFlags.FireAndForget);
+        }
+
+        private void OnEviction(object key, object value, EvictionReason reason, object state)
+        {
+            switch (reason)
+            {
+                case EvictionReason.Replaced:
+                case EvictionReason.TokenExpired: // e.g. clear cache event
+                    _ = PublishChangeEventAsync(key);
+                    break;
+                // don't publish here on removed, as it could be triggered by a redis event itself
+                default:
+                    break;
+            }
+        }
+
+        public ICacheEntry CreateEntry(object key)
+        {
+            return _memoryCache.CreateEntry(key).RegisterPostEvictionCallback(OnEviction);
+        }
+
+        public void Remove(object key)
+        {
+            _memoryCache.Remove(key);
+            // publish event manually instead of through eviction callback to avoid feedback loops
+            _ = PublishChangeEventAsync(key);
+        }
+
+        public bool TryGetValue(object key, out object value)
+        {
+            return _memoryCache.TryGetValue(key, out value);
+        }
+
+        protected virtual async Task DisposeAsync(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    var channel = await GetChannelAsync();
+                    (await _connection.GetSubscriberAsync()).Unsubscribe(channel + "*");
+                }
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            DisposeAsync(disposing: true).Wait();
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Libraries/Nop.Services/Configuration/SettingService.cs
+++ b/src/Libraries/Nop.Services/Configuration/SettingService.cs
@@ -134,8 +134,8 @@ namespace Nop.Services.Configuration
             var valueStr = TypeDescriptor.GetConverter(type).ConvertToInvariantString(value);
 
             var allSettings = await GetAllSettingsDictionaryAsync();
-            var settingForCaching = allSettings.ContainsKey(key) ?
-                allSettings[key].FirstOrDefault(x => x.StoreId == storeId) : null;
+            var settingForCaching = allSettings.TryGetValue(key, out var settings) ?
+                settings.FirstOrDefault(x => x.StoreId == storeId) : null;
             if (settingForCaching != null)
             {
                 //update
@@ -172,8 +172,8 @@ namespace Nop.Services.Configuration
             var valueStr = TypeDescriptor.GetConverter(type).ConvertToInvariantString(value);
 
             var allSettings = GetAllSettingsDictionary();
-            var settingForCaching = allSettings.ContainsKey(key) ?
-                allSettings[key].FirstOrDefault(x => x.StoreId == storeId) : null;
+            var settingForCaching = allSettings.TryGetValue(key, out var settings) ?
+                settings.FirstOrDefault(x => x.StoreId == storeId) : null;
             if (settingForCaching != null)
             {
                 //update
@@ -831,8 +831,8 @@ namespace Nop.Services.Configuration
             key = key.Trim().ToLowerInvariant();
 
             var allSettings = await GetAllSettingsDictionaryAsync();
-            var settingForCaching = allSettings.ContainsKey(key) ?
-                allSettings[key].FirstOrDefault(x => x.StoreId == storeId) : null;
+            var settingForCaching = allSettings.TryGetValue(key, out var settings_) ?
+                settings_.FirstOrDefault(x => x.StoreId == storeId) : null;
             if (settingForCaching == null) 
                 return;
 

--- a/src/Libraries/Nop.Services/Localization/LocalizationService.cs
+++ b/src/Libraries/Nop.Services/Localization/LocalizationService.cs
@@ -318,7 +318,7 @@ namespace Nop.Services.Localization
 
             //get all locale string resources by language identifier
             var allLocales =
-                await _staticCacheManager.GetAsync(key, () => (Dictionary<string, KeyValuePair<int, string>>)null);
+                await _staticCacheManager.GetAsync<Dictionary<string, KeyValuePair<int, string>>>(key);
 
             if (!loadPublicLocales.HasValue || allLocales != null)
             {

--- a/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -185,6 +185,15 @@ namespace Nop.Web.Framework.Infrastructure.Extensions
                     services.AddStackExchangeRedisCache(options =>
                     {
                         options.Configuration = distributedCacheConfig.ConnectionString;
+                        options.InstanceName = distributedCacheConfig.InstanceName ?? string.Empty;
+                    });
+                    break;
+
+                case DistributedCacheType.RedisSynchronizedMemory:
+                    services.AddStackExchangeRedisCache(options =>
+                    {
+                        options.Configuration = distributedCacheConfig.ConnectionString;
+                        options.InstanceName = distributedCacheConfig.InstanceName ?? string.Empty;
                     });
                     break;
             }

--- a/src/Presentation/Nop.Web.Framework/Infrastructure/NopStartup.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/NopStartup.cs
@@ -92,6 +92,8 @@ namespace Nop.Web.Framework.Infrastructure
             //static cache manager
             var appSettings = Singleton<AppSettings>.Instance;
             var distributedCacheConfig = appSettings.Get<DistributedCacheConfig>();
+            var cacheKeyManager = new CacheKeyManager();
+            services.AddSingleton<CacheKeyManager>(cacheKeyManager);
             if (distributedCacheConfig.Enabled)
             {
                 switch (distributedCacheConfig.DistributedCacheType)
@@ -113,7 +115,9 @@ namespace Nop.Web.Framework.Infrastructure
                                 appSettings,
                                 new RedisSynchronizedMemoryCache(
                                     services.GetRequiredService<IMemoryCache>(),
-                                    services.GetRequiredService<RedisConnectionWrapper>())));
+                                    services.GetRequiredService<RedisConnectionWrapper>(),
+                                    cacheKeyManager),
+                                cacheKeyManager));
                         break;
                 }
                 services.AddSingleton<ILocker, DistributedCacheLocker>();

--- a/src/Presentation/Nop.Web.Framework/Migrations/UpgradeTo440/LocalizationMigration.cs
+++ b/src/Presentation/Nop.Web.Framework/Migrations/UpgradeTo440/LocalizationMigration.cs
@@ -314,6 +314,8 @@ namespace Nop.Web.Framework.Migrations.UpgradeTo440
                 ["Admin.Configuration.AppSettings.DistributedCache.SchemaName.Hint"] = "Specify the schema name (by default it is dbo)",
                 ["Admin.Configuration.AppSettings.DistributedCache.TableName"] = "Table name",
                 ["Admin.Configuration.AppSettings.DistributedCache.TableName.Hint"] = "Specify the table name",
+                ["Admin.Configuration.AppSettings.DistributedCache.InstanceName"] = "Instance name",
+                ["Admin.Configuration.AppSettings.DistributedCache.InstanceName.Hint"] = "Specify the instance name (by default \"nopCommerce\")",
                 ["Admin.Configuration.Settings.GeneralCommon.LoadAllLocaleRecordsOnStartup.Warning"] = "It seems that you use distributed cache, keep in mind that enabling this setting creates a lot of traffic between the distributed cache server and the application because of the large number of locales",
 
                 //configuration steps tour

--- a/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
+++ b/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
@@ -4575,6 +4575,12 @@
   <LocaleResource Name="Admin.Configuration.AppSettings.DistributedCache.TableName.Hint">
     <Value>Specify the table name"</Value>
   </LocaleResource>
+  <LocaleResource Name="Admin.Configuration.AppSettings.DistributedCache.InstanceName">
+    <Value>Instance name</Value>
+  </LocaleResource>
+  <LocaleResource Name="Admin.Configuration.AppSettings.DistributedCache.InstanceName.Hint">
+    <Value>Specify the instance name (by default "nopCommerce")</Value>
+  </LocaleResource>
   <LocaleResource Name="Admin.Configuration.AppSettings.EnvironmentVariablesWarning">
     <Value>Warning! The current setting value is overridden in environment variables</Value>
   </LocaleResource>

--- a/src/Presentation/Nop.Web/Areas/Admin/Models/Settings/DistributedCacheConfigModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Models/Settings/DistributedCacheConfigModel.cs
@@ -27,6 +27,9 @@ namespace Nop.Web.Areas.Admin.Models.Settings
         [NopResourceDisplayName("Admin.Configuration.AppSettings.DistributedCache.TableName")]
         public string TableName { get; set; } = "DistributedCache";
 
+        [NopResourceDisplayName("Admin.Configuration.AppSettings.DistributedCache.InstanceName")]
+        public string InstanceName { get; private set; } = string.Empty;
+
         #endregion
     }
 }

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_AppSettings.DistributedCache.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_AppSettings.DistributedCache.cshtml
@@ -47,6 +47,15 @@
                 <span asp-validation-for="DistributedCacheConfigModel.TableName"></span>
             </div>
         </div>
+        <div class="form-group row" id="distributed-cache-instance-name">
+            <div class="col-md-3">
+                <nop-label asp-for="DistributedCacheConfigModel.InstanceName" />
+            </div>
+            <div class="col-md-9">
+                <nop-editor asp-for="DistributedCacheConfigModel.InstanceName" />
+                <span asp-validation-for="DistributedCacheConfigModel.InstanceName"></span>
+            </div>
+        </div>
     </nop-nested-setting>
 </div>
 <script>
@@ -61,25 +70,32 @@
             $('#distributed-cache-connection-string').showElement();
             $('#distributed-cache-type').showElement();
 
-            var cacheType = $('#@Html.IdFor(model => model.DistributedCacheConfigModel.DistributedCacheType)').val();
+            var cacheType = Number.parseInt($('#@Html.IdFor(model => model.DistributedCacheConfigModel.DistributedCacheType)').val());
 
-            if (cacheType == @((int)DistributedCacheType.Memory))
+            switch (cacheType)
             {
-                $('#distributed-cache-connection-string').hideElement();
-            }
-
-            if (cacheType == @((int)DistributedCacheType.SqlServer)) {
-                $('#distributed-cache-schema-name').showElement();
-                $('#distributed-cache-table-name').showElement();
-            } else {
-                $('#distributed-cache-schema-name').hideElement();
-                $('#distributed-cache-table-name').hideElement();
+                case @((int)DistributedCacheType.Memory):
+                    $('#distributed-cache-connection-string').hideElement();
+                    $('#distributed-cache-schema-name').hideElement();
+                    $('#distributed-cache-table-name').hideElement();
+                    $('#distributed-cache-instance-name').hideElement();
+                    break;
+                case @((int)DistributedCacheType.SqlServer):
+                    $('#distributed-cache-schema-name').showElement();
+                    $('#distributed-cache-table-name').showElement();
+                    $('#distributed-cache-instance-name').hideElement();
+                    break;
+                default:
+                    $('#distributed-cache-schema-name').hideElement();
+                    $('#distributed-cache-table-name').hideElement();
+                    $('#distributed-cache-instance-name').showElement();
             }
         } else {
             $('#distributed-cache-connection-string').hideElement();
             $('#distributed-cache-schema-name').hideElement();
             $('#distributed-cache-table-name').hideElement();
             $('#distributed-cache-type').hideElement();
+            $('#distributed-cache-instance-name').hideElement();
         }
     }
 </script>

--- a/src/Tests/Nop.Tests/BaseNopTest.cs
+++ b/src/Tests/Nop.Tests/BaseNopTest.cs
@@ -107,14 +107,14 @@ namespace Nop.Tests
 
         private static void Init()
         {
-            
+
             var dataProvider = _serviceProvider.GetService<IDataProviderManager>().DataProvider;
-            
+
             dataProvider.CreateDatabase(null);
             dataProvider.InitializeDatabase();
 
             var languagePackInfo = (DownloadUrl: string.Empty, Progress: 0);
-            
+
             _serviceProvider.GetService<IInstallationService>()
                 .InstallRequiredDataAsync(NopTestsDefaults.AdminEmail, NopTestsDefaults.AdminPassword, languagePackInfo, null, null).Wait();
             _serviceProvider.GetService<IInstallationService>().InstallSampleDataAsync(NopTestsDefaults.AdminEmail).Wait();
@@ -122,7 +122,7 @@ namespace Nop.Tests
             var provider = (IPermissionProvider)Activator.CreateInstance(typeof(StandardPermissionProvider));
             EngineContext.Current.Resolve<IPermissionService>().InstallPermissionsAsync(provider).Wait();
         }
-        
+
         protected static T PropertiesShouldEqual<T, Tm>(T entity, Tm model, params string[] filter) where T : BaseEntity
         where Tm : BaseNopModel
         {
@@ -178,7 +178,7 @@ namespace Nop.Tests
                 .FindClassesOfType<IConfig>()
                 .Select(configType => (IConfig)Activator.CreateInstance(configType))
                 .ToList();
-            
+
             var appSettings = new AppSettings(configurations);
             appSettings.Update(new List<IConfig> { Singleton<DataConfig>.Instance });
             Singleton<AppSettings>.Instance = appSettings;
@@ -261,10 +261,13 @@ namespace Nop.Tests
 
             services.AddSingleton<IMemoryCache>(memoryCache);
             services.AddSingleton<IStaticCacheManager, MemoryCacheManager>();
-            services.AddSingleton<ILocker, MemoryCacheManager>();
+            services.AddSingleton<ILocker, MemoryCacheLocker>();
+            services.AddSingleton<MemoryCacheLocker>();
 
-            services.AddSingleton<IDistributedCache>(new MemoryDistributedCache(new TestMemoryDistributedCacheoptions()));
+            var memoryDistributedCache = new MemoryDistributedCache(new TestMemoryDistributedCacheoptions());
+            services.AddSingleton<IDistributedCache>(memoryDistributedCache);
             services.AddTransient<MemoryDistributedCacheManager>();
+            services.AddSingleton(new DistributedCacheLocker(memoryDistributedCache));
             
             //services
             services.AddTransient<IBackInStockSubscriptionService, BackInStockSubscriptionService>();
@@ -565,7 +568,7 @@ namespace Nop.Tests
 
             await insert(baseEntity);
             baseEntity.Id.Should().BeGreaterThan(0);
-            
+
             updateEntity.Id = baseEntity.Id;
             await update(updateEntity);
 

--- a/src/Tests/Nop.Tests/BaseNopTest.cs
+++ b/src/Tests/Nop.Tests/BaseNopTest.cs
@@ -259,6 +259,7 @@ namespace Nop.Tests
             //plugins
             services.AddTransient<IPluginService, PluginService>();
 
+            services.AddSingleton<CacheKeyManager>();
             services.AddSingleton<IMemoryCache>(memoryCache);
             services.AddSingleton<IStaticCacheManager, MemoryCacheManager>();
             services.AddSingleton<ILocker, MemoryCacheLocker>();

--- a/src/Tests/Nop.Tests/Nop.Core.Tests/Caching/DistributedCacheManagerTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Core.Tests/Caching/DistributedCacheManagerTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Text;
+﻿using System;
+using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.Extensions.Caching.Distributed;
@@ -37,6 +39,14 @@ namespace Nop.Tests.Nop.Core.Tests.Caching
             (await _distributedCache.GetAsync("some_key_1")).Should().NotBeNullOrEmpty();
             await _staticCacheManager.RemoveByPrefixAsync("some_key_1");
             (await _distributedCache.GetAsync("some_key_1")).Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public async Task DoesNotIgnoreKeyCase()
+        {
+            await _staticCacheManager.SetAsync(new CacheKey("Some_Key_1"), 3);
+            var rez = await _staticCacheManager.GetAsync(new CacheKey("some_key_1"), () => 0);
+            rez.Should().Be(0);
         }
 
         [Test]
@@ -81,6 +91,23 @@ namespace Nop.Tests.Nop.Core.Tests.Caching
         }
 
         [Test]
+        public async Task CanRemoveByPrefix()
+        {
+            await _staticCacheManager.SetAsync(new CacheKey("some_key_1"), 1);
+            await _staticCacheManager.SetAsync(new CacheKey("some_key_2"), 2);
+            await _staticCacheManager.SetAsync(new CacheKey("some_other_key"), 3);
+
+            await _staticCacheManager.RemoveByPrefixAsync("some_key");
+
+            var result = await _staticCacheManager.GetAsync(new CacheKey("some_key_1"), () => 0);
+            result.Should().Be(0);
+            result = await _staticCacheManager.GetAsync(new CacheKey("some_key_2"), () => 0);
+            result.Should().Be(0);
+            result = await _staticCacheManager.GetAsync(new CacheKey("some_other_key"), () => 0);
+            result.Should().Be(3);
+        }
+
+        [Test]
         public async Task CanGet()
         {
             await _distributedCache.SetAsync("some_key_1", Encoding.UTF8.GetBytes("1"));
@@ -118,6 +145,39 @@ namespace Nop.Tests.Nop.Core.Tests.Caching
             _distributedCache.Get("some_key_1").Should().BeNullOrEmpty();
             _distributedCache.Get("some_key_2").Should().BeNullOrEmpty();
             _distributedCache.Get("some_key_3").Should().BeNullOrEmpty();
+        }
+
+        [Test]
+        public void ThrowsException()
+        {
+            Assert.ThrowsAsync<ApplicationException>(() => _staticCacheManager.GetAsync(
+                new CacheKey("some_key_1"),
+                Task<object> () => throw new ApplicationException()));
+        }
+
+        [Test]
+        public async Task ExecutesSetInOrder()
+        {
+            await Task.WhenAll(Enumerable.Range(1, 5).Select(i => _staticCacheManager.SetAsync(new CacheKey("some_key_1"), i)));
+            var value = await _staticCacheManager.GetAsync(new CacheKey("some_key_1"), () => Task.FromResult(0));
+            value.Should().Be(5);
+        }
+
+        [Test]
+        public async Task GetsLazily()
+        {
+            var xs = new int[5];
+            await Task.WhenAll(xs.Select((_, i) => _staticCacheManager.GetAsync(
+                new CacheKey("some_key_1"),
+                async () =>
+                {
+                    xs[i] = 1;
+                    await Task.Delay(10);
+                    return i;
+                })));
+            var value = await _staticCacheManager.GetAsync(new CacheKey("some_key_1"), () => Task.FromResult(-1));
+            value.Should().Be(0);
+            xs.Sum().Should().Be(1);
         }
     }
 }

--- a/src/Tests/Nop.Tests/Nop.Core.Tests/Caching/DistributedCacheManagerTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Core.Tests/Caching/DistributedCacheManagerTests.cs
@@ -79,15 +79,15 @@ namespace Nop.Tests.Nop.Core.Tests.Caching
             {
                 var manager = GetService<MemoryDistributedCacheManager>(scope);
                 manager.Equals(_staticCacheManager).Should().BeFalse();
-                _staticCacheManager.Get<int?>(new CacheKey("some_key_1"), () => null).Should().Be(1);
-                _staticCacheManager.Get<int?>(new CacheKey("some_key_2"), () => null).Should().Be(2);
-                _staticCacheManager.Get<int?>(new CacheKey("some_key_3"), () => null).Should().Be(3);
+                _staticCacheManager.Get<int?>(new CacheKey("some_key_1"), null).Should().Be(1);
+                _staticCacheManager.Get<int?>(new CacheKey("some_key_2"), null).Should().Be(2);
+                _staticCacheManager.Get<int?>(new CacheKey("some_key_3"), null).Should().Be(3);
                 await manager.ClearAsync();
             }
 
-            _staticCacheManager.Get<int?>(new CacheKey("some_key_1"), () => null).Should().BeNull();
-            _staticCacheManager.Get<int?>(new CacheKey("some_key_2"), () => null).Should().BeNull();
-            _staticCacheManager.Get<int?>(new CacheKey("some_key_3"), () => null).Should().BeNull();
+            _staticCacheManager.Get<int?>(new CacheKey("some_key_1"), null).Should().BeNull();
+            _staticCacheManager.Get<int?>(new CacheKey("some_key_2"), null).Should().BeNull();
+            _staticCacheManager.Get<int?>(new CacheKey("some_key_3"), null).Should().BeNull();
         }
 
         [Test]
@@ -114,9 +114,9 @@ namespace Nop.Tests.Nop.Core.Tests.Caching
             await _distributedCache.SetAsync("some_key_2", Encoding.UTF8.GetBytes("2"));
             await _distributedCache.SetAsync("some_key_3", Encoding.UTF8.GetBytes("3"));
 
-            _staticCacheManager.Get<int?>(new CacheKey("some_key_1"), () => null).Should().Be(1);
-            _staticCacheManager.Get<int?>(new CacheKey("some_key_2"), () => null).Should().Be(2);
-            _staticCacheManager.Get<int?>(new CacheKey("some_key_3"), () => null).Should().Be(3);
+            _staticCacheManager.Get<int?>(new CacheKey("some_key_1"), null).Should().Be(1);
+            _staticCacheManager.Get<int?>(new CacheKey("some_key_2"), null).Should().Be(2);
+            _staticCacheManager.Get<int?>(new CacheKey("some_key_3"), null).Should().Be(3);
 
             _staticCacheManager.Get<int?>(new CacheKey("some_key_4"), () => 4).Should().Be(4);
 
@@ -134,9 +134,9 @@ namespace Nop.Tests.Nop.Core.Tests.Caching
             await _distributedCache.SetAsync("some_key_2", Encoding.UTF8.GetBytes("2"));
             await _staticCacheManager.SetAsync(new CacheKey("some_key_3"), "3");
 
-            _staticCacheManager.Get<string>(new CacheKey("some_key_1"), () => null).Should().Be("1");
-            _staticCacheManager.Get<string>(new CacheKey("some_key_2"), () => null).Should().Be("2");
-            _staticCacheManager.Get<string>(new CacheKey("some_key_3"), () => null).Should().Be("3");
+            _staticCacheManager.Get<string>(new CacheKey("some_key_1"), null).Should().Be("1");
+            _staticCacheManager.Get<string>(new CacheKey("some_key_2"), null).Should().Be("2");
+            _staticCacheManager.Get<string>(new CacheKey("some_key_3"), null).Should().Be("3");
 
             await _staticCacheManager.RemoveAsync(new CacheKey("some_key_1"));
             await _staticCacheManager.RemoveAsync(new CacheKey("some_key_2"));

--- a/src/Tests/Nop.Tests/Nop.Core.Tests/Caching/LockerTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Core.Tests/Caching/LockerTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Nop.Core.Caching;
-using Nop.Services.Caching;
 using NUnit.Framework;
 
 namespace Nop.Tests.Nop.Core.Tests.Caching
@@ -10,64 +10,161 @@ namespace Nop.Tests.Nop.Core.Tests.Caching
     [TestFixture]
     public class LockerTests : BaseNopTest
     {
-        [Test]
-        [TestCase(true)]
-        [TestCase(false)]
-        public async Task CanPerformLock(bool isDistributed)
-        {
-            var staticCacheManager = isDistributed ? GetService<MemoryDistributedCacheManager>() : GetService<IStaticCacheManager>();
-            staticCacheManager.Should().NotBeNull();
-            var locker = staticCacheManager as ILocker;
-            locker.Should().NotBeNull();
+        private ILocker _memCacheLocker;
+        private ILocker _distCacheLocker;
 
-            var key = new CacheKey("Nop.Task");
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            _memCacheLocker = GetService<MemoryCacheLocker>();
+            _distCacheLocker = GetService<DistributedCacheLocker>();
+        }
+
+        [Test]
+        public async Task Distributed_CanPerformLockAsync()
+        {
+            await TestLockerAsync(_distCacheLocker);
+        }
+
+        [Test]
+        public async Task Memory_CanPerformLockAsync()
+        {
+            await TestLockerAsync(_memCacheLocker);
+        }
+
+        [Test]
+        public async Task Distributed_CanRunWithHeartbeatAsync()
+        {
+            await TestHeartbeatAsync(_distCacheLocker);
+        }
+
+        [Test]
+        public async Task Memory_CanRunWithHeartbeatAsync()
+        {
+            await TestHeartbeatAsync(_memCacheLocker);
+        }
+
+        [Test]
+        public async Task Distributed_CanCancelAsync()
+        {
+            await TestCancellationAsync(_distCacheLocker);
+        }
+
+        [Test]
+        public async Task Memory_CanCancelAsync()
+        {
+            await TestCancellationAsync(_memCacheLocker);
+        }
+
+        private static async Task TestLockerAsync(ILocker locker)
+        {
+            var key = Guid.NewGuid().ToString();
             var expiration = TimeSpan.FromMinutes(2);
 
             var actionCount = 0;
-            var action = new Func<Task>(async () =>
+            async Task action()
             {
-                var isSet = staticCacheManager.GetAsync<object>(key, () => null);
-                isSet.Should().NotBeNull();
-
-                var rez = await locker.PerformActionWithLockAsync(key.Key, expiration,
+                var res = await locker.PerformActionWithLockAsync(key, expiration,
                     () =>
                     {
                         Assert.Fail("Action in progress");
                         return Task.CompletedTask;
                     });
-                    
-                    rez.Should().BeFalse();
 
-                if (++actionCount % 2 == 0)
-                    throw new ApplicationException("Alternating actions fail");
-            });
+                res.Should().BeFalse();
+                actionCount++;
+            }
 
-            var rez = await locker.PerformActionWithLockAsync(key.Key, expiration, action);
-            rez.Should().BeTrue();
-
+            var result = await locker.PerformActionWithLockAsync(key, expiration, () => action());
+            result.Should().BeTrue();
             actionCount.Should().Be(1);
 
-            Assert.Throws<AggregateException>(() =>
-                locker.PerformActionWithLockAsync(key.Key, expiration, action).Wait());
+            Assert.ThrowsAsync<ApplicationException>(() => locker.PerformActionWithLockAsync(key, expiration, FailingAction));
 
+            result = await locker.PerformActionWithLockAsync(key, expiration, action);
+            result.Should().BeTrue();
             actionCount.Should().Be(2);
+        }
 
-            rez = await locker.PerformActionWithLockAsync(key.Key, expiration, action);
-            rez.Should().BeTrue();
-            actionCount.Should().Be(3);
+        private static async Task TestHeartbeatAsync(ILocker locker)
+        {
+            var key = Guid.NewGuid().ToString();
+            var expiration = TimeSpan.FromMinutes(2);
+            var heartbeat = TimeSpan.FromSeconds(10);
 
-            var dt = DateTime.Now;
-
-            await locker.PerformActionWithLockAsync("action_with_lock", TimeSpan.FromSeconds(1), async () =>
+            var actionCount = 0;
+            async Task action(CancellationToken _)
             {
-                while (!await locker.PerformActionWithLockAsync("action_with_lock", TimeSpan.FromSeconds(1), () => Task.CompletedTask))
+                await locker.RunWithHeartbeatAsync(
+                    key,
+                    expiration,
+                    heartbeat,
+                    _ =>
+                    {
+                        Assert.Fail("Action in progress");
+                        return Task.CompletedTask;
+                    });
+
+                actionCount++;
+            }
+
+            await locker.RunWithHeartbeatAsync(key, expiration, heartbeat, action);
+            actionCount.Should().Be(1);
+
+            Assert.ThrowsAsync<ApplicationException>(() => locker.RunWithHeartbeatAsync(key, expiration, heartbeat, _ => FailingAction()));
+
+            await locker.RunWithHeartbeatAsync(key, expiration, heartbeat, action);
+            actionCount.Should().Be(2);
+        }
+
+        private static async Task TestCancellationAsync(ILocker locker)
+        {
+            var key = Guid.NewGuid().ToString();
+            var expiration = TimeSpan.FromSeconds(1);
+            var heartbeat = TimeSpan.FromMilliseconds(100);
+            var delay = TimeSpan.FromSeconds(5);
+
+            async Task testAsync(Func<Task> cancel, CancellationTokenSource tokenSource = default)
+            {
+                var cancelled = false;
+                async Task action(CancellationToken token)
                 {
+                    await locker.RunWithHeartbeatAsync(
+                        key,
+                        expiration,
+                        heartbeat,
+                        _ =>
+                        {
+                            Assert.Fail("Action in progress");
+                            return Task.CompletedTask;
+                        });
+
+                    try
+                    {
+                        await Task.Delay(delay, token);
+                    }
+                    catch
+                    {
+                        cancelled = true;
+                    }
                 }
-            });
 
-            var span = DateTime.Now - dt;
+                var task = locker.RunWithHeartbeatAsync(key, expiration, heartbeat, action, tokenSource);
+                (await locker.IsTaskRunningAsync(key)).Should().BeTrue();
+                await cancel();
+                await task;
+                cancelled.Should().BeTrue();
+                (await locker.IsTaskRunningAsync(key)).Should().BeFalse();
+            }
 
-            span.Seconds.Should().Be(1);
+            await testAsync(() => locker.CancelTaskAsync(key, expiration));
+            var cancellationTokenSource = new CancellationTokenSource();
+            await testAsync(() => Task.Run(cancellationTokenSource.Cancel), cancellationTokenSource);
+        }
+
+        private static Task FailingAction()
+        {
+            throw new ApplicationException("This action is supposed to fail");
         }
     }
 }

--- a/src/Tests/Nop.Tests/Nop.Core.Tests/Caching/MemoryCacheManagerTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Core.Tests/Caching/MemoryCacheManagerTests.cs
@@ -59,8 +59,27 @@ namespace Nop.Tests.Nop.Core.Tests.Caching
 
             await _staticCacheManager.ClearAsync();
 
-            var rez = await _staticCacheManager.GetAsync(new CacheKey("some_key_1"), () => Task.FromResult((object)null));
+            var rez = await _staticCacheManager.GetAsync<object>(new CacheKey("some_key_1"));
             rez.Should().BeNull();
+        }
+
+        [Test]
+        public async Task GetReturnsValueIfSet()
+        {
+            var key = new CacheKey("some_key_1");
+            await _staticCacheManager.SetAsync(key, 3);
+            var res = await _staticCacheManager.GetAsync<int>(key);
+            res.Should().Be(3);
+        }
+
+        [Test]
+        public async Task GetReturnsDefaultIfNotSet()
+        {
+            var key = new CacheKey("some_key_1");
+            var res = await _staticCacheManager.GetAsync(key, 1);
+            res.Should().Be(1);
+            res = await _staticCacheManager.GetAsync<int>(key);
+            res.Should().Be(0);
         }
 
         [Test]
@@ -72,11 +91,11 @@ namespace Nop.Tests.Nop.Core.Tests.Caching
 
             await _staticCacheManager.RemoveByPrefixAsync("some_key");
 
-            var result = await _staticCacheManager.GetAsync(new CacheKey("some_key_1"), () => 0);
+            var result = await _staticCacheManager.GetAsync(new CacheKey("some_key_1"), 0);
             result.Should().Be(0);
-            result = await _staticCacheManager.GetAsync(new CacheKey("some_key_2"), () => 0);
+            result = await _staticCacheManager.GetAsync(new CacheKey("some_key_2"), 0);
             result.Should().Be(0);
-            result = await _staticCacheManager.GetAsync(new CacheKey("some_other_key"), () => 0);
+            result = await _staticCacheManager.GetAsync(new CacheKey("some_other_key"), 0);
             result.Should().Be(3);
         }
 
@@ -84,7 +103,7 @@ namespace Nop.Tests.Nop.Core.Tests.Caching
         public async Task ExecutesSetInOrder()
         {
             await Task.WhenAll(Enumerable.Range(1, 5).Select(i => _staticCacheManager.SetAsync(new CacheKey("some_key_1"), i)));
-            var value = await _staticCacheManager.GetAsync(new CacheKey("some_key_1"), () => 0);
+            var value = await _staticCacheManager.GetAsync(new CacheKey("some_key_1"), 0);
             value.Should().Be(5);
         }
 

--- a/src/Tests/Nop.Tests/Nop.Core.Tests/Infrastructure/ConcurrentTrieTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Core.Tests/Infrastructure/ConcurrentTrieTests.cs
@@ -1,0 +1,119 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Nop.Core.Infrastructure;
+using NUnit.Framework;
+
+namespace Nop.Tests.Nop.Core.Tests.Infrastructure
+{
+    [TestFixture]
+    public class ConcurrentTrieTests
+    {
+        [Test]
+        public void CanAddAndGetValue()
+        {
+            var sut = new ConcurrentTrie<int>();
+            sut.TryGetValue("a", out _).Should().BeFalse();
+            sut.Add("a", 1);
+            sut.TryGetValue("a", out var value).Should().BeTrue();
+            value.Should().Be(1);
+            sut.Add("a", 2);
+            sut.TryGetValue("a", out value).Should().BeTrue();
+            value.Should().Be(2);
+        }
+
+        [Test]
+        public void CanAddAndGetValues()
+        {
+            var sut = new ConcurrentTrie<int>();
+            sut.Add("a", 1);
+            sut.TryGetValue("ab", out _).Should().BeFalse();
+            sut.Add("abc", 3);
+            sut.TryGetValue("ab", out _).Should().BeFalse();
+            sut.TryGetValue("a", out var value).Should().BeTrue();
+            value.Should().Be(1);
+            sut.TryGetValue("abc", out value).Should().BeTrue();
+            value.Should().Be(3);
+        }
+
+        [Test]
+        public void CanRemoveValue()
+        {
+            var sut = new ConcurrentTrie<int>();
+            sut.Add("a", 1);
+            sut.Add("ab", 1);
+            sut.Add("abc", 1);
+            sut.Remove("ab");
+            sut.TryGetValue("ab", out _).Should().BeFalse();
+            sut.TryGetValue("abc", out _).Should().BeTrue();
+            sut.TryGetValue("a", out _).Should().BeTrue();
+            Assert.DoesNotThrow(() => sut.Remove("ab"));
+        }
+
+        [Test]
+        public void CanGetKeys()
+        {
+            var sut = new ConcurrentTrie<int>();
+            var keys = new[] { "a", "b", "abc" };
+            foreach (var key in keys)
+                sut.Add(key, 1);
+            sut.Keys.Should().BeEquivalentTo(keys);
+        }
+
+        [Test]
+        public void CanGetValues()
+        {
+            var sut = new ConcurrentTrie<int>();
+            var keys = new[] { "a", "b", "abc" };
+            var values = new[] { 1, 2, 3 };
+            foreach (var (key, value) in keys.Zip(values))
+                sut.Add(key, value);
+            sut.Values.Should().BeEquivalentTo(values);
+        }
+
+        [Test]
+        public void CanPrune()
+        {
+            var sut = new ConcurrentTrie<int>();
+            sut.Add("a", 1);
+            sut.Add("b", 1);
+            sut.Add("ab", 1);
+            sut.Add("abc", 1);
+            sut.Add("abd", 1);
+            sut.Prune("ab", out var subtree).Should().BeTrue();
+            subtree.Keys.Should().BeEquivalentTo(new[] { "ab", "abc", "abd" });
+            sut.Keys.Should().BeEquivalentTo(new[] { "a", "b" });
+            sut.Prune("b", out subtree).Should().BeTrue();
+            subtree.Keys.Should().BeEquivalentTo(new[] { "b" });
+            sut.Keys.Should().BeEquivalentTo(new[] { "a" });
+        }
+
+        [Test]
+        public void CanSearch()
+        {
+            var sut = new ConcurrentTrie<int>();
+            sut.Add("a", 1);
+            sut.Add("b", 1);
+            sut.Add("ab", 1);
+            sut.Add("abc", 2);
+            var keys = sut.Keys.ToList();
+            sut.Search("ab").Should().BeEquivalentTo(new KeyValuePair<string, int>[]
+            {
+                new("ab", 1),
+                new("abc", 2)
+            });
+            sut.Keys.Should().BeEquivalentTo(keys);
+        }
+
+        [Test]
+        public void CanClear()
+        {
+            var sut = new ConcurrentTrie<int>();
+            sut.Add("a", 1);
+            sut.Add("ab", 1);
+            sut.Add("abc", 1);
+            sut.Clear();
+            sut.Keys.Should().BeEmpty();
+        }
+    }
+}

--- a/src/Tests/Nop.Tests/Nop.Data.Tests/EntityRepositoryTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Data.Tests/EntityRepositoryTests.cs
@@ -68,11 +68,11 @@ namespace Nop.Tests.Nop.Data.Tests
             product = await productRepository.GetByIdAsync(2, includeDeleted:false);
             product.Should().BeNull();
 
-            product = await _cacheManager.GetAsync(_cacheKey, () => default(Product));
+            product = await _cacheManager.GetAsync(_cacheKey, default(Product));
             product.Should().BeNull();
 
             await productRepository.GetByIdAsync(1, _ => _cacheKey);
-            product = await _cacheManager.GetAsync(_cacheKey, () => default(Product));
+            product = await _cacheManager.GetAsync(_cacheKey, default(Product));
             product.Should().NotBeNull();
         }
 
@@ -100,11 +100,11 @@ namespace Nop.Tests.Nop.Data.Tests
             products = await productRepository.GetByIdsAsync(ids, includeDeleted: false);
             products.Count.Should().Be(2);
 
-            products = await _cacheManager.GetAsync(_cacheKey, () => default(IList<Product>));
+            products = await _cacheManager.GetAsync(_cacheKey, default(IList<Product>));
             products.Should().BeNull();
 
             await productRepository.GetByIdsAsync(ids, _ => _cacheKey);
-            products = await _cacheManager.GetAsync(_cacheKey, () => default(IList<Product>));
+            products = await _cacheManager.GetAsync(_cacheKey, default(IList<Product>));
             products.Count.Should().Be(3);
         }
 


### PR DESCRIPTION
This pull request addresses a few performance issues with the current caching infrastructure:

- value factories are wrapped in Lazy instances to avoid spawning multiple acquisition threads performing the same work
- keys are stored in a trie (prefix tree) to optimise removing by prefix, bringing the time complexity of finding keys by prefix down from $O(n|k|)$ to $O(|k|)$, where $n$ is the number of keys and $|k|$ is the length of the prefix

The existing implementations of the distributed cache also suffers from a bug where prefixes are not case-sensitive while the actual cache keys are. This has been fixed so both are case-sensitive.

### New Redis-synchronised memory cache
Furthermore, a more performant implementation of a Redis-based cache is added to make distributed and scalable hosting feasible. This new RedisSynchronizedMemoryCache does not actually store cache entries on Redis, but uses Redis' pub/sub functionality to keep instances in sync. Although this pattern is easily extensible to storage and retrieval of values with in-memory L1 caching, the hybrid approach has the advantage of using almost no storage and not hinging on high throughput. Therefore, one can use a very small and cheap Redis server while still getting the performance of a regular memory cache.

Redis settings now include the option to set the instance name, which allows partitioning of a single Redis server between different applications (e.g. development and production environments).

### Support for background tasks
Finally, Locker implementations have been refactored to separate classes (due to the introduction of RedisSynchronizedMemoryCache, which is used by a regular MemoryCacheManager but needs to store task locks as Redis keys), and extended to include support for long-running background tasks. Background tasks can be run with a "heartbeat": a status flag that is periodically updated by the executing nopCommerce instance as long as the task is running. Other instances can observe this flag to avoid starting the same task, and the heartbeat will be automatically expired after a given timespan if the application is unexpectedly shutdown. Majako has two plugins using this functionality waiting to be published.

Best regards,

Rickard von Haugwitz
Majako
[https://www.majako.se/](https://www.majako.se/) and [https://www.majako.net/](https://www.majako.net/)
![majako](https://user-images.githubusercontent.com/44768499/212493534-8a129aa1-de0d-4dc7-bb16-e18570f8c54d.png)
