### PR TITLE
Cache lookups instead of lists

### DIFF
--- a/src/Libraries/Nop.Services/Catalog/Caching/ProductCategoryCacheEventConsumer.cs
+++ b/src/Libraries/Nop.Services/Catalog/Caching/ProductCategoryCacheEventConsumer.cs
@@ -21,6 +21,7 @@ namespace Nop.Services.Catalog.Caching
             await RemoveByPrefixAsync(NopCatalogDefaults.ProductPricePrefix, entity.ProductId);
             await RemoveByPrefixAsync(NopCatalogDefaults.ProductMultiplePricePrefix, entity.ProductId);
             await RemoveByPrefixAsync(NopCatalogDefaults.CategoryFeaturedProductsIdsPrefix, entity.CategoryId);
+            await RemoveByPrefixAsync(NopCatalogDefaults.ChildCategoryIdLookupPrefix);
             await RemoveAsync(NopCatalogDefaults.SpecificationAttributeOptionsByCategoryCacheKey, entity.CategoryId.ToString());
             await RemoveAsync(NopCatalogDefaults.ManufacturersByCategoryCacheKey, entity.CategoryId.ToString());
         }

--- a/src/Libraries/Nop.Services/Catalog/CategoryService.cs
+++ b/src/Libraries/Nop.Services/Catalog/CategoryService.cs
@@ -406,15 +406,20 @@ namespace Nop.Services.Catalog
                 //little hack for performance optimization
                 //there's no need to invoke "GetAllCategoriesByParentCategoryId" multiple times (extra SQL commands) to load childs
                 //so we load all categories at once (we know they are cached) and process them server-side
-                var categoriesIds = new List<int>();
-                var categories = (await GetAllCategoriesAsync(storeId: storeId, showHidden: showHidden))
-                    .Where(c => c.ParentCategoryId == parentCategoryId)
-                    .Select(c => c.Id)
-                    .ToList();
-                categoriesIds.AddRange(categories);
-                categoriesIds.AddRange(await categories.SelectManyAwait(async cId => await GetChildCategoryIdsAsync(cId, storeId, showHidden)).ToListAsync());
-
-                return categoriesIds;
+                var lookup = await _staticCacheManager.GetAsync(
+                    _staticCacheManager.PrepareKeyForDefaultCache(NopCatalogDefaults.ChildCategoryIdLookupCacheKey, storeId, showHidden),
+                    async () => (await GetAllCategoriesAsync(storeId: storeId, showHidden: showHidden))
+                        .ToGroupedDictionary(c => c.ParentCategoryId, x => x.Id));
+                var categoryIds = new List<int>();
+                if (lookup.TryGetValue(parentCategoryId, out var categories))
+                {
+                    categoryIds.AddRange(categories);
+                    var childCategoryIds = categories.SelectAwait(async cId => await GetChildCategoryIdsAsync(cId, storeId, showHidden));
+                    // avoid allocating a new list or blocking with ToEnumerable
+                    await foreach (var cIds in childCategoryIds)
+                        categoryIds.AddRange(cIds);
+                }
+                return categoryIds;
             });
         }
 

--- a/src/Libraries/Nop.Services/Catalog/NopCatalogDefaults.cs
+++ b/src/Libraries/Nop.Services/Catalog/NopCatalogDefaults.cs
@@ -84,6 +84,20 @@ namespace Nop.Services.Catalog
         /// <summary>
         /// Gets a key for caching
         /// </summary>
+        /// <remarks>
+        /// {0} : current store ID
+        /// {1} : show hidden records?
+        /// </remarks>
+        public static CacheKey ChildCategoryIdLookupCacheKey => new("Nop.childcategoryidlookup.bystore.{0}-{1}", prefixes: ChildCategoryIdLookupPrefix);
+
+        /// <summary>
+        /// Gets a key pattern to clear cache
+        /// </summary>
+        public static string ChildCategoryIdLookupPrefix => "Nop.childcategoryidlookup.";
+
+        /// <summary>
+        /// Gets a key for caching
+        /// </summary>
         public static CacheKey CategoriesHomepageCacheKey => new("Nop.category.homepage.", CategoriesHomepagePrefix);
 
         /// <summary>

