### PR TITLE
Undo null caching

### DIFF
--- a/src/Libraries/Nop.Core/Caching/DistributedCacheManager.cs
+++ b/src/Libraries/Nop.Core/Caching/DistributedCacheManager.cs
@@ -177,7 +177,7 @@ namespace Nop.Core.Caching
                 {
                     item = (T)await lazy.Value;
 
-                    if (key.CacheTime == 0)
+                    if (key.CacheTime == 0 || item == null)
                         return item;
 
                     setTask = _distributedCache.SetStringAsync(
@@ -235,10 +235,10 @@ namespace Nop.Core.Caching
             
             try
             {
+                _ongoing.TryAdd(key.Key, lazy);
                 // await the lazy task in order to force value creation instead of directly setting data
                 // this way, other cache manager instances can access it while it is being set
                 SetLocal(key.Key, await lazy.Value);
-                _ongoing.TryAdd(key.Key, lazy);
                 await _distributedCache.SetStringAsync(key.Key, JsonConvert.SerializeObject(data), PrepareEntryOptions(key));
             }
             finally

--- a/src/Libraries/Nop.Core/Caching/MemoryCacheManager.cs
+++ b/src/Libraries/Nop.Core/Caching/MemoryCacheManager.cs
@@ -115,18 +115,18 @@ namespace Nop.Core.Caching
             if ((key?.CacheTime ?? 0) <= 0)
                 return await acquire();
 
-            var value = _memoryCache.GetOrCreate(
+            var value = await _memoryCache.GetOrCreate(
                 key.Key,
                 entry =>
                 {
                     entry.SetOptions(PrepareEntryOptions(key));
                     return new Lazy<Task<T>>(acquire, true);
-                })?.Value;
+                }).Value;
 
-            if (value != null)
-                return await value;
+            if (value == null)
+                await RemoveAsync(key);
 
-            return default;
+            return value;
         }
 
         /// <summary>
@@ -221,7 +221,7 @@ namespace Nop.Core.Caching
             if (disposing)
                 // don't dispose of the MemoryCache, as it is injected
                 _clearToken.Dispose();
-            
+
             _disposed = true;
         }
 

--- a/src/Libraries/Nop.Core/Caching/MemoryCacheManager.cs
+++ b/src/Libraries/Nop.Core/Caching/MemoryCacheManager.cs
@@ -143,7 +143,7 @@ namespace Nop.Core.Caching
         {
             var value = _memoryCache.Get<Lazy<Task<T>>>(key.Key)?.Value;
 
-            return value != null ? await value : defaultValue;
+            return value != null ? (await value) ?? defaultValue : defaultValue;
         }
 
         /// <summary>


### PR DESCRIPTION
A bug seems to have been introduced regarding handling of null values in the cache, so we have made the following fixes:

- don't cache nulls in DistributedCacheManager
- the `Lazy<Task<T>>` instance from `_memoryCache.GetOrCreate` in MemoryCacheManager cannot be null, but the resulting `T` value might be - since we won't know until the task is awaited, we have to remove the key if the result is null
- as a result of the above, thread interleaving could cause a key to return a null result before it has been removed, so we need to deal with that possibility in the default value overload of `GetAsync`

I believe it would be much better if we did allow for the possibility of null caching and instead dealt with it outside the cache manager, though. Thoughts?

Best regards,
Rickard von Haugwitz
Majako [majako.net](https://www.majako.net/)