### PR TITLE
move GetTaxDisplayTypeAsync() to ICustomerService

### DIFF
--- a/src/Libraries/Nop.Core/IWorkContext.cs
+++ b/src/Libraries/Nop.Core/IWorkContext.cs
@@ -63,14 +63,9 @@ namespace Nop.Core
         Task SetWorkingCurrencyAsync(Currency currency);
 
         /// <summary>
-        /// Gets or sets current tax display type
-        /// </summary>
-        /// <returns>A task that represents the asynchronous operation</returns>
-        Task<TaxDisplayType> GetTaxDisplayTypeAsync();
-
-        /// <summary>
         /// Sets current tax display type
         /// </summary>
+        /// <param name="taxDisplayType">Tax Display Type</param>
         /// <returns>A task that represents the asynchronous operation</returns>
         Task SetTaxDisplayTypeAsync(TaxDisplayType taxDisplayType);        
     }

--- a/src/Libraries/Nop.Services/Catalog/PriceFormatter.cs
+++ b/src/Libraries/Nop.Services/Catalog/PriceFormatter.cs
@@ -5,6 +5,7 @@ using Nop.Core;
 using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Directory;
 using Nop.Core.Domain.Tax;
+using Nop.Services.Customers;
 using Nop.Services.Directory;
 using Nop.Services.Localization;
 
@@ -19,6 +20,7 @@ namespace Nop.Services.Catalog
 
         private readonly CurrencySettings _currencySettings;
         private readonly ICurrencyService _currencyService;
+        private readonly ICustomerService _customerService;
         private readonly ILocalizationService _localizationService;
         private readonly IMeasureService _measureService;
         private readonly IPriceCalculationService _priceCalculationService;
@@ -31,6 +33,7 @@ namespace Nop.Services.Catalog
 
         public PriceFormatter(CurrencySettings currencySettings,
             ICurrencyService currencyService,
+            ICustomerService customerService,
             ILocalizationService localizationService,
             IMeasureService measureService,
             IPriceCalculationService priceCalculationService,
@@ -39,6 +42,7 @@ namespace Nop.Services.Catalog
         {
             _currencySettings = currencySettings;
             _currencyService = currencyService;
+            _customerService = customerService;
             _localizationService = localizationService;
             _measureService = measureService;
             _priceCalculationService = priceCalculationService;
@@ -155,7 +159,7 @@ namespace Nop.Services.Catalog
         /// </returns>
         public virtual async Task<string> FormatPriceAsync(decimal price, bool showCurrency, Currency targetCurrency)
         {
-            var priceIncludesTax = await _workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax;
+            var priceIncludesTax = await _customerService.GetTaxDisplayTypeAsync(await _workContext.GetCurrentCustomerAsync()) == TaxDisplayType.IncludingTax;
             return await FormatPriceAsync(price, showCurrency, targetCurrency, (await _workContext.GetWorkingLanguageAsync()).Id, priceIncludesTax);
         }
 
@@ -171,7 +175,7 @@ namespace Nop.Services.Catalog
         /// </returns>
         public virtual async Task<string> FormatPriceAsync(decimal price, bool showCurrency, bool showTax)
         {
-            var priceIncludesTax = await _workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax;
+            var priceIncludesTax = await _customerService.GetTaxDisplayTypeAsync(await _workContext.GetCurrentCustomerAsync()) == TaxDisplayType.IncludingTax;
             return await FormatPriceAsync(price, showCurrency, await _workContext.GetWorkingCurrencyAsync(), (await _workContext.GetWorkingLanguageAsync()).Id, priceIncludesTax, showTax);
         }
 
@@ -195,7 +199,7 @@ namespace Nop.Services.Catalog
                 CurrencyCode = currencyCode
             };
 
-            var priceIncludesTax = await _workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax;
+            var priceIncludesTax = await _customerService.GetTaxDisplayTypeAsync(await _workContext.GetCurrentCustomerAsync()) == TaxDisplayType.IncludingTax;
             return await FormatPriceAsync(price, showCurrency, currency, languageId, priceIncludesTax, showTax);
         }
 
