### PR TITLE
change caret icon styling to prevent movement when clicked

### DIFF
--- a/src/Presentation/Nop.Web/wwwroot/css/admin/styles.css
+++ b/src/Presentation/Nop.Web/wwwroot/css/admin/styles.css
@@ -1349,9 +1349,12 @@ input[type="text"].k-input {
   align-items: flex-start;
 }
 
-.nav-sidebar .nav-treeview > li > a i {
+.nav-sidebar .nav-treeview > li > a i.nav-icon {
   padding-top: 4px;
-  min-width: 26px;
+}
+
+.nav-sidebar .nav-treeview > li > a i.right {
+    right: 2rem;
 }
 
 .sidebar-form {


### PR DESCRIPTION
This resolves issue #6549 . 

Previously, when clicking a child-level item in the Admin menu, the caret would move down and to the right: 

![image](https://user-images.githubusercontent.com/90517350/215150481-129ca62b-e6a4-44c8-b5af-1e0ca302fd69.png)

Now it stays put: 

![image](https://user-images.githubusercontent.com/90517350/215151008-6405b3b3-4fc5-470c-915e-acefe1e815d8.png)

**Changes:** 

Line 1354 -- Removed the **min-width** styling. This was being used to move child-items' carets left/inward, and was the cause of this issue. Removing this necessitates lines 1356-1358.

Line 1352 -- Narrowed the scope of the **padding-top** styling, which is needed for the 'circle' icon (this styling pushes it down toward the vertical center-line), but not the 'caret' icon (the styling pushes it down/away from the vertical center-line).

![image](https://user-images.githubusercontent.com/90517350/215149000-10c63935-f873-474a-9756-081aff24856f.png)

Lines 1356-1358 -- override AdminLTE.io styling to move child-level caret icons left/inward. 