--- a/src/Libraries/Nop.Services/Extensions.cs
+++ b/src/Libraries/Nop.Services/Extensions.cs
@@ -61,5 +61,48 @@ namespace Nop.Services
         {
             return new SelectList(objList.Select(p => new { ID = p.Id, Name = selector(p) }), "ID", "Name");
         }
+
+        /// <summary>
+        /// Convert to lookup-like dictionary, for JSON serialisation
+        /// </summary>
+        /// <typeparam name="T">Source type</typeparam>
+        /// <typeparam name="TKey">Key type</typeparam>
+        /// <typeparam name="TValue">Value type</typeparam>
+        /// <param name="xs">List of objects</param>
+        /// <param name="keySelector">A key-selector function</param>
+        /// <param name="valueSelector">A value-selector function</param>
+        /// <returns>A dictionary with values grouped by key</returns>
+        public static IDictionary<TKey, IList<TValue>> ToGroupedDictionary<T, TKey, TValue>(
+          this IEnumerable<T> xs,
+          Func<T, TKey> keySelector,
+          Func<T, TValue> valueSelector)
+        {
+            var result = new Dictionary<TKey, IList<TValue>>();
+            foreach (var x in xs)
+            {
+                var key = keySelector(x);
+                var value = valueSelector(x);
+                if (result.TryGetValue(key, out var list))
+                    list.Add(value);
+                else
+                    result[key] = new List<TValue> { value };
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Convert to lookup-like dictionary, for JSON serialisation
+        /// </summary>
+        /// <typeparam name="T">Source type</typeparam>
+        /// <typeparam name="TKey">Key type</typeparam>
+        /// <param name="xs">List of objects</param>
+        /// <param name="keySelector">A key-selector function</param>
+        /// <returns>A dictionary with values grouped by key</returns>
+        public static IDictionary<TKey, IList<T>> ToGroupedDictionary<T, TKey>(
+          this IEnumerable<T> xs,
+          Func<T, TKey> keySelector)
+        {
+            return xs.ToGroupedDictionary(keySelector, x => x);
+        }
     }
 }

--- a/src/Libraries/Nop.Services/Localization/Caching/LocalizedPropertyCacheEventConsumer.cs
+++ b/src/Libraries/Nop.Services/Localization/Caching/LocalizedPropertyCacheEventConsumer.cs
@@ -18,6 +18,7 @@ namespace Nop.Services.Localization.Caching
         {
             await RemoveAsync(NopLocalizationDefaults.LocalizedPropertyCacheKey, entity.LanguageId, entity.EntityId, entity.LocaleKeyGroup, entity.LocaleKey);
             await RemoveAsync(NopLocalizationDefaults.LocalizedPropertiesCacheKey, entity.EntityId, entity.LocaleKeyGroup, entity.LocaleKey);
+            await RemoveAsync(NopLocalizationDefaults.LocalizedPropertyLookupCacheKey, entity.LanguageId);
         }
     }
 }

--- a/src/Libraries/Nop.Services/Localization/NopLocalizationDefaults.cs
+++ b/src/Libraries/Nop.Services/Localization/NopLocalizationDefaults.cs
@@ -123,6 +123,14 @@ namespace Nop.Services.Localization
         /// </remarks>
         public static CacheKey LocalizedPropertiesCacheKey => new("Nop.localizedproperty.all.{0}-{1}-{2}");
 
+        /// <summary>
+        /// Gets a key for caching
+        /// </summary>
+        /// <remarks>
+        /// {0} : language ID
+        /// </remarks>
+        public static CacheKey LocalizedPropertyLookupCacheKey => new("Nop.localizedproperty.value.{0}");
+
         #endregion
 
         #endregion

--- a/src/Libraries/Nop.Services/Seo/Caching/UrlRecordCacheEventConsumer.cs
+++ b/src/Libraries/Nop.Services/Seo/Caching/UrlRecordCacheEventConsumer.cs
@@ -18,6 +18,8 @@ namespace Nop.Services.Seo.Caching
         {
             await RemoveAsync(NopSeoDefaults.UrlRecordCacheKey, entity.EntityId, entity.EntityName, entity.LanguageId);
             await RemoveAsync(NopSeoDefaults.UrlRecordBySlugCacheKey, entity.Slug);
+            await RemoveAsync(NopSeoDefaults.UrlRecordEntityIdLookupCacheKey, entity.LanguageId);
+            await RemoveAsync(NopSeoDefaults.UrlRecordSlugLookupCacheKey);
         }
     }
 }

