### PR TITLE
#6555 - Adding new KnownNetworks property to HostingConfig

### DIFF
--- a/src/Libraries/Nop.Core/Configuration/HostingConfig.cs
+++ b/src/Libraries/Nop.Core/Configuration/HostingConfig.cs
@@ -25,5 +25,10 @@ namespace Nop.Core.Configuration
         /// Gets or sets addresses of known proxies to accept forwarded headers from
         /// </summary>
         public string KnownProxies { get; private set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets addresses of known networks to accept forwarded headers from
+        /// </summary>
+        public string KnownNetworks { get; private set; } = string.Empty;
     }
 }

--- a/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
@@ -487,10 +487,23 @@ namespace Nop.Web.Framework.Infrastructure.Extensions
                         if (IPAddress.TryParse(strIp, out var ip))
                             options.KnownProxies.Add(ip);
                     }
-
-                    if (options.KnownProxies.Count > 1)
-                        options.ForwardLimit = null; //disable the limit, because KnownProxies is configured
                 }
+
+                if (!string.IsNullOrEmpty(appSettings.Get<HostingConfig>().KnownNetworks))
+                {
+                    foreach (var strIpNet in appSettings.Get<HostingConfig>().KnownNetworks.Split(',', StringSplitOptions.RemoveEmptyEntries).ToList())
+                    {
+                        string[] ipNetParts = strIpNet.Split("/");
+                        if (ipNetParts.Length == 2)
+                        {
+                            if (IPAddress.TryParse(ipNetParts[0], out var ip) && int.TryParse(ipNetParts[1], out var length))
+                                options.KnownNetworks.Add(new IPNetwork(ip, length));
+                        }
+                    }
+                }
+
+                if (options.KnownProxies.Count > 1 || options.KnownNetworks.Count > 1)
+                    options.ForwardLimit = null; //disable the limit, because KnownProxies is configured
 
                 //configure forwarding
                 application.UseForwardedHeaders(options);

--- a/src/Presentation/Nop.Web.Framework/Migrations/UpgradeTo470/LocalizationMigration.cs
+++ b/src/Presentation/Nop.Web.Framework/Migrations/UpgradeTo470/LocalizationMigration.cs
@@ -52,7 +52,7 @@ namespace Nop.Web.Framework.Migrations.UpgradeTo470
                 ["Admin.Configuration.Settings.Catalog.CacheProductPrices.Hint"] = "Check to cache product prices. It can significantly improve performance. But you should not enable it if you use some complex discounts, discount requirement rules, or coupon codes.",
                 //6541
                 ["Customer.FullNameFormat"] = "{0} {1}",
-                //TODO: update comment with issue number for KnownNetworks Update
+                //#6555
                 ["Admin.Configuration.AppSettings.Hosting.KnownNetworks"] = "Addresses of known proxy networks",
                 ["Admin.Configuration.AppSettings.Hosting.KnownNetworks.Hint"] = "Specify a list of IP CIDR notations (comma separated) to accept forwarded headers.  e.g. 172.64.0.0/13,162.158.0.0/15",
             }, languageId);

--- a/src/Presentation/Nop.Web.Framework/Migrations/UpgradeTo470/LocalizationMigration.cs
+++ b/src/Presentation/Nop.Web.Framework/Migrations/UpgradeTo470/LocalizationMigration.cs
@@ -52,6 +52,9 @@ namespace Nop.Web.Framework.Migrations.UpgradeTo470
                 ["Admin.Configuration.Settings.Catalog.CacheProductPrices.Hint"] = "Check to cache product prices. It can significantly improve performance. But you should not enable it if you use some complex discounts, discount requirement rules, or coupon codes.",
                 //6541
                 ["Customer.FullNameFormat"] = "{0} {1}",
+                //TODO: update comment with issue number for KnownNetworks Update
+                ["Admin.Configuration.AppSettings.Hosting.KnownNetworks"] = "Addresses of known proxy networks",
+                ["Admin.Configuration.AppSettings.Hosting.KnownNetworks.Hint"] = "Specify a list of IP CIDR notations (comma separated) to accept forwarded headers.  e.g. 172.64.0.0/13,162.158.0.0/15",
             }, languageId);
 
             #endregion

--- a/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
+++ b/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
@@ -4608,6 +4608,12 @@
   <LocaleResource Name="Admin.Configuration.AppSettings.Hosting.KnownProxies.Hint">
     <Value>Specify a list of IP addresses (comma separated) to accept forwarded headers.</Value>
   </LocaleResource>
+  <LocaleResource Name="Admin.Configuration.AppSettings.Hosting.KnownNetworks">
+    <Value>Addresses of known proxy networks</Value>
+  </LocaleResource>
+  <LocaleResource Name="Admin.Configuration.AppSettings.Hosting.KnownNetworks.Hint">
+    <Value>Specify a list of IP CIDR notations (comma separated) to accept forwarded headers.  e.g. 172.64.0.0/13,162.158.0.0/15</Value>
+  </LocaleResource>
   <LocaleResource Name="Admin.Configuration.AppSettings.Hosting.UseProxy">
     <Value>Use proxy servers</Value>
   </LocaleResource>

--- a/src/Presentation/Nop.Web/Areas/Admin/Models/Settings/HostingConfigModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Models/Settings/HostingConfigModel.cs
@@ -22,6 +22,8 @@ namespace Nop.Web.Areas.Admin.Models.Settings
         [NopResourceDisplayName("Admin.Configuration.AppSettings.Hosting.KnownProxies")]
         public string KnownProxies { get; set; }
 
+        [NopResourceDisplayName("Admin.Configuration.AppSettings.Hosting.KnownNetworks")]
+        public string KnownNetworks { get; set; }
         #endregion
     }
 }

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_AppSettings.Hosting.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_AppSettings.Hosting.cshtml
@@ -37,4 +37,13 @@
             <span asp-validation-for="HostingConfigModel.KnownProxies"></span>
         </div>
     </div>
+    <div class="form-group row advanced-setting">
+        <div class="col-md-3">
+            <nop-label asp-for="HostingConfigModel.KnownNetworks" />
+        </div>
+        <div class="col-md-9">
+            <nop-editor asp-for="HostingConfigModel.KnownNetworks" />
+            <span asp-validation-for="HostingConfigModel.KnownNetworks"></span>
+        </div>
+    </div>
 </div>


### PR DESCRIPTION
This pull request is for issue #6555 that I reported.
- Added the appropriate migrations for nop resource strings
- Added KnownNetworks to HostingConfig and HostingConfigModel classes
- Added logic to UseNopProxy to loop through the new setting and parse entries into IPNetwork object and add to the ForwardedHeaderOptions.KnownNetworks property