@@ -219,7 +223,7 @@ namespace Nop.Services.Catalog
             Currency primaryStoreCurrency, int languageId, bool? priceIncludesTax = null, bool? showTax = null)
         {
             var needAddPriceOnCustomerCurrency = primaryStoreCurrency.CurrencyCode != customerCurrencyCode && displayCustomerCurrency;
-            var includesTax = priceIncludesTax ?? await _workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax;
+            var includesTax = priceIncludesTax ?? await _customerService.GetTaxDisplayTypeAsync(await _workContext.GetCurrentCustomerAsync()) == TaxDisplayType.IncludingTax;
             var priceText = await FormatPriceAsync(price, true, primaryStoreCurrency,
                 languageId, includesTax, showTax ?? _taxSettings.DisplayTaxSuffix);
 
@@ -358,7 +362,7 @@ namespace Nop.Services.Catalog
         /// </returns>
         public virtual async Task<string> FormatShippingPriceAsync(decimal price, bool showCurrency)
         {
-            var priceIncludesTax = await _workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax;
+            var priceIncludesTax = await _customerService.GetTaxDisplayTypeAsync(await _workContext.GetCurrentCustomerAsync()) == TaxDisplayType.IncludingTax;
             return await FormatShippingPriceAsync(price, showCurrency, await _workContext.GetWorkingCurrencyAsync(), (await _workContext.GetWorkingLanguageAsync()).Id, priceIncludesTax);
         }
 
@@ -415,7 +419,7 @@ namespace Nop.Services.Catalog
         /// </returns>
         public virtual async Task<string> FormatPaymentMethodAdditionalFeeAsync(decimal price, bool showCurrency)
         {
-            var priceIncludesTax = await _workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax;
+            var priceIncludesTax = await _customerService.GetTaxDisplayTypeAsync(await _workContext.GetCurrentCustomerAsync()) == TaxDisplayType.IncludingTax;
 
             return await FormatPaymentMethodAdditionalFeeAsync(price, showCurrency, await _workContext.GetWorkingCurrencyAsync(),
                 (await _workContext.GetWorkingLanguageAsync()).Id, priceIncludesTax);

--- a/src/Libraries/Nop.Services/Customers/CustomerService.cs
+++ b/src/Libraries/Nop.Services/Customers/CustomerService.cs
@@ -51,6 +51,9 @@ namespace Nop.Services.Customers
         private readonly IStaticCacheManager _staticCacheManager;
         private readonly IStoreContext _storeContext;
         private readonly ShoppingCartSettings _shoppingCartSettings;
+        private readonly TaxSettings _taxSettings;
+
+        private TaxDisplayType? _cachedTaxDisplayType;
 
         #endregion
 
@@ -77,7 +80,8 @@ namespace Nop.Services.Customers
             IRepository<ShoppingCartItem> shoppingCartRepository,
             IStaticCacheManager staticCacheManager,
             IStoreContext storeContext,
-            ShoppingCartSettings shoppingCartSettings)
+            ShoppingCartSettings shoppingCartSettings,
+            TaxSettings taxSettings)
         {
             _customerSettings = customerSettings;
             _genericAttributeService = genericAttributeService;
@@ -101,6 +105,7 @@ namespace Nop.Services.Customers
             _staticCacheManager = staticCacheManager;
             _storeContext = storeContext;
             _shoppingCartSettings = shoppingCartSettings;
+            _taxSettings = taxSettings;
         }
 
         #endregion
@@ -710,6 +715,56 @@ namespace Nop.Services.Customers
             await _customerAddressRepository.DeleteAsync(a => tmpAddresses.Any(tmp => tmp.AddressId == a.Id));
 
             return totalRecordsDeleted;
+        }
+
+        /// <summary>
+        /// Gets or sets current tax display type
+        /// </summary>
+        /// <param name="customer">Customer</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation
+        /// The task result contains the tax display type
+        /// </returns>
+        public virtual async Task<TaxDisplayType> GetTaxDisplayTypeAsync(Customer customer)
+        {
+            //whether there is a cached value
+            if (_cachedTaxDisplayType.HasValue)
+                return _cachedTaxDisplayType.Value;
+
+            var taxDisplayType = TaxDisplayType.IncludingTax;
+
+            //whether customers are allowed to select tax display type
+            if (_taxSettings.AllowCustomersToSelectTaxDisplayType && customer != null)
+            {
+                //try to get previously saved tax display type
+                var taxDisplayTypeId = customer.TaxDisplayTypeId;
+                if (taxDisplayTypeId.HasValue)
+                    taxDisplayType = (TaxDisplayType)taxDisplayTypeId.Value;
+                else
+                {
+                    //default tax type by customer roles
+                    var defaultRoleTaxDisplayType = await GetCustomerDefaultTaxDisplayTypeAsync(customer);
+                    if (defaultRoleTaxDisplayType != null)
+                        taxDisplayType = defaultRoleTaxDisplayType.Value;
+                }
+            }
+            else
+            {
+                //default tax type by customer roles
+                var defaultRoleTaxDisplayType = await GetCustomerDefaultTaxDisplayTypeAsync(customer);
+                if (defaultRoleTaxDisplayType != null)
+                    taxDisplayType = defaultRoleTaxDisplayType.Value;
+                else
+                {
+                    //or get the default tax display type
+                    taxDisplayType = _taxSettings.TaxDisplayType;
+                }
+            }
+
+            //cache the value
+            _cachedTaxDisplayType = taxDisplayType;
+
+            return _cachedTaxDisplayType.Value;
         }
 
         /// <summary>

