### PR TITLE
Fix array indexing in StripedReaderWriterLock

### DIFF
--- a/src/Libraries/Nop.Core/Infrastructure/ConcurrentTrie.cs
+++ b/src/Libraries/Nop.Core/Infrastructure/ConcurrentTrie.cs
@@ -589,7 +589,6 @@ namespace Nop.Core.Infrastructure
 
             protected const int MULTIPLIER = 8;
             protected readonly ReaderWriterLockSlim[] _locks;
-            protected readonly int _mask;
 
             #endregion
 
@@ -601,7 +600,6 @@ namespace Nop.Core.Infrastructure
                 if(nLocks == 0)
                     nLocks = Environment.ProcessorCount * MULTIPLIER;
 
-                _mask = nLocks - 1;
                 _locks = new ReaderWriterLockSlim[nLocks];
 
                 for (var i = 0; i < nLocks; i++)
@@ -617,7 +615,7 @@ namespace Nop.Core.Infrastructure
             /// </summary>
             public ReaderWriterLockSlim GetLock(object obj)
             {
-                return _locks[obj.GetHashCode() & _mask];
+                return _locks[obj.GetHashCode() % _locks.Length];
             }
 
             #endregion


### PR DESCRIPTION
@skoshelev since I used a bit mask to index the locks array, we can't just allow any number of locks - only powers of 2 will work for that. It probably doesn't matter here since processor cores always (I think) come in powers of 2 and we have hardcoded the multiple to 8, but it's still wrong. If you insist on allowing arbitrary values of nLocks, we should remove _mask and replace `& _mask` with `% _locks.Length`, as I have done here. Modulus is a slightly slower operation than masking, and since we use powers of 2 anyway I thought we might as well make use of it, but to be fair the time saved is minimal (on the order of a ms or so per million operations) and is overshadowed by basically everything else we do.