--- a/src/Libraries/Nop.Services/Seo/NopSeoDefaults.cs
+++ b/src/Libraries/Nop.Services/Seo/NopSeoDefaults.cs
@@ -107,6 +107,19 @@ namespace Nop.Services.Seo
         /// </remarks>
         public static CacheKey UrlRecordBySlugCacheKey => new("Nop.urlrecord.byslug.{0}");
 
+        /// <summary>
+        /// Gets a key for caching
+        /// </summary>
+        public static CacheKey UrlRecordSlugLookupCacheKey => new("Nop.urlrecord.sluglookup");
+
+        /// <summary>
+        /// Gets a key for caching
+        /// </summary>
+        /// <remarks>
+        /// {0} : language ID
+        /// </remarks>
+        public static CacheKey UrlRecordEntityIdLookupCacheKey => new("Nop.urlrecord.entityidlookup.{0}");
+
         #endregion
     }
 }

--- a/src/Libraries/Nop.Services/Seo/UrlRecordService.cs
+++ b/src/Libraries/Nop.Services/Seo/UrlRecordService.cs
@@ -51,7 +51,7 @@ namespace Nop.Services.Seo
         #endregion
 
         #region Utilities
-        
+
         /// <summary>
         /// Stores Unicode characters and their "normalized"
         /// values to a hash table. Character codes are referenced
@@ -1120,7 +1120,7 @@ namespace Nop.Services.Seo
         #endregion
 
         #region Methods
-        
+
         /// <summary>
         /// Deletes an URL records
         /// </summary>
@@ -1176,36 +1176,32 @@ namespace Nop.Services.Seo
         {
             if (string.IsNullOrEmpty(slug))
                 return null;
-            
+
             var key = _staticCacheManager.PrepareKeyForDefaultCache(NopSeoDefaults.UrlRecordBySlugCacheKey, slug);
 
-            if (_localizationSettings.LoadAllUrlRecordsOnStartup)
+            return await _staticCacheManager.GetAsync(key, async () =>
             {
-                return await _staticCacheManager.GetAsync(key, async () =>
+                if (_localizationSettings.LoadAllUrlRecordsOnStartup)
                 {
-                    //load all records (we know they are cached)
-                    var source = await GetAllUrlRecordsAsync();
-                    var urlRecords = from ur in source
-                        where ur.Slug.Equals(slug, StringComparison.InvariantCultureIgnoreCase)
-                        //first, try to find an active record
-                        orderby ur.IsActive descending, ur.Id
-                        select ur;
-                    var urlRecordForCaching = urlRecords.FirstOrDefault();
+                    var lookup = await _staticCacheManager.GetAsync(
+                        _staticCacheManager.PrepareKeyForDefaultCache(NopSeoDefaults.UrlRecordSlugLookupCacheKey),
+                        async () => (await GetAllUrlRecordsAsync())
+                            .ToGroupedDictionary(x => x.Slug.ToLowerInvariant()));
 
-                    return urlRecordForCaching;
-                });
-            }
+                    return lookup.TryGetValue(slug.ToLowerInvariant(), out var records)
+                        ? records.OrderByDescending(x => x.IsActive).ThenBy(x => x.Id).FirstOrDefault()
+                        : null;
+                }
 
-            //gradual loading
-            var query = from ur in _urlRecordRepository.Table
-                where ur.Slug == slug
-                //first, try to find an active record
-                orderby ur.IsActive descending, ur.Id
-                select ur;
+                // gradual loading
+                var query = from ur in _urlRecordRepository.Table
+                            where ur.Slug == slug
+                            //first, try to find an active record
+                            orderby ur.IsActive descending, ur.Id
+                            select ur;
 
-            var urlRecord = await _staticCacheManager.GetAsync(key, async () => await query.FirstOrDefaultAsync());
-
-            return urlRecord;
+                return await query.FirstOrDefaultAsync();
+            });
         }
 
         /// <summary>
