### PR TITLE
Buffer redis messages

### DIFF
--- a/src/Libraries/Nop.Core/Configuration/DistributedCacheConfig.cs
+++ b/src/Libraries/Nop.Core/Configuration/DistributedCacheConfig.cs
@@ -39,5 +39,13 @@ namespace Nop.Core.Configuration
         /// Useful when one wants to partition a single Redis server for use with multiple apps, e.g. by setting InstanceName to "development" and "production".
         /// </summary>
         public string InstanceName { get; private set; } = "nopCommerce";
+
+        /// <summary>
+        /// Gets or sets the Redis event publish interval in milliseconds.
+        /// Used when distributed cache is enabled and DistributedCacheType property is set as RedisSynchronizedMemory.
+        /// If greater than zero, events will be buffered for this long before being published in batch, in order to reduce server load.
+        /// If zero, events are published when they are raised, without buffering.
+        /// </summary>
+        public int PublishIntervalMs { get; private set; } = 500;
     }
 }

--- a/src/Libraries/Nop.Services/Caching/RedisSynchronizedMemoryCache.cs
+++ b/src/Libraries/Nop.Services/Caching/RedisSynchronizedMemoryCache.cs
@@ -115,6 +115,7 @@ namespace Nop.Services.Caching
 
         /// <summary>
         /// Publish change events on key channel
+        /// <param name="keys">The evicted entries to publish on the key channel.</param>
         /// </summary>
         protected void BatchPublishChangeEvents(params string[] keys)
         {

--- a/src/Libraries/Nop.Services/Caching/RedisSynchronizedMemoryCache.cs
+++ b/src/Libraries/Nop.Services/Caching/RedisSynchronizedMemoryCache.cs
@@ -191,9 +191,9 @@ namespace Nop.Services.Caching
         {
             if (!_disposed)
             {
+                _timer?.Dispose();
                 var subscriber = _connection.GetSubscriber();
                 subscriber.Unsubscribe(ChannelPrefix + "*");
-                _timer.Dispose();
 
                 _disposed = true;
             }

--- a/src/Libraries/Nop.Services/Caching/RedisSynchronizedMemoryCache.cs
+++ b/src/Libraries/Nop.Services/Caching/RedisSynchronizedMemoryCache.cs
@@ -92,14 +92,12 @@ namespace Nop.Services.Caching
         /// <summary>
         /// Enqueue or publish change event
         /// </summary>
-        /// <param name="key"></param>
+        /// <param name="key">The evicted cache key to be published</param>
         protected void PublishChangeEvent(object key)
         {
             var stringKey = key.ToString();
-            if (_timer == null)
-                BatchPublishChangeEvents(stringKey);
-            else
-                _messageQueue.Enqueue(stringKey);
+            if (_timer == null) BatchPublishChangeEvents(stringKey);
+            else _messageQueue.Enqueue(stringKey);
         }
 
         /// <summary>
@@ -195,6 +193,7 @@ namespace Nop.Services.Caching
             {
                 var subscriber = _connection.GetSubscriber();
                 subscriber.Unsubscribe(ChannelPrefix + "*");
+                _timer.Dispose();
 
                 _disposed = true;
             }

--- a/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
+++ b/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
@@ -4593,6 +4593,12 @@
   <LocaleResource Name="Admin.Configuration.AppSettings.DistributedCache.InstanceName.Hint">
     <Value>Specify the instance name (by default "nopCommerce")</Value>
   </LocaleResource>
+  <LocaleResource Name="Admin.Configuration.AppSettings.DistributedCache.PublishIntervalMs">
+    <Value>Publish interval (ms)</Value>
+  </LocaleResource>
+  <LocaleResource Name="Admin.Configuration.AppSettings.DistributedCache.PublishIntervalMs.Hint">
+    <Value>Specify the interval to publish key change events, in milliseconds</Value>
+  </LocaleResource>
   <LocaleResource Name="Admin.Configuration.AppSettings.EnvironmentVariablesWarning">
     <Value>Warning! The current setting value is overridden in environment variables</Value>
   </LocaleResource>

--- a/src/Presentation/Nop.Web/Areas/Admin/Models/Settings/DistributedCacheConfigModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Models/Settings/DistributedCacheConfigModel.cs
@@ -30,6 +30,9 @@ namespace Nop.Web.Areas.Admin.Models.Settings
         [NopResourceDisplayName("Admin.Configuration.AppSettings.DistributedCache.InstanceName")]
         public string InstanceName { get; private set; } = string.Empty;
 
+        [NopResourceDisplayName("Admin.Configuration.AppSettings.DistributedCache.PublishIntervalMs")]
+        public int PublishIntervalMs { get; private set; }
+
         #endregion
     }
 }

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_AppSettings.DistributedCache.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_AppSettings.DistributedCache.cshtml
@@ -95,12 +95,19 @@
                     $('#distributed-cache-table-name').showElement();
                     $('#distributed-cache-publish-interval').hideElement();
                     break;
