### PR TITLE
Optimise ConcurrentTrie

### DIFF
--- a/src/Libraries/Nop.Core/Infrastructure/ConcurrentTrie.cs
+++ b/src/Libraries/Nop.Core/Infrastructure/ConcurrentTrie.cs
@@ -8,9 +8,9 @@ namespace Nop.Core.Infrastructure
     public partial class ConcurrentTrie<TValue>
     {
         #region Fields
-        private volatile TrieNode _root = new();
-        private readonly StripedReaderWriterLock _locks = new();
-        private readonly ReaderWriterLockSlim _structureLock = new();
+        protected volatile TrieNode _root = new();
+        protected readonly StripedReaderWriterLock _locks = new();
+        protected readonly ReaderWriterLockSlim _structureLock = new();
 
         #endregion
 
@@ -23,7 +23,7 @@ namespace Nop.Core.Infrastructure
         {
         }
 
-        private ConcurrentTrie(TrieNode subtreeRoot)
+        protected ConcurrentTrie(TrieNode subtreeRoot)
         {
             _root.Children[subtreeRoot.Label[0]] = subtreeRoot;
         }
@@ -486,7 +486,7 @@ namespace Nop.Core.Infrastructure
 
         protected class TrieNode
         {
-            private class ValueWrapper
+            protected class ValueWrapper
             {
                 public readonly TValue Value;
 
@@ -497,11 +497,11 @@ namespace Nop.Core.Infrastructure
             }
 
             // used to avoid keeping a separate boolean flag that would use another byte per node
-            private static readonly ValueWrapper _deleted = new(default);
+            protected static readonly ValueWrapper _deleted = new(default);
 
             public readonly string Label;
             public readonly Dictionary<char, TrieNode> Children = new();
-            private volatile ValueWrapper _value;
+            protected volatile ValueWrapper _value;
 
             public bool IsDeleted => _value == _deleted;
             public bool HasValue => _value != null && !IsDeleted;

--- a/src/Libraries/Nop.Core/Infrastructure/ConcurrentTrie.cs
+++ b/src/Libraries/Nop.Core/Infrastructure/ConcurrentTrie.cs
@@ -1,90 +1,307 @@
-﻿using System.Collections.Concurrent;
+﻿using System.Runtime.CompilerServices;
 
 namespace Nop.Core.Infrastructure
 {
     /// <summary>
-    /// A thread-safe implementation of a trie, or prefix tree
+    /// A thread-safe implementation of a radix tree
     /// </summary>
     public partial class ConcurrentTrie<TValue>
     {
         #region Fields
-
-        protected readonly TrieNode _root;
-        protected readonly string _prefix;
+        private volatile TrieNode _root = new();
+        private readonly StripedReaderWriterLock _locks = new();
+        private readonly ReaderWriterLockSlim _structureLock = new();
 
         #endregion
 
         #region Ctor
 
-        public ConcurrentTrie() : this(new(), string.Empty)
+        /// <summary>
+        /// Initializes a new empty instance of <see cref="ConcurrentTrie{TValue}" />
+        /// </summary>
+        public ConcurrentTrie()
         {
         }
 
-        protected ConcurrentTrie(TrieNode root, string prefix)
+        private ConcurrentTrie(TrieNode subtreeRoot)
         {
-            _root = root;
-            _prefix = prefix;
+            _root.Children[subtreeRoot.Label[0]] = subtreeRoot;
         }
 
         #endregion
 
         #region Utilities
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected static int GetCommonPrefixLength(ReadOnlySpan<char> s1, ReadOnlySpan<char> s2)
+        {
+            var i = 0;
+            var minLength = Math.Min(s1.Length, s2.Length);
+            for (; i < minLength && s2[i] == s1[i]; i++)
+                ;
+            return i;
+        }
+
         /// <summary>
-        /// Adds a node if key does not already exist.
+        /// Gets a lock on the node's children
         /// </summary>
-        /// <param name="key">The key</param>
-        /// <returns>The <see cref="TrieNode"/> item</returns>
-        protected virtual TrieNode GetOrAddNode(string key)
+        /// <remarks>
+        /// May return the same lock for two different nodes, so the user needs to check to avoid lock recursion exceptions
+        /// </remarks>
+        protected virtual ReaderWriterLockSlim GetLock(TrieNode node)
+        {
+            return _locks.GetLock(node.Children);
+        }
+
+        protected virtual bool Find(string key, TrieNode subtreeRoot, out TrieNode node)
+        {
+            node = subtreeRoot;
+            if (key.Length == 0)
+                return true;
+            var suffix = key.AsSpan();
+            while (true)
+            {
+                var nodeLock = GetLock(node);
+                nodeLock.EnterReadLock();
+                try
+                {
+                    if (!node.Children.TryGetValue(suffix[0], out node))
+                        return false;
+                }
+                finally { nodeLock.ExitReadLock(); }
+                var span = node.Label.AsSpan();
+                var i = GetCommonPrefixLength(suffix, span);
+                if (i == span.Length)
+                {
+                    if (i == suffix.Length)
+                        return node.HasValue;
+                    suffix = suffix[i..];
+                    continue;
+                }
+                return false;
+            }
+        }
+
+        protected virtual TrieNode GetOrAddNode(ReadOnlySpan<char> key, TValue value, bool overwrite = false)
         {
             var node = _root;
-
-            foreach (var c in key)
-                node = node.Children.GetOrAdd(c, _ => new());
-
-            return node;
-        }
-
-        /// <summary>
-        /// Try to find the node by key
-        /// </summary>
-        /// <param name="key">The key</param>
-        /// <param name="node">The <see cref="TrieNode"/> item</param>
-        /// <returns>True if item is exists</returns>
-        protected virtual bool Find(string key, out TrieNode node)
-        {
-            node = _root;
-
-            foreach (var c in key)
-                if (!node.Children.TryGetValue(c, out node))
-                    return false;
-
-            return true;
-        }
-
-        /// <summary>
-        /// Remove the node
-        /// </summary>
-        /// <param name="node">The <see cref="TrieNode"/> item</param>
-        /// <param name="key">The key</param>
-        /// <returns>True if item is deleted</returns>
-        protected virtual bool Remove(TrieNode node, string key)
-        {
-            if (key.Length == 0)
+            var suffix = key;
+            ReaderWriterLockSlim nodeLock;
+            char c;
+            TrieNode nextNode;
+            _structureLock.EnterReadLock();
+            try
             {
-                if (node.GetValue(out _))
-                    node.RemoveValue();
-
-                return !node.Children.IsEmpty;
+                while (true)
+                {
+                    c = suffix[0];
+                    nodeLock = GetLock(node);
+                    nodeLock.EnterUpgradeableReadLock();
+                    try
+                    {
+                        if (node.Children.TryGetValue(c, out nextNode))
+                        {
+                            var label = nextNode.Label.AsSpan();
+                            var i = GetCommonPrefixLength(label, suffix);
+                            if (i == label.Length)   // suffix starts with label
+                            {
+                                if (i == suffix.Length)    // keys are equal - this is the node we're looking for
+                                {
+                                    if (overwrite)
+                                        nextNode.SetValue(value);
+                                    else
+                                        nextNode.GetOrAddValue(value);
+                                    return nextNode;
+                                }
+                                // advance the suffix and continue the search from nextNode
+                                suffix = suffix[label.Length..];
+                                node = nextNode;
+                                continue;
+                            }
+                            // we need to add a node, but don't want to hold an upgradeable read lock on _structureLock
+                            // since only one can be held at a time, so we break, release the lock and reacquire a write lock
+                            break;
+                        }
+                        // if there is no child starting with c, we can just add and return one
+                        nodeLock.EnterWriteLock();
+                        try
+                        {
+                            var suffixNode = new TrieNode(suffix.ToString());
+                            suffixNode.SetValue(value);
+                            return node.Children[c] = suffixNode;
+                        }
+                        finally { nodeLock.ExitWriteLock(); }
+                    }
+                    finally { nodeLock.ExitUpgradeableReadLock(); }
+                }
             }
+            finally { _structureLock.ExitReadLock(); }
 
-            var c = key[0];
+            // If we need to restructure the tree, we do it after releasing and reacquiring the lock.
+            // However, another thread may have restructured around the node we're on in the meantime,
+            // and in that case we need to retry the insertion
+            _structureLock.EnterWriteLock();
+            nodeLock.EnterUpgradeableReadLock();
+            try
+            {
+                // we use while instead of if so we can break
+                while (!node.IsDeleted && node.Children.TryGetValue(c, out nextNode))
+                {
+                    var label = nextNode.Label.AsSpan();
+                    var i = GetCommonPrefixLength(label, suffix);
+                    if (i == label.Length)   // suffix starts with label?
+                    {
+                        if (i == suffix.Length)    // if the keys are equal, the key has already been inserted
+                        {
+                            if (overwrite)
+                                nextNode.SetValue(value);
+                            return nextNode;
+                        }
+                        // structure has changed since last; try again
+                        break;
+                    }
+                    var splitNode = new TrieNode(suffix[..i].ToString());
+                    splitNode.Children[label[i]] = new TrieNode(label[i..].ToString(), nextNode);
+                    TrieNode outNode;
+                    if (i == suffix.Length) // label starts with suffix, so we can return splitNode
+                        outNode = splitNode;
+                    else    // the keys diverge, so we need to branch from splitNode
+                        splitNode.Children[suffix[i]] = outNode = new TrieNode(suffix[i..].ToString());
+                    outNode.SetValue(value);
+                    nodeLock.EnterWriteLock();
+                    try
+                    {
+                        node.Children[c] = splitNode;
+                    }
+                    finally { nodeLock.ExitWriteLock(); }
+                    return outNode;
+                }
+            }
+            finally
+            {
+                nodeLock.ExitUpgradeableReadLock();
+                _structureLock.ExitWriteLock();
+            }
+            // we failed to add a node, so we have to retry;
+            // the recursive call is placed at the end to enable tail-recursion optimisation
+            return GetOrAddNode(key, value, overwrite);
+        }
 
-            if (node.Children.TryGetValue(c, out var child))
-                if (!Remove(child, key[1..]))
-                    node.Children.TryRemove(new(c, child));
+        protected virtual void Remove(TrieNode subtreeRoot, ReadOnlySpan<char> key)
+        {
+            TrieNode node = null, grandparent = null;
+            var parent = subtreeRoot;
+            var i = 0;
+            _structureLock.EnterReadLock();
+            try
+            {
+                while (i < key.Length)
+                {
+                    var c = key[i];
+                    var parentLock = GetLock(parent);
+                    parentLock.EnterReadLock();
+                    try
+                    {
+                        if (!parent.Children.TryGetValue(c, out node))
+                            return;
+                    }
+                    finally { parentLock.ExitReadLock(); }
+                    var label = node.Label.AsSpan();
+                    var k = GetCommonPrefixLength(key[i..], label);
+                    if (k == label.Length && k == key.Length - i)   // is this the node we're looking for?
+                    {
+                        if (node.TryRemoveValue(out _))
+                            break;  // this node has to be removed or merged
+                        return; // the node is either already removed, or it is a branching node
+                    }
+                    if (k < label.Length)
+                        return;
+                    i += label.Length;
+                    grandparent = parent;
+                    parent = node;
+                }
+            }
+            finally { _structureLock.ExitReadLock(); }
 
-            return true;
+            if (node == null)
+                return;
+
+            // if we need to delete a node, the tree has to be restructured to remove empty leaves or merge
+            // single children with branching node parents, and other threads may be currently on these nodes
+            _structureLock.EnterWriteLock();
+            try
+            {
+                var nodeLock = GetLock(node);
+                var parentLock = GetLock(parent);
+                var grandparentLock = grandparent != null ? GetLock(grandparent) : null;
+                var lockAlreadyHeld = nodeLock == parentLock || nodeLock == grandparentLock;
+                if (lockAlreadyHeld)
+                    nodeLock.EnterUpgradeableReadLock();
+                else
+                    nodeLock.EnterReadLock();
+                try
+                {
+                    if (node.HasValue)
+                        return;  // another thread has written a value to the node while we were waiting
+
+                    var c = node.Label[0];
+                    var nChildren = node.Children.Count;
+                    if (nChildren == 0) // if the node has no children, we can just remove it
+                    {
+                        parentLock.EnterWriteLock();
+                        try
+                        {
+                            if (!parent.Children.TryGetValue(c, out var n) || n != node)
+                                return;  // was removed or replaced by another thread
+                            parent.Children.Remove(c);
+                            node.Delete();
+                            // since we removed a node, we may be able to merge a lone sibling with the parent
+                            if (parent.Children.Count == 1 && grandparent != null && !parent.HasValue)
+                            {
+                                var grandparentLockAlreadyHeld = grandparentLock == parentLock;
+                                if (!grandparentLockAlreadyHeld)
+                                    grandparentLock.EnterWriteLock();
+                                try
+                                {
+                                    c = parent.Label[0];
+                                    if (!grandparent.Children.TryGetValue(c, out n) || n != parent || parent.HasValue)
+                                        return;
+                                    var child = parent.Children.First().Value;
+                                    grandparent.Children[c] = new TrieNode(parent.Label + child.Label, child);
+                                    parent.Delete();
+                                }
+                                finally
+                                {
+                                    if (!grandparentLockAlreadyHeld)
+                                        grandparentLock.ExitWriteLock();
+                                }
+                            }
+                        }
+                        finally { parentLock.ExitWriteLock(); }
+                    }
+                    else if (nChildren == 1)    // if there is a single child, we can merge it with node
+                    {
+                        parentLock.EnterWriteLock();
+                        try
+                        {
+                            if (!parent.Children.TryGetValue(c, out var n) || n != node)
+                                return;  // was removed or replaced by another thread
+                            var child = node.Children.FirstOrDefault().Value;
+                            parent.Children[c] = new TrieNode(node.Label + child.Label, child);
+                            node.Delete();
+                        }
+                        finally { parentLock.ExitWriteLock(); }
+                    }
+                }
+                finally
+                {
+                    if (lockAlreadyHeld)
+                        nodeLock.ExitUpgradeableReadLock();
+                    else
+                        nodeLock.ExitReadLock();
+                }
+            }
+            finally { _structureLock.ExitWriteLock(); }
         }
 
         #endregion
@@ -94,7 +311,7 @@ namespace Nop.Core.Infrastructure
         /// <summary>
         /// Attempts to get the value associated with the specified key
         /// </summary>
-        /// <param name="key">The key of the item to get (case-insensitive)</param>
+        /// <param name="key">The key of the item to get (case-sensitive)</param>
         /// <param name="value">The value associated with <paramref name="key"/>, if found</param>
         /// <returns>
         /// True if the key was found, otherwise false
@@ -105,20 +322,20 @@ namespace Nop.Core.Infrastructure
                 throw new ArgumentNullException(nameof(key));
 
             value = default;
-            return Find(key, out var node) && node.GetValue(out value);
+            return Find(key, _root, out var node) && node.TryGetValue(out value);
         }
 
         /// <summary>
         /// Adds a key-value pair to the trie
         /// </summary>
-        /// <param name="key">The key of the new item (case-insensitive)</param>
+        /// <param name="key">The key of the new item (case-sensitive)</param>
         /// <param name="value">The value to be associated with <paramref name="key"/></param>
         public virtual void Add(string key, TValue value)
         {
             if (string.IsNullOrEmpty(key))
                 throw new ArgumentException($"'{nameof(key)}' cannot be null or empty.", nameof(key));
 
-            GetOrAddNode(key).SetValue(value);
+            GetOrAddNode(key, value, true);
         }
 
         /// <summary>
@@ -126,13 +343,13 @@ namespace Nop.Core.Infrastructure
         /// </summary>
         public virtual void Clear()
         {
-            _root.Children.Clear();
+            _root = new();
         }
 
         /// <summary>
         /// Gets all key-value pairs for keys starting with the given prefix
         /// </summary>
-        /// <param name="prefix">The prefix to search for (case-insensitive)</param>
+        /// <param name="prefix">The prefix (case-sensitive) to search for</param>
         /// <returns>
         /// All key-value pairs for keys starting with <paramref name="prefix"/>
         /// </returns>
@@ -141,17 +358,26 @@ namespace Nop.Core.Infrastructure
             if (prefix is null)
                 throw new ArgumentNullException(nameof(prefix));
 
-            if (!Find(prefix, out var node))
+            if (!Find(prefix, _root, out var node))
                 return Enumerable.Empty<KeyValuePair<string, TValue>>();
 
             // depth-first traversal
             IEnumerable<KeyValuePair<string, TValue>> traverse(TrieNode n, string s)
             {
-                if (n.GetValue(out var value))
-                    yield return new KeyValuePair<string, TValue>(_prefix + s, value);
-                foreach (var (c, child) in n.Children)
+                if (n.TryGetValue(out var value))
+                    yield return new KeyValuePair<string, TValue>(s, value);
+                var nLock = GetLock(n);
+                nLock.EnterReadLock();
+                List<TrieNode> children;
+                try
                 {
-                    foreach (var kv in traverse(child, s + c))
+                    // we can't know what is done during enumeration, so we need to make a copy of the children
+                    children = n.Children.Values.ToList();
+                }
+                finally { nLock.ExitReadLock(); }
+                foreach (var child in children)
+                {
+                    foreach (var kv in traverse(child, s + child.Label))
                         yield return kv;
                 }
             }
@@ -161,57 +387,83 @@ namespace Nop.Core.Infrastructure
         /// <summary>
         /// Removes the item with the given key, if present
         /// </summary>
-        /// <param name="key">The key of the item to be removed (case-insensitive)</param>
-        public virtual void Remove(string key)
+        /// <param name="key">The key (case-sensitive) of the item to be removed</param>
+        public void Remove(string key)
         {
+            if (string.IsNullOrEmpty(key))
+                throw new ArgumentException($"'{nameof(key)}' cannot be null or empty.", nameof(key));
+
             Remove(_root, key);
         }
 
         /// <summary>
         /// Gets the value with the specified key, adding a new item if one does not exist
         /// </summary>
-        /// <param name="key">The key of the item to be deleted (case-insensitive)</param>
+        /// <param name="key">The key (case-sensitive) of the item to be deleted</param>
         /// <param name="valueFactory">A function for producing a new value if one was not found</param>
         /// <returns>
         /// The existing value for the given key, if found, otherwise the newly inserted value
         /// </returns>
-        public virtual TValue GetOrAdd(string key, Func<TValue> valueFactory)
+        public TValue GetOrAdd(string key, TValue value)
         {
-            var node = GetOrAddNode(key);
-            if (node.GetValue(out var value))
-                return value;
-            value = valueFactory();
-            node.SetValue(value);
-            return value;
+            if (string.IsNullOrEmpty(key))
+                throw new ArgumentException($"'{nameof(key)}' cannot be null or empty.", nameof(key));
+
+            // the value is already set when we get the node if it already exists, but we call GetOrAddValue anyway to get the value
+            return GetOrAddNode(key, value).GetOrAddValue(value);
         }
 
         /// <summary>
         /// Attempts to remove all items with keys starting with the specified prefix
         /// </summary>
-        /// <param name="prefix">The prefix of the items to be deleted (case-insensitive)</param>
+        /// <param name="prefix">The prefix (case-sensitive) of the items to be deleted</param>
         /// <param name="subtree">The subtree containing all deleted items, if found</param>
         /// <returns>
         /// True if the prefix was successfully removed from the trie, otherwise false
         /// </returns>
         public virtual bool Prune(string prefix, out ConcurrentTrie<TValue> subtree)
         {
-            if (string.IsNullOrEmpty(prefix))
-                throw new ArgumentException($"'{nameof(prefix)}' cannot be null or empty.", nameof(prefix));
+            if (prefix is null)
+                throw new ArgumentNullException(nameof(prefix));
 
             subtree = default;
             var node = _root;
-            TrieNode parent = null;
-            char last = default;
-            foreach (var c in prefix)
+            var parent = node;
+            var span = prefix.AsSpan();
+            var i = 0;
+            while (i < span.Length)
             {
+                var c = span[i];
+                var parentLock = GetLock(parent);
+                parentLock.EnterUpgradeableReadLock();
+                try
+                {
+                    if (!parent.Children.TryGetValue(c, out node))
+                        return false;
+                    var label = node.Label.AsSpan();
+                    var k = GetCommonPrefixLength(span[i..], label);
+                    if (k == span.Length - i)
+                    {
+                        parentLock.EnterWriteLock();
+                        try
+                        {
+                            if (parent.Children.Remove(c, out node))
+                            {
+                                subtree = new(new TrieNode(prefix[..i] + node.Label, node));
+                                return true;
+                            }
+                        }
+                        finally { parentLock.ExitWriteLock(); }
+                        return false;   // was removed by another thread
+                    }
+                    if (k < label.Length)
+                        return false;
+                    i += label.Length;
+                }
+                finally { parentLock.ExitUpgradeableReadLock(); }
                 parent = node;
-                if (!node.Children.TryGetValue(c, out node))
-                    return false;
-                last = c;
             }
-            if (parent?.Children.TryRemove(last, out var subtreeRoot) == true)
-                subtree = new ConcurrentTrie<TValue>(subtreeRoot, prefix);
-            return true;
+            return false;
         }
 
         #endregion
@@ -219,83 +471,89 @@ namespace Nop.Core.Infrastructure
         #region Properties
 
         /// <summary>
-        /// Keys
+        /// Gets a collection that contains the keys in the <see cref="ConcurrentTrie{TValue}" />
         /// </summary>
-        public virtual IEnumerable<string> Keys => Search(string.Empty).Select(kv => kv.Key);
+        public IEnumerable<string> Keys => Search(string.Empty).Select(t => t.Key);
 
         /// <summary>
-        /// Values
+        /// Gets a collection that contains the values in the <see cref="ConcurrentTrie{TValue}" />
         /// </summary>
-        public virtual IEnumerable<TValue> Values => Search(string.Empty).Select(kv => kv.Value);
+        public IEnumerable<TValue> Values => Search(string.Empty).Select(t => t.Value);
 
         #endregion
 
         #region Nested class
 
-        /// <summary>
-        /// A thread-safe implementation of a trie node
-        /// </summary>
         protected class TrieNode
         {
-            #region Fields
-
-            protected readonly ReaderWriterLockSlim _lock = new();
-            protected (bool hasValue, TValue value) _value;
-
-            #endregion
-
-            #region Utilities
-
-            protected virtual void SetValue(TValue value, bool hasValue)
+            private class ValueWrapper
             {
-                _lock.EnterWriteLock();
+                public readonly TValue Value;
 
-                try
+                public ValueWrapper(TValue value)
                 {
-                    _value = (hasValue, value);
-                }
-                finally
-                {
-                    _lock.ExitWriteLock();
+                    Value = value;
                 }
             }
 
-            #endregion
+            // used to avoid keeping a separate boolean flag that would use another byte per node
+            private static readonly ValueWrapper _deleted = new(default);
 
-            #region Methods
+            public readonly string Label;
+            public readonly Dictionary<char, TrieNode> Children = new();
+            private volatile ValueWrapper _value;
 
-            public virtual bool GetValue(out TValue value)
+            public bool IsDeleted => _value == _deleted;
+            public bool HasValue => _value != null && !IsDeleted;
+
+            public TrieNode(string label = "")
             {
-                _lock.EnterReadLock();
-                try
+                Label = label;
+            }
+
+            public TrieNode(string label, TrieNode node) : this(label)
+            {
+                Children = node.Children;
+                _value = node._value;
+            }
+
+            public bool TryGetValue(out TValue value)
+            {
+                var wrapper = _value;
+                value = default;
+                if (wrapper == null)
+                    return false;
+                value = wrapper.Value;
+                return true;
+            }
+
+            public bool TryRemoveValue(out TValue value)
+            {
+                var wrapper = Interlocked.Exchange(ref _value, null);
+                if (wrapper == null)
                 {
-                    (var hasValue, value) = _value;
-
-                    return hasValue;
+                    value = default;
+                    return false;
                 }
-                finally
-                {
-                    _lock.ExitReadLock();
-                }
+                value = wrapper.Value;
+                return true;
             }
 
-            public virtual void SetValue(TValue value)
+            public void SetValue(TValue value)
             {
-                SetValue(value, true);
+                _value = new(value);
             }
 
-            public virtual void RemoveValue()
+            public TValue GetOrAddValue(TValue value)
             {
-                SetValue(default, false);
+                var wrapper = Interlocked.CompareExchange(ref _value, new(value), null);
+                return wrapper != null ? wrapper.Value : value;
             }
 
-            #endregion
-
-            #region Properties
-
-            public readonly ConcurrentDictionary<char, TrieNode> Children = new();
-
-            #endregion
+            public void Delete()
+            {
+                _value = _deleted;
+            }
         }
 
         #endregion

--- a/src/Libraries/Nop.Core/Infrastructure/StripedReaderWriterLock.cs
+++ b/src/Libraries/Nop.Core/Infrastructure/StripedReaderWriterLock.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Threading;
-
-namespace Nop.Core.Infrastructure
+﻿namespace Nop.Core.Infrastructure
 {
     /// <summary>
     /// A striped ReaderWriterLock wrapper

--- a/src/Libraries/Nop.Core/Infrastructure/StripedReaderWriterLock.cs
+++ b/src/Libraries/Nop.Core/Infrastructure/StripedReaderWriterLock.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading;
+
+namespace Nop.Core.Infrastructure
+{
+    /// <summary>
+    /// A striped ReaderWriterLock wrapper
+    /// </summary>
+    public class StripedReaderWriterLock
+    {
+        private readonly ReaderWriterLockSlim[] _locks;
+        private readonly int _mask;
+
+        // defaults to 8 times the number of processor cores
+        public StripedReaderWriterLock() : this((int)Math.Log2(Environment.ProcessorCount) + 3)
+        {
+        }
+
+        public StripedReaderWriterLock(int nLocksExp)
+        {
+            var n = 1 << nLocksExp;
+            _mask = n - 1;
+            _locks = new ReaderWriterLockSlim[n];
+            for (var i = 0; i < n; i++)
+                _locks[i] = new ReaderWriterLockSlim(LockRecursionPolicy.NoRecursion);
+        }
+
+        public ReaderWriterLockSlim GetLock(object obj)
+        {
+            return _locks[obj.GetHashCode() & _mask];
+        }
+
+        public ReadOnlySpan<ReaderWriterLockSlim> GetAllLocks()
+        {
+            return _locks.AsSpan();
+        }
+    }
+}

--- a/src/Tests/Nop.Tests/Nop.Core.Tests/Infrastructure/ConcurrentTrieTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Core.Tests/Infrastructure/ConcurrentTrieTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Diagnostics;
+using FluentAssertions;
 using Nop.Core.Infrastructure;
 using NUnit.Framework;
 
@@ -32,6 +33,19 @@ namespace Nop.Tests.Nop.Core.Tests.Infrastructure
             value.Should().Be(1);
             sut.TryGetValue("abc", out value).Should().BeTrue();
             value.Should().Be(3);
+            sut.Add("ab", 2);
+            sut.TryGetValue("ab", out value).Should().BeTrue();
+            value.Should().Be(2);
+        }
+
+        [Test]
+        public void DoesNotBlockWhileEnumerating()
+        {
+            var sut = new ConcurrentTrie<int>();
+            sut.Add("a", 0);
+            sut.Add("ab", 0);
+            foreach (var item in sut.Keys)
+                sut.Remove(item);
         }
 
         [Test]
@@ -39,13 +53,24 @@ namespace Nop.Tests.Nop.Core.Tests.Infrastructure
         {
             var sut = new ConcurrentTrie<int>();
             sut.Add("a", 1);
+            sut.Add("b", 1);
+            sut.Add("bbb", 1);
             sut.Add("ab", 1);
+            sut.Add("aa", 1);
             sut.Add("abc", 1);
+            sut.Add("abb", 1);
             sut.Remove("ab");
             sut.TryGetValue("ab", out _).Should().BeFalse();
-            sut.TryGetValue("abc", out _).Should().BeTrue();
-            sut.TryGetValue("a", out _).Should().BeTrue();
+            sut.Keys.Should().BeEquivalentTo(new[] { "abc", "a", "b", "aa", "abb", "bbb" });
             Assert.DoesNotThrow(() => sut.Remove("ab"));
+            sut.Remove("bb");
+            sut.TryGetValue("b", out _).Should().BeTrue();
+            sut.TryGetValue("bbb", out _).Should().BeTrue();
+
+            sut.Prune("b", out sut);
+            sut.Keys.Should().BeEquivalentTo(new[] { "b", "bbb" });
+            sut.Remove("b");
+            sut.Keys.Should().BeEquivalentTo(new[] { "bbb" });
         }
 
         [Test]
@@ -75,15 +100,37 @@ namespace Nop.Tests.Nop.Core.Tests.Infrastructure
             var sut = new ConcurrentTrie<int>();
             sut.Add("a", 1);
             sut.Add("b", 1);
+            sut.Add("bba", 1);
+            sut.Add("bbb", 1);
             sut.Add("ab", 1);
             sut.Add("abc", 1);
             sut.Add("abd", 1);
+            sut.Prune("bc", out _).Should().BeFalse();
             sut.Prune("ab", out var subtree).Should().BeTrue();
             subtree.Keys.Should().BeEquivalentTo(new[] { "ab", "abc", "abd" });
-            sut.Keys.Should().BeEquivalentTo(new[] { "a", "b" });
+            sut.Keys.Should().BeEquivalentTo(new[] { "a", "b", "bba", "bbb" });
             sut.Prune("b", out subtree).Should().BeTrue();
-            subtree.Keys.Should().BeEquivalentTo(new[] { "b" });
+            subtree.Keys.Should().BeEquivalentTo(new[] { "b", "bba", "bbb" });
             sut.Keys.Should().BeEquivalentTo(new[] { "a" });
+
+            sut = subtree;
+            sut.Prune("bb", out subtree).Should().BeTrue();
+            subtree.Keys.Should().BeEquivalentTo(new[] { "bba", "bbb" });
+            sut.Keys.Should().BeEquivalentTo(new[] { "b" });
+            sut = subtree;
+            sut.Prune("bba", out subtree);
+            subtree.Keys.Should().BeEquivalentTo(new[] { "bba" });
+            sut.Keys.Should().BeEquivalentTo(new[] { "bbb" });
+
+            sut = new ConcurrentTrie<int>();
+            sut.Add("aaa", 1);
+            sut.Prune("a", out subtree).Should().BeTrue();
+            subtree.Keys.Should().BeEquivalentTo(new[] { "aaa" });
+            sut.Keys.Should().BeEmpty();
+            sut = subtree;
+            sut.Prune("aa", out subtree).Should().BeTrue();
+            sut.Keys.Should().BeEmpty();
+            subtree.Keys.Should().BeEquivalentTo(new[] { "aaa" });
         }
 
         [Test]
@@ -112,6 +159,74 @@ namespace Nop.Tests.Nop.Core.Tests.Infrastructure
             sut.Add("abc", 1);
             sut.Clear();
             sut.Keys.Should().BeEmpty();
+        }
+
+        [Test]
+        [Ignore("Not a test, used for profiling.")]
+        public void Profile()
+        {
+            var sut = new ConcurrentTrie<byte>();
+            var sw = new Stopwatch();
+            var memory = GC.GetTotalMemory(true);
+            sw.Start();
+            for (var i = 0; i < 1000000; i++)
+                sut.Add(Guid.NewGuid().ToString(), 0);
+            sw.Stop();
+            var delta = GC.GetTotalMemory(true) - memory;
+            Console.WriteLine(sw.ElapsedMilliseconds);
+            Console.WriteLine(delta);
+        }
+
+        [Test]
+        [Ignore("Concurrency tests are inherently flaky, and may give false positives. Enable manually when needed.")]
+        public void DoesNotBreakDuringParallelAddRemove()
+        {
+            var sut = new ConcurrentTrie<int>();
+            var sw = new Stopwatch();
+            var memory = GC.GetTotalMemory(true);
+            sw.Start();
+            Parallel.For(0, 1000, new ParallelOptions { MaxDegreeOfParallelism = 8 }, j =>
+            {
+                for (var i = 0; i < 1000; i++)
+                {
+                    var s = $"{i}-{j}";
+                    sut.Add(s, i);
+                    sut.TryGetValue(s, out var value).Should().BeTrue();
+                    value.Should().Be(i);
+                    sut.Remove(s);
+                    sut.TryGetValue(s, out _).Should().BeFalse();
+                }
+            });
+            sw.Stop();
+            var delta = GC.GetTotalMemory(true) - memory;
+            Console.WriteLine(sw.ElapsedMilliseconds);
+            Console.WriteLine(delta);
+            sut.Keys.Count().Should().Be(0);
+        }
+
+        [Test]
+        [Ignore("Concurrency tests are inherently flaky, and may give false positives. Enable manually when needed.")]
+        public void DoesNotBreakDuringParallelAddPrune()
+        {
+            var sut = new ConcurrentTrie<int>();
+            var sw = new Stopwatch();
+            var memory = GC.GetTotalMemory(true);
+            sw.Start();
+            Parallel.For(0, 1000, new ParallelOptions { MaxDegreeOfParallelism = 8 }, j =>
+            {
+                for (var i = 0; i < 1000; i++)
+                {
+                    var s = $"{j}-{i}";
+                    sut.Add(s, i);
+                }
+                sut.Prune($"{j}-", out var st);
+                st.Keys.Count().Should().Be(1000);
+            });
+            sw.Stop();
+            var delta = GC.GetTotalMemory(true) - memory;
+            Console.WriteLine(sw.ElapsedMilliseconds);
+            Console.WriteLine(delta);
+            sut.Keys.Count().Should().Be(0);
         }
     }
 }


