### PR TITLE
Use async main

### DIFF
--- a/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
-using DocumentFormat.OpenXml.Wordprocessing;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Hosting;
@@ -55,7 +55,7 @@ namespace Nop.Web.Framework.Infrastructure.Extensions
             EngineContext.Current.ConfigureRequestPipeline(application);
         }
 
-        public static void StartEngine(this IApplicationBuilder application)
+        public static async Task StartEngineAsync(this IApplicationBuilder _)
         {
             var engine = EngineContext.Current;
 
@@ -67,8 +67,8 @@ namespace Nop.Web.Framework.Infrastructure.Extensions
 
                 //install and update plugins
                 var pluginService = engine.Resolve<IPluginService>();
-                pluginService.InstallPluginsAsync().Wait();
-                pluginService.UpdatePluginsAsync().Wait();
+                await pluginService.InstallPluginsAsync();
+                await pluginService.UpdatePluginsAsync();
 
                 //update nopCommerce core and db
                 var migrationManager = engine.Resolve<IMigrationManager>();
@@ -78,7 +78,7 @@ namespace Nop.Web.Framework.Infrastructure.Extensions
                 migrationManager.ApplyUpMigrations(assembly, MigrationProcessType.Update);
 
                 var taskScheduler = engine.Resolve<ITaskScheduler>();
-                taskScheduler.InitializeAsync().Wait();
+                await taskScheduler.InitializeAsync();
                 taskScheduler.StartScheduler();
             }
         }
@@ -398,7 +398,7 @@ namespace Nop.Web.Framework.Infrastructure.Extensions
         /// Configure PDF
         /// </summary>
         /// <param name="application">Builder for configuring an application's request pipeline</param>
-        public static void UseNopPdf(this IApplicationBuilder application)
+        public static void UseNopPdf(this IApplicationBuilder _)
         {
             if (!DataSettingsManager.IsDatabaseInstalled())
                 return;

--- a/src/Presentation/Nop.Web/Program.cs
+++ b/src/Presentation/Nop.Web/Program.cs
@@ -1,4 +1,5 @@
-﻿using Autofac.Extensions.DependencyInjection;
+﻿using System.Threading.Tasks;
+using Autofac.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -6,41 +7,49 @@ using Nop.Core.Configuration;
 using Nop.Core.Infrastructure;
 using Nop.Web.Framework.Infrastructure.Extensions;
 
-var builder = WebApplication.CreateBuilder(args);
-
-
-builder.Configuration.AddJsonFile(NopConfigurationDefaults.AppSettingsFilePath, true, true);
-if (!string.IsNullOrEmpty(builder.Environment?.EnvironmentName))
+namespace Nop.Web
 {
-    var path = string.Format(NopConfigurationDefaults.AppSettingsEnvironmentFilePath, builder.Environment.EnvironmentName);
-    builder.Configuration.AddJsonFile(path, true, true);
-}
-builder.Configuration.AddEnvironmentVariables();
-
-//load application settings
-builder.Services.ConfigureApplicationSettings(builder);
-
-var appSettings = Singleton<AppSettings>.Instance;
-var useAutofac = appSettings.Get<CommonConfig>().UseAutofac;
-
-if (useAutofac)
-    builder.Host.UseServiceProviderFactory(new AutofacServiceProviderFactory());
-else
-    builder.Host.UseDefaultServiceProvider(options =>
+    public class Program
     {
-        //we don't validate the scopes, since at the app start and the initial configuration we need 
-        //to resolve some services (registered as "scoped") through the root container
-        options.ValidateScopes = false;
-        options.ValidateOnBuild = true;
-    });
+        public static async Task Main(string[] args)
+        {
+            var builder = WebApplication.CreateBuilder(args);
 
-//add services to the application and configure service provider
-builder.Services.ConfigureApplicationServices(builder);
+            builder.Configuration.AddJsonFile(NopConfigurationDefaults.AppSettingsFilePath, true, true);
+            if (!string.IsNullOrEmpty(builder.Environment?.EnvironmentName))
+            {
+                var path = string.Format(NopConfigurationDefaults.AppSettingsEnvironmentFilePath, builder.Environment.EnvironmentName);
+                builder.Configuration.AddJsonFile(path, true, true);
+            }
+            builder.Configuration.AddEnvironmentVariables();
 
-var app = builder.Build();
+            //load application settings
+            builder.Services.ConfigureApplicationSettings(builder);
 
-//configure the application HTTP request pipeline
-app.ConfigureRequestPipeline();
-app.StartEngine();
+            var appSettings = Singleton<AppSettings>.Instance;
+            var useAutofac = appSettings.Get<CommonConfig>().UseAutofac;
 
-app.Run();
+            if (useAutofac)
+                builder.Host.UseServiceProviderFactory(new AutofacServiceProviderFactory());
+            else
+                builder.Host.UseDefaultServiceProvider(options =>
+                {
+                    //we don't validate the scopes, since at the app start and the initial configuration we need 
+                    //to resolve some services (registered as "scoped") through the root container
+                    options.ValidateScopes = false;
+                    options.ValidateOnBuild = true;
+                });
+
+            //add services to the application and configure service provider
+            builder.Services.ConfigureApplicationServices(builder);
+
+            var app = builder.Build();
+
+            //configure the application HTTP request pipeline
+            app.ConfigureRequestPipeline();
+            await app.StartEngineAsync();
+
+            await app.RunAsync();
+        }
+    }
+}


### PR DESCRIPTION
Since C# 7.1, main can be declared async (see [this article](https://learn.microsoft.com/en-us/archive/blogs/mazhou/c-7-series-part-2-async-main#the-async-main-method)). By using this, we can remove some Task.Wait calls and simplify startup.

Best regards,

Rickard von Haugwitz
Majako
[https://www.majako.se/](https://www.majako.se/) and [https://www.majako.net/](https://www.majako.net/)
![majako](https://user-images.githubusercontent.com/44768499/212493534-8a129aa1-de0d-4dc7-bb16-e18570f8c54d.png)