-                case @((int)DistributedCacheType.RedisSynchronizedMemory):
-                    $('#distributed-cache-publish-interval').showElement();
-                default:
+                case @((int)DistributedCacheType.Redis):
+                    $('#distributed-cache-publish-interval').hideElement();
                     $('#distributed-cache-schema-name').hideElement();
                     $('#distributed-cache-table-name').hideElement();
                     $('#distributed-cache-instance-name').showElement();
+                    break;
+                case @((int)DistributedCacheType.RedisSynchronizedMemory):
+                    $('#distributed-cache-publish-interval').showElement();
+                    $('#distributed-cache-schema-name').hideElement();
+                    $('#distributed-cache-table-name').hideElement();
+                    $('#distributed-cache-instance-name').showElement();
+                default:
+                    break;
             }
         } else {
             $('#distributed-cache-connection-string').hideElement();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_AppSettings.DistributedCache.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_AppSettings.DistributedCache.cshtml
@@ -56,6 +56,15 @@
                 <span asp-validation-for="DistributedCacheConfigModel.InstanceName"></span>
             </div>
         </div>
+        <div class="form-group row" id="distributed-cache-publish-interval">
+            <div class="col-md-3">
+                <nop-label asp-for="DistributedCacheConfigModel.PublishIntervalMs" />
+            </div>
+            <div class="col-md-9">
+                <nop-editor asp-for="DistributedCacheConfigModel.PublishIntervalMs" />
+                <span asp-validation-for="DistributedCacheConfigModel.PublishIntervalMs"></span>
+            </div>
+        </div>
     </nop-nested-setting>
 </div>
 <script>
@@ -79,12 +88,15 @@
                     $('#distributed-cache-schema-name').hideElement();
                     $('#distributed-cache-table-name').hideElement();
                     $('#distributed-cache-instance-name').hideElement();
+                    $('#distributed-cache-publish-interval').hideElement();
                     break;
                 case @((int)DistributedCacheType.SqlServer):
                     $('#distributed-cache-schema-name').showElement();
                     $('#distributed-cache-table-name').showElement();
-                    $('#distributed-cache-instance-name').hideElement();
+                    $('#distributed-cache-publish-interval').hideElement();
                     break;
+                case @((int)DistributedCacheType.RedisSynchronizedMemory):
+                    $('#distributed-cache-publish-interval').showElement();
                 default:
                     $('#distributed-cache-schema-name').hideElement();
                     $('#distributed-cache-table-name').hideElement();
@@ -96,6 +108,7 @@
             $('#distributed-cache-table-name').hideElement();
             $('#distributed-cache-type').hideElement();
             $('#distributed-cache-instance-name').hideElement();
+            $('#distributed-cache-publish-interval').hideElement();
         }
     }
 </script>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_AppSettings.DistributedCache.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_AppSettings.DistributedCache.cshtml
@@ -93,6 +93,7 @@
                 case @((int)DistributedCacheType.SqlServer):
                     $('#distributed-cache-schema-name').showElement();
                     $('#distributed-cache-table-name').showElement();
+                    $('#distributed-cache-instance-name').hideElement();
                     $('#distributed-cache-publish-interval').hideElement();
                     break;
                 case @((int)DistributedCacheType.Redis):


### PR DESCRIPTION
We discovered a potential performance bottleneck in the Redis-synced cache where the instances could be flooded with key events (each of which spawns a new thread on the receiving side) when a lot of keys were deleted at once. To address this, we added message buffering to send updates in batch once per a set interval (default 500 ms). Setting the interval to 0 restores the original behaviour, but since instantaneous propagation cannot be guaranteed (or even achieved) in the first place, this should never be desirable.

Best regards,
Rickard von Haugwitz
Majako [majako.net](https://www.majako.net)