### PR TITLE
Remove null handling from memory cache

### DIFF
--- a/src/Libraries/Nop.Core/Caching/MemoryCacheManager.cs
+++ b/src/Libraries/Nop.Core/Caching/MemoryCacheManager.cs
@@ -115,18 +115,13 @@ namespace Nop.Core.Caching
             if ((key?.CacheTime ?? 0) <= 0)
                 return await acquire();
 
-            var value = await _memoryCache.GetOrCreate(
+            return await _memoryCache.GetOrCreate(
                 key.Key,
                 entry =>
                 {
                     entry.SetOptions(PrepareEntryOptions(key));
                     return new Lazy<Task<T>>(acquire, true);
                 }).Value;
-
-            if (value == null)
-                await RemoveAsync(key);
-
-            return value;
         }
 
         /// <summary>
@@ -143,7 +138,7 @@ namespace Nop.Core.Caching
         {
             var value = _memoryCache.Get<Lazy<Task<T>>>(key.Key)?.Value;
 
-            return value != null ? (await value) ?? defaultValue : defaultValue;
+            return value != null ? await value : defaultValue;
         }
 
         /// <summary>


### PR DESCRIPTION
I made a mistake with my previous pull request #6618 - because certain methods, such as [UrlRecordService.GetBySlugAsync](https://github.com/nopSolutions/nopCommerce/blob/2c130c60018be960808382496e1aeeeb0a9acc6e/src/Libraries/Nop.Services/Seo/UrlRecordService.cs#L1175) do in some cases try to cache null, instantly removing it again will cause many meaningless events to be posted on the Redis pub/sub channel when using the synchronised cache. See issue #6622.

LocalizationService.GetAllResourceValuesAsync [previously](https://github.com/nopSolutions/nopCommerce/blob/a930e574d545d8aa651ac0119907ae8751283089/src/Libraries/Nop.Services/Localization/LocalizationService.cs#L321) did something similar, and this method in particular caused huge trouble when we incorporated the latest cache changes into a 4.5 codebase but forgot to update the calling method to use the new overload of [IStaticCacheManager.GetAsync](https://github.com/nopSolutions/nopCommerce/blob/2c130c60018be960808382496e1aeeeb0a9acc6e/src/Libraries/Nop.Core/Caching/IStaticCacheManager.cs#L45) that takes a default value instead of a factory function. This method was added to address the use case where we don't want to acquire and set a new value on a cache miss, instead of trying to write null and expecting it to fail. We were hasty in assuming that the same problem would occur in the latest version, and apologise for the confusion.

Either way, since `_memoryCache.GetOrCreate` is guaranteed never to directly return null, we can simplify the original code.

Best regards,
Rickard von Haugwitz
Majako [majako.net](https://www.majako.net)