@@ -1260,38 +1256,35 @@ namespace Nop.Services.Seo
             //gradual loading
             var key = _staticCacheManager.PrepareKeyForDefaultCache(NopSeoDefaults.UrlRecordCacheKey, entityId, entityName, languageId);
 
-            if (_localizationSettings.LoadAllUrlRecordsOnStartup)
+            return await _staticCacheManager.GetAsync(key, async () =>
             {
-                return await _staticCacheManager.GetAsync(key, async () =>
+                if (_localizationSettings.LoadAllUrlRecordsOnStartup)
                 {
-                    //load all records (we know they are cached)
-                    var source = await GetAllUrlRecordsAsync();
-                    var urlRecords = from ur in source
-                        where ur.EntityId == entityId &&
-                              ur.EntityName == entityName &&
-                              ur.LanguageId == languageId &&
-                              ur.IsActive
-                        orderby ur.Id descending
-                        select ur.Slug;
+                    var lookup = await _staticCacheManager.GetAsync(
+                        _staticCacheManager.PrepareKeyForDefaultCache(NopSeoDefaults.UrlRecordEntityIdLookupCacheKey, languageId),
+                        async () => (await GetAllUrlRecordsAsync()) // these are cached
+                            .Where(x => x.IsActive && x.LanguageId == languageId)
+                            .ToGroupedDictionary(x => x.EntityId));
 
-                    //little hack here. nulls aren't cacheable so set it to ""
-                    var slug = urlRecords.FirstOrDefault() ?? string.Empty;
+                    return lookup.TryGetValue(entityId, out var records)
+                        ? records.Where(x => x.EntityName == entityName)
+                            .OrderBy(x => x.Id)
+                            .FirstOrDefault()?.Slug ?? string.Empty
+                        : string.Empty;
+                }
 
-                    return slug;
-                });
-            }
+                //gradual loading
+                var query = from ur in _urlRecordRepository.Table
+                            where ur.EntityId == entityId &&
+                                  ur.EntityName == entityName &&
+                                  ur.LanguageId == languageId &&
+                                  ur.IsActive
+                            orderby ur.Id descending
+                            select ur.Slug;
 
-            var query = from ur in _urlRecordRepository.Table
-                where ur.EntityId == entityId &&
-                      ur.EntityName == entityName &&
-                      ur.LanguageId == languageId &&
-                      ur.IsActive
-                orderby ur.Id descending
-                select ur.Slug;
-
-            var rezSlug = await _staticCacheManager.GetAsync(key, async () => await query.FirstOrDefaultAsync()) ?? string.Empty;
-
-            return rezSlug;
+                //little hack here. nulls aren't cacheable so set it to ""
+                return await query.FirstOrDefaultAsync() ?? string.Empty;
+            }) ?? string.Empty;
         }
 
         /// <summary>
@@ -1435,7 +1428,7 @@ namespace Nop.Services.Seo
         {
             languageId ??= (await _workContext.GetWorkingLanguageAsync()).Id;
             var result = string.Empty;
-            
+
             if (languageId > 0)
             {
                 //ensure that we have at least two published languages


### PR DESCRIPTION
Cache categories, localized entities and URL records as lookups for faster retrieval.

Currently, CategoryService, LocalizedEntityService and UrlRecordService cache their respective entities as one big list, and every new lookup is performed by querying this list. Every such operation has a time complexity in $O(n)$, where $n$ is the total number of entities. Since the number of entities in these services can easily number in the thousands, in some cases hundreds of thousands, this quickly becomes a problem.

To address this issue, we instead cache these entities as lookups (specifically, lookup-like dictionaries, since actual lookups cannot be JSON-serialised), reducing retrieval complexity to $O(1)$ (subsequent filtering and sorting of the retrieved lists is negligible, as they are typically very small). Where applicable, the lookups are broken up into smaller pieces (e.g. storing localizations by language) to avoid added complexity from having to store nested lookups, and to reduce the size of the objects for faster serialisation and transfer in scenarios like distributed caching.

Best regards,

Rickard von Haugwitz
Majako
[https://www.majako.se/](https://www.majako.se/) and [https://www.majako.net/](https://www.majako.net/)
![majako](https://user-images.githubusercontent.com/44768499/212493534-8a129aa1-de0d-4dc7-bb16-e18570f8c54d.png)