### PR TITLE
Add non-generic IStaticCacheManager.GetAsync

### DIFF
--- a/src/Libraries/Nop.Core/Caching/DistributedCacheManager.cs
+++ b/src/Libraries/Nop.Core/Caching/DistributedCacheManager.cs
@@ -230,10 +230,7 @@ namespace Nop.Core.Caching
         /// </returns>
         public async Task<object> GetAsync(CacheKey key)
         {
-            var value = await _distributedCache.GetStringAsync(key.Key);
-            if (value == null)
-                return null;
-            return JsonConvert.DeserializeObject(value);
+            return await GetAsync<object>(key);
         }
 
         /// <summary>

--- a/src/Libraries/Nop.Core/Caching/DistributedCacheManager.cs
+++ b/src/Libraries/Nop.Core/Caching/DistributedCacheManager.cs
@@ -128,7 +128,7 @@ namespace Nop.Core.Caching
             _ongoing.TryRemove(key, out _);
             await _distributedCache.RemoveAsync(key);
 
-            if(!removeFromInstance)
+            if (!removeFromInstance)
                 return;
 
             RemoveLocal(key);
@@ -221,6 +221,22 @@ namespace Nop.Core.Caching
         }
 
         /// <summary>
+        /// Get a cached item as an <see cref="object"/> instance, or null on a cache miss.
+        /// </summary>
+        /// <param name="key">Cache key</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation
+        /// The task result contains the cached value associated with the specified key, or null if none was found
+        /// </returns>
+        public async Task<object> GetAsync(CacheKey key)
+        {
+            var value = await _distributedCache.GetStringAsync(key.Key);
+            if (value == null)
+                return null;
+            return JsonConvert.DeserializeObject(value);
+        }
+
+        /// <summary>
         /// Add the specified key and object to the cache
         /// </summary>
         /// <param name="key">Key of cached item</param>
@@ -232,7 +248,7 @@ namespace Nop.Core.Caching
                 return;
 
             var lazy = new Lazy<Task<object>>(() => Task.FromResult(data as object), true);
-            
+
             try
             {
                 _ongoing.TryAdd(key.Key, lazy);

--- a/src/Libraries/Nop.Core/Caching/IStaticCacheManager.cs
+++ b/src/Libraries/Nop.Core/Caching/IStaticCacheManager.cs
@@ -45,6 +45,16 @@ namespace Nop.Core.Caching
         Task<T> GetAsync<T>(CacheKey key, T defaultValue = default);
 
         /// <summary>
+        /// Get a cached item as an <see cref="object"/> instance, or null on a cache miss.
+        /// </summary>
+        /// <param name="key">Cache key</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation
+        /// The task result contains the cached value associated with the specified key, or null if none was found
+        /// </returns>
+        Task<object> GetAsync(CacheKey key);
+
+        /// <summary>
         /// Remove the value with the specified key from the cache
         /// </summary>
         /// <param name="cacheKey">Cache key</param>

--- a/src/Libraries/Nop.Core/Caching/MemoryCacheManager.cs
+++ b/src/Libraries/Nop.Core/Caching/MemoryCacheManager.cs
@@ -157,6 +157,31 @@ namespace Nop.Core.Caching
         }
 
         /// <summary>
+        /// Get a cached item as an <see cref="object"/> instance, or null on a cache miss.
+        /// </summary>
+        /// <param name="key">Cache key</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation
+        /// The task result contains the cached value associated with the specified key, or null if none was found
+        /// </returns>
+        public async Task<object> GetAsync(CacheKey key)
+        {
+            var entry = _memoryCache.Get(key.Key);
+            if (entry == null)
+                return null;
+            try
+            {
+                var task = (Task)entry.GetType().GetProperty("Value").GetValue(entry);
+                await task;
+                return task.GetType().GetProperty("Result").GetValue(task);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
         /// Add the specified key and object to the cache
         /// </summary>
         /// <param name="key">Key of cached item</param>

--- a/src/Tests/Nop.Tests/Nop.Core.Tests/Caching/DistributedCacheManagerTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Core.Tests/Caching/DistributedCacheManagerTests.cs
@@ -183,5 +183,16 @@ namespace Nop.Tests.Nop.Core.Tests.Caching
             value.Should().Be(0);
             xs.Sum().Should().Be(1);
         }
+
+        [Test]
+        public async Task CanGetAsObject()
+        {
+            var key = new CacheKey("some_key_1");
+            await _staticCacheManager.SetAsync(new CacheKey("some_key_1"), 1);
+            var obj = await _staticCacheManager.GetAsync(key);
+            obj.Should().Be(1);
+            obj = await _staticCacheManager.GetAsync(new CacheKey("some_key_2"));
+            obj.Should().BeNull();
+        }
     }
 }

--- a/src/Tests/Nop.Tests/Nop.Core.Tests/Caching/DistributedCacheManagerTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Core.Tests/Caching/DistributedCacheManagerTests.cs
@@ -188,7 +188,7 @@ namespace Nop.Tests.Nop.Core.Tests.Caching
         public async Task CanGetAsObject()
         {
             var key = new CacheKey("some_key_1");
-            await _staticCacheManager.SetAsync(new CacheKey("some_key_1"), 1);
+            await _staticCacheManager.SetAsync(key, 1);
             var obj = await _staticCacheManager.GetAsync(key);
             obj.Should().Be(1);
             obj = await _staticCacheManager.GetAsync(new CacheKey("some_key_2"));

--- a/src/Tests/Nop.Tests/Nop.Core.Tests/Caching/MemoryCacheManagerTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Core.Tests/Caching/MemoryCacheManagerTests.cs
@@ -136,7 +136,7 @@ namespace Nop.Tests.Nop.Core.Tests.Caching
         public async Task CanGetAsObject()
         {
             var key = new CacheKey("some_key_1");
-            await _staticCacheManager.SetAsync(new CacheKey("some_key_1"), 1);
+            await _staticCacheManager.SetAsync(key, 1);
             var obj = await _staticCacheManager.GetAsync(key);
             obj.Should().Be(1);
             obj = await _staticCacheManager.GetAsync(new CacheKey("some_key_2"));

--- a/src/Tests/Nop.Tests/Nop.Core.Tests/Caching/MemoryCacheManagerTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Core.Tests/Caching/MemoryCacheManagerTests.cs
@@ -131,5 +131,16 @@ namespace Nop.Tests.Nop.Core.Tests.Caching
                 new CacheKey("some_key_1"),
                 Task<object> () => throw new ApplicationException()));
         }
+
+        [Test]
+        public async Task CanGetAsObject()
+        {
+            var key = new CacheKey("some_key_1");
+            await _staticCacheManager.SetAsync(new CacheKey("some_key_1"), 1);
+            var obj = await _staticCacheManager.GetAsync(key);
+            obj.Should().Be(1);
+            obj = await _staticCacheManager.GetAsync(new CacheKey("some_key_2"));
+            obj.Should().BeNull();
+        }
     }
 }


### PR DESCRIPTION
In previous versions, one could access a cached value without knowing the type beforehand by doing `await _staticCacheManager.GetAsync<object>(key, () => null)`, but this is no longer possible with the memory-cache manager. Although not used anywhere in the core codebase, it is possible some plugins are making use of this. In order to keep this functionality, we added a non-generic overload of IStaticCacheManager.GetAsync that returns an object instance instead of a typed value.