### PR DESCRIPTION
Due to space-complexity problems with the previous ConcurrentTrie, and the time-complexity issues with using a simple ConcurrentDictionary, I have completely rewritten ConcurrentTrie to optimise for both time and memory.

- Instead of a naïve trie, ConcurrentTrie is now implemented as a radix tree (see [https://en.wikipedia.org/wiki/Radix_tree](https://en.wikipedia.org/wiki/Radix_tree)).
- Due to the significant memory overhead caused by having a ConcurrentDictionary in each node, children are stored in regular dictionaries and locking is done outside.
- Instead of keeping one lock per node, the lock striping pattern is used with a fixed number (eight times the number of processor cores) of shared locks.
- Values are stored and manipulated in a lockless manner using volatile fields and the Interlocked class.
- String comparisons are performed with ReadOnlySpan to avoid allocating and copying substrings.

I had preferred to avoid making this kind of changes, as it severely impacts the readability of the code, but I recommend starting from the tests and benchmarks to review the code.

We have been running the code in production for almost a week already, and memory and CPU usage are both more stable than ever (see response times comparison below), and we have not encountered any unexpected behaviour so far. Memory usage grows in $O(n)$ for $n$ keys even with random UUID keys, and insertion, deletion and removal by prefix are all in $O(k)$ for key length $k$.

![response time comparison](https://user-images.githubusercontent.com/44768499/228610176-120c7877-6510-4121-b19d-249e1a9bdb7b.png)

Since we recognise that maintaining this sort of code can be difficult (and due to the lack of existing open-source implementations), we plan to set up a public repository to release it separately. We will then update the file here with a link to that repository for issue reporting and feature requests.

Best regards,
Rickard von Haugwitz
Majako [majako.net](https://www.majako.net)