--- a/src/Libraries/Nop.Services/Customers/ICustomerService.cs
+++ b/src/Libraries/Nop.Services/Customers/ICustomerService.cs
@@ -242,6 +242,16 @@ namespace Nop.Services.Customers
         Task<int> DeleteGuestCustomersAsync(DateTime? createdFromUtc, DateTime? createdToUtc, bool onlyWithoutShoppingCart);
 
         /// <summary>
+        /// Gets or sets current tax display type
+        /// </summary>
+        /// <param name="customer">Customer</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation
+        /// The task result contains the tax display type
+        /// </returns>
+        Task<TaxDisplayType> GetTaxDisplayTypeAsync(Customer customer);
+
+        /// <summary>
         /// Gets a default tax display type (if configured)
         /// </summary>
         /// <param name="customer">Customer</param>

--- a/src/Libraries/Nop.Services/Orders/OrderProcessingService.cs
+++ b/src/Libraries/Nop.Services/Orders/OrderProcessingService.cs
@@ -480,17 +480,7 @@ namespace Nop.Services.Orders
                 details.AffiliateId = affiliate.Id;
 
             //tax display type
-            //TODO: this code duplicates method IWorkContext.GetTaxDisplayTypeAsync(), let's move it to a ICustomerService with "customer" parameter passing
-            var taxDisplayType = _taxSettings.TaxDisplayType;
-            if (_taxSettings.AllowCustomersToSelectTaxDisplayType && details.Customer.TaxDisplayTypeId.HasValue)
-                taxDisplayType = (TaxDisplayType)details.Customer.TaxDisplayTypeId.Value;
-            else
-            {
-                var defaultRoleTaxDisplayType = await _customerService.GetCustomerDefaultTaxDisplayTypeAsync(details.Customer);
-                if (defaultRoleTaxDisplayType.HasValue)
-                    taxDisplayType = defaultRoleTaxDisplayType.Value;
-            }
-            details.CustomerTaxDisplayType = taxDisplayType;
+            details.CustomerTaxDisplayType = await _customerService.GetTaxDisplayTypeAsync(details.Customer);
 
             //recurring or standard shopping cart?
             details.IsRecurringShoppingCart = await _shoppingCartService.ShoppingCartIsRecurringAsync(details.Cart);

--- a/src/Libraries/Nop.Services/Orders/OrderTotalCalculationService.cs
+++ b/src/Libraries/Nop.Services/Orders/OrderTotalCalculationService.cs
@@ -1070,7 +1070,7 @@ namespace Nop.Services.Orders
         /// </returns>
         public virtual async Task<decimal?> GetShoppingCartShippingTotalAsync(IList<ShoppingCartItem> cart)
         {
-            var includingTax = await _workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax;
+            var includingTax = await _customerService.GetTaxDisplayTypeAsync(await _workContext.GetCurrentCustomerAsync()) == TaxDisplayType.IncludingTax;
             return (await GetShoppingCartShippingTotalAsync(cart, includingTax)).shippingTotal;
         }
 

--- a/src/Libraries/Nop.Services/Tax/TaxService.cs
+++ b/src/Libraries/Nop.Services/Tax/TaxService.cs
@@ -482,7 +482,7 @@ namespace Nop.Services.Tax
         public virtual async Task<(decimal price, decimal taxRate)> GetProductPriceAsync(Product product, decimal price,
             Customer customer)
         {
-            var includingTax = await _workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax;
+            var includingTax = await _customerService.GetTaxDisplayTypeAsync(customer) == TaxDisplayType.IncludingTax;
             return await GetProductPriceAsync(product, price, includingTax, customer);
         }
 
@@ -622,7 +622,7 @@ namespace Nop.Services.Tax
         /// </returns>
         public virtual async Task<(decimal price, decimal taxRate)> GetShippingPriceAsync(decimal price, Customer customer)
         {
-            var includingTax = await _workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax;
+            var includingTax = await _customerService.GetTaxDisplayTypeAsync(customer) == TaxDisplayType.IncludingTax;
 
             return await GetShippingPriceAsync(price, includingTax, customer);
         }
@@ -667,7 +667,7 @@ namespace Nop.Services.Tax
         /// </returns>
         public virtual async Task<(decimal price, decimal taxRate)> GetPaymentMethodAdditionalFeeAsync(decimal price, Customer customer)
         {
-            var includingTax = await _workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax;
+            var includingTax = await _customerService.GetTaxDisplayTypeAsync(customer) == TaxDisplayType.IncludingTax;
             
             return await GetPaymentMethodAdditionalFeeAsync(price, includingTax, customer);
         }
@@ -728,7 +728,7 @@ namespace Nop.Services.Tax
         /// </returns>
         public virtual async Task<(decimal price, decimal taxRate)> GetCheckoutAttributePriceAsync(CheckoutAttribute ca, CheckoutAttributeValue cav, Customer customer)
         {
-            var includingTax = await _workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax;
+            var includingTax = await _customerService.GetTaxDisplayTypeAsync(customer) == TaxDisplayType.IncludingTax;
 
             return await GetCheckoutAttributePriceAsync(ca, cav, includingTax, customer);
         }

--- a/src/Plugins/Nop.Plugin.Misc.Sendinblue/Services/MarketingAutomationManager.cs
+++ b/src/Plugins/Nop.Plugin.Misc.Sendinblue/Services/MarketingAutomationManager.cs
@@ -151,7 +151,7 @@ namespace Nop.Plugin.Misc.Sendinblue.Services
 
                     //get shopping cart amounts
                     var (_, cartDiscount, _, cartSubtotal, _) = await _orderTotalCalculationService.GetShoppingCartSubTotalAsync(cart,
-                        await _workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax);
+                        await _customerService.GetTaxDisplayTypeAsync(customer) == TaxDisplayType.IncludingTax);
                     var cartTax = await _orderTotalCalculationService.GetTaxTotalAsync(cart, false);
                     var cartShipping = await _orderTotalCalculationService.GetShoppingCartShippingTotalAsync(cart);
                     var (cartTotal, _, _, _, _, _) = await _orderTotalCalculationService.GetShoppingCartTotalAsync(cart, false, false);

--- a/src/Presentation/Nop.Web.Framework/WebWorkContext.cs
+++ b/src/Presentation/Nop.Web.Framework/WebWorkContext.cs
@@ -52,7 +52,6 @@ namespace Nop.Web.Framework
         private Vendor _cachedVendor;
         private Language _cachedLanguage;
         private Currency _cachedCurrency;
-        private TaxDisplayType? _cachedTaxDisplayType;
 
         #endregion
 
@@ -469,52 +468,9 @@ namespace Nop.Web.Framework
         }
 
         /// <summary>
-        /// Gets or sets current tax display type
+        /// Sets current customer tax display type
         /// </summary>
-        /// <returns>A task that represents the asynchronous operation</returns>
-        public virtual async Task<TaxDisplayType> GetTaxDisplayTypeAsync()
-        {
-            //whether there is a cached value
-            if (_cachedTaxDisplayType.HasValue)
-                return _cachedTaxDisplayType.Value;
-
-            var taxDisplayType = TaxDisplayType.IncludingTax;
-            var customer = await GetCurrentCustomerAsync();
-
-            //whether customers are allowed to select tax display type
-            if (_taxSettings.AllowCustomersToSelectTaxDisplayType && customer != null)
-            {
-                //try to get previously saved tax display type
-                var taxDisplayTypeId = customer.TaxDisplayTypeId;
-                if (taxDisplayTypeId.HasValue)
-                    taxDisplayType = (TaxDisplayType)taxDisplayTypeId.Value;
-                else
-                {
-                    //default tax type by customer roles
-                    var defaultRoleTaxDisplayType = await _customerService.GetCustomerDefaultTaxDisplayTypeAsync(customer);
-                    if (defaultRoleTaxDisplayType != null)
-                        taxDisplayType = defaultRoleTaxDisplayType.Value;
-                }
-            }
-            else
-            {
-                //default tax type by customer roles
-                var defaultRoleTaxDisplayType = await _customerService.GetCustomerDefaultTaxDisplayTypeAsync(customer);
-                if (defaultRoleTaxDisplayType != null)
-                    taxDisplayType = defaultRoleTaxDisplayType.Value;
-                else
-                {
-                    //or get the default tax display type
-                    taxDisplayType = _taxSettings.TaxDisplayType;
-                }
-            }
-
-            //cache the value
-            _cachedTaxDisplayType = taxDisplayType;
-
-            return _cachedTaxDisplayType.Value;
-        }
-
+        /// <param name="taxDisplayType">Tax Display Type</param>
         /// <returns>A task that represents the asynchronous operation</returns>
         public virtual async Task SetTaxDisplayTypeAsync(TaxDisplayType taxDisplayType)
         {
@@ -526,9 +482,6 @@ namespace Nop.Web.Framework
             var customer = await GetCurrentCustomerAsync();
             customer.TaxDisplayType = taxDisplayType;
             await _customerService.UpdateCustomerAsync(customer);
-
-            //then reset the cached value
-            _cachedTaxDisplayType = null;
         }
 
         /// <summary>

--- a/src/Presentation/Nop.Web/Factories/CommonModelFactory.cs
+++ b/src/Presentation/Nop.Web/Factories/CommonModelFactory.cs
@@ -310,7 +310,7 @@ namespace Nop.Web.Factories
         {
             var model = new TaxTypeSelectorModel
             {
-                CurrentTaxType = await _workContext.GetTaxDisplayTypeAsync()
+                CurrentTaxType = await _customerService.GetTaxDisplayTypeAsync(await _workContext.GetCurrentCustomerAsync())
             };
 
             return model;

--- a/src/Presentation/Nop.Web/Factories/ShoppingCartModelFactory.cs
+++ b/src/Presentation/Nop.Web/Factories/ShoppingCartModelFactory.cs
@@ -1028,7 +1028,7 @@ namespace Nop.Web.Factories
                     model.TotalProducts = cart.Sum(item => item.Quantity);
 
                     //subtotal
-                    var subTotalIncludingTax = await _workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax && !_taxSettings.ForceTaxExclusionFromOrderSubtotal;
+                    var subTotalIncludingTax = await _customerService.GetTaxDisplayTypeAsync(customer) == TaxDisplayType.IncludingTax && !_taxSettings.ForceTaxExclusionFromOrderSubtotal;
                     var (_, _, _, subTotalWithoutDiscountBase, _) = await _orderTotalCalculationService.GetShoppingCartSubTotalAsync(cart, subTotalIncludingTax);
                     var subtotalBase = subTotalWithoutDiscountBase;
                     var currentCurrency = await _workContext.GetWorkingCurrencyAsync();
@@ -1143,7 +1143,7 @@ namespace Nop.Web.Factories
             if (cart.Any())
             {
                 //subtotal
-                var subTotalIncludingTax = await _workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax && !_taxSettings.ForceTaxExclusionFromOrderSubtotal;
+                var subTotalIncludingTax = await _customerService.GetTaxDisplayTypeAsync(await _workContext.GetCurrentCustomerAsync()) == TaxDisplayType.IncludingTax && !_taxSettings.ForceTaxExclusionFromOrderSubtotal;
                 var (orderSubTotalDiscountAmountBase, _, subTotalWithoutDiscountBase, _, _) = await _orderTotalCalculationService.GetShoppingCartSubTotalAsync(cart, subTotalIncludingTax);
                 var subtotalBase = subTotalWithoutDiscountBase;
                 var currentCurrency = await _workContext.GetWorkingCurrencyAsync();
@@ -1194,7 +1194,7 @@ namespace Nop.Web.Factories
                 //tax
                 bool displayTax;
                 bool displayTaxRates;
-                if (_taxSettings.HideTaxInOrderSummary && await _workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax)
+                if (_taxSettings.HideTaxInOrderSummary && await _customerService.GetTaxDisplayTypeAsync(customer) == TaxDisplayType.IncludingTax)
                 {
                     displayTax = false;
                     displayTaxRates = false;

--- a/src/Presentation/Nop.Web/Views/Product/_ProductPrice.cshtml
+++ b/src/Presentation/Nop.Web/Views/Product/_ProductPrice.cshtml
@@ -1,9 +1,11 @@
 ﻿@model ProductDetailsModel.ProductPriceModel
 
 @using Nop.Core
+@using Nop.Services.Customers
 @using Nop.Core.Domain.Tax
 
 @inject IWorkContext workContext
+@inject ICustomerService customerService
 
 @if (!Model.CustomerEntersPrice)
 {
@@ -68,7 +70,7 @@
             }
             if (Model.DisplayTaxShippingInfo)
             {
-                var inclTax = await workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax;
+                var inclTax = await customerService.GetTaxDisplayTypeAsync(await workContext.GetCurrentCustomerAsync()) == TaxDisplayType.IncludingTax;
                 //tax info is already included in the price (incl/excl tax). that's why we display only shipping info here
                 //of course, you can modify appropriate locales to include VAT info there
                 <div class="tax-shipping-info">

--- a/src/Presentation/Nop.Web/Views/Shared/Components/Footer/Default.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/Components/Footer/Default.cshtml
@@ -3,8 +3,10 @@
 @using Nop.Core
 @using Nop.Core.Domain.Tax
 @using Nop.Core.Domain.Topics
+@using Nop.Services.Customers
 
 @inject IWorkContext workContext
+@inject ICustomerService customerService
 
 <div class="footer">
     <div class="footer-upper">
@@ -120,7 +122,7 @@
             <span class="footer-disclaimer">@T("Content.CopyrightNotice", DateTime.Now.Year, Model.StoreName)</span>
             @if (Model.DisplayTaxShippingInfoFooter)
             {
-                var inclTax = await workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax;
+                var inclTax = await customerService.GetTaxDisplayTypeAsync(await workContext.GetCurrentCustomerAsync()) == TaxDisplayType.IncludingTax;
                 <span class="footer-tax-shipping">
                     @T(inclTax ? "Footer.TaxShipping.InclTax" : "Footer.TaxShipping.ExclTax", Url.RouteTopicUrl("shippinginfo"))
                 </span>

--- a/src/Presentation/Nop.Web/Views/Shared/Components/OrderSummary/Default.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/Components/OrderSummary/Default.cshtml
@@ -4,9 +4,11 @@
 @using Nop.Core.Domain.Catalog
 @using Nop.Core.Domain.Orders
 @using Nop.Core.Domain.Tax
+@using Nop.Services.Customers
 
 @inject IWebHelper webHelper
 @inject IWorkContext workContext
+@inject ICustomerService customerService
 @inject OrderSettings orderSettings
 
 <div class="order-summary-content">
@@ -219,7 +221,7 @@
             </div>
             @if (Model.IsEditable && Model.Items.Count > 0 && Model.DisplayTaxShippingInfo)
             {
-                var inclTax = await workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax;
+                var inclTax = await customerService.GetTaxDisplayTypeAsync(await workContext.GetCurrentCustomerAsync()) == TaxDisplayType.IncludingTax;
                 //tax info is already included in the price (incl/excl tax). that's why we display only shipping info here
                 //of course, you can modify appropriate locales to include VAT info there
                 <div class="tax-shipping-info">

--- a/src/Presentation/Nop.Web/Views/Shared/_ProductBox.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/_ProductBox.cshtml
@@ -4,9 +4,11 @@
 @using Nop.Core.Domain.Catalog
 @using Nop.Core.Domain.Orders
 @using Nop.Core.Domain.Tax
+@using Nop.Services.Customers
 
 @inject CatalogSettings catalogSettings
 @inject IWorkContext workContext
+@inject ICustomerService customerService
 
 @{
     //prepare "Add to cart" AJAX link
@@ -96,7 +98,7 @@
                 <span class="price actual-price">@Model.ProductPrice.Price</span>
                 @if (Model.ProductPrice.DisplayTaxShippingInfo)
                 {
-                    var inclTax = await workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax;
+                    var inclTax = await customerService.GetTaxDisplayTypeAsync(await workContext.GetCurrentCustomerAsync()) == TaxDisplayType.IncludingTax;
                     //tax info is already included in the price (incl/excl tax). that's why we display only shipping info here
                     //of course, you can modify appropriate locales to include VAT info there
                     <span class="tax-shipping-info">

--- a/src/Presentation/Nop.Web/Views/ShoppingCart/Wishlist.cshtml
+++ b/src/Presentation/Nop.Web/Views/ShoppingCart/Wishlist.cshtml
@@ -3,10 +3,11 @@
 @using Nop.Core
 @using Nop.Core.Domain.Catalog
 @using Nop.Core.Domain.Tax
+@using Nop.Services.Customers
 
+@inject ICustomerService customerService
 @inject IWebHelper webHelper
 @inject IWorkContext workContext
-
 @{
     Layout = "_ColumnsOne";
 
@@ -230,7 +231,7 @@
                     </div>
                     @if (Model.Items.Count > 0 && Model.DisplayTaxShippingInfo)
                     {
-                        var inclTax = await workContext.GetTaxDisplayTypeAsync() == TaxDisplayType.IncludingTax;
+                        var inclTax = await customerService.GetTaxDisplayTypeAsync(await workContext.GetCurrentCustomerAsync()) == TaxDisplayType.IncludingTax;
                         //tax info is already included in the price (incl/excl tax). that's why we display only shipping info here
                         //of course, you can modify appropriate locales to include VAT info there
                         <div class="tax-shipping-info">

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Factories/CommonModelFactoryTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Factories/CommonModelFactoryTests.cs
@@ -11,6 +11,7 @@ using Nop.Core.Domain.Forums;
 using Nop.Core.Domain.Localization;
 using Nop.Core.Domain.News;
 using Nop.Core.Domain.Vendors;
+using Nop.Services.Customers;
 using Nop.Services.Vendors;
 using Nop.Web.Factories;
 using Nop.Web.Models.Common;
@@ -25,6 +26,7 @@ namespace Nop.Tests.Nop.Web.Tests.Public.Factories
         private LocalizationSettings _localizationSettings;
         private IWorkContext _workContext;
         private CustomerSettings _customerSettings;
+        private CustomerService _customerService;
         private ForumSettings _forumSettings;
         private StoreInformationSettings _storeInformationSettings;
         private NewsSettings _newsSettings;
@@ -40,6 +42,7 @@ namespace Nop.Tests.Nop.Web.Tests.Public.Factories
             _localizationSettings = GetService<LocalizationSettings>();
             _workContext = GetService<IWorkContext>();
             _customerSettings = GetService<CustomerSettings>();
+            _customerService = GetService<CustomerService>();
             _forumSettings = GetService<ForumSettings>();
             _storeInformationSettings = GetService<StoreInformationSettings>();
             _newsSettings = GetService<NewsSettings>();
@@ -89,7 +92,7 @@ namespace Nop.Tests.Nop.Web.Tests.Public.Factories
         public async Task CanPrepareTaxTypeSelectorModel()
         {
             var model = await _commonModelFactory.PrepareTaxTypeSelectorModelAsync();
-            model.CurrentTaxType.Should().Be(await _workContext.GetTaxDisplayTypeAsync());
+            model.CurrentTaxType.Should().Be(await _customerService.GetTaxDisplayTypeAsync(await _workContext.GetCurrentCustomerAsync()));
         }
 
         [Test]


### PR DESCRIPTION
This PR addresses issue #6566  

* Moved GetTaxDisplayTypeAsync() from IWorkContext/WebWorkContext to ICustomerService/CustomerService
* Added Customer parameter
* Some callers already had a Customer handy, in which case I pass it in: (example: [OrderProcessingService.cs line 483](https://github.com/nopSolutions/nopCommerce/compare/develop...mike-warren-dev:nopCommerce:issue-6566-move-GetTaxDisplayTypeAsync-to-ICustomerService?expand=1#diff-4069435708f22ec14a7849f0ee21ca36c0a657865aa09f386e51db8ce6040a39))
* Some did not have a Customer handy, in which case I'm getting one from WebWorkContext.GetCurrentCustomerAsync() (example: [OrderTotalCalculationService.cs line 1073](https://github.com/nopSolutions/nopCommerce/compare/develop...mike-warren-dev:nopCommerce:issue-6566-move-GetTaxDisplayTypeAsync-to-ICustomerService?expand=1#diff-650f03649de03f1f52a2f1811d4d34568fe1f4ff42d081a05b9476e98a0542a5)). The GetTaxDisplayTypeAsync() method no longer calls GetCurrentCustomerAsync(), so as to avoid a circular dependency (which I assume is why you wanted the Customer parameter!) 