### PR TITLE
Add new edit type - select

### DIFF
--- a/src/Presentation/Nop.Web.Framework/Models/DataTables/ColumnProperty.cs
+++ b/src/Presentation/Nop.Web.Framework/Models/DataTables/ColumnProperty.cs
@@ -1,4 +1,6 @@
-﻿namespace Nop.Web.Framework.Models.DataTables
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace Nop.Web.Framework.Models.DataTables
 {
     /// <summary>
     /// Represent DataTables column property
@@ -17,6 +19,7 @@
             //set default values
             Visible = true;
             Encode = true;
+            DropDownItems = new List<SelectListItem>();
         }
 
         #endregion
@@ -83,6 +86,11 @@
         /// Enable or disable encode on the data in this column.
         /// </summary>
         public bool Encode { get; set; }
+
+        /// <summary>
+        /// Set the dropdown items.
+        /// </summary>
+        public IEnumerable<SelectListItem> DropDownItems { get; set; }
 
         #endregion
     }

--- a/src/Presentation/Nop.Web.Framework/Models/DataTables/EditType.cs
+++ b/src/Presentation/Nop.Web.Framework/Models/DataTables/EditType.cs
@@ -7,6 +7,7 @@
     {
         Number = 1,
         Checkbox = 2,
-        String = 3
+        String = 3,
+        Select = 4
     }
 }

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/Table.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/Table.cshtml
@@ -246,7 +246,7 @@
                     if (columnType == 'select')
                     {
                         var selectedValue = editRowData_@(tableName)[cellName],
-                            html = '<select class="userinput" style="width: 99%;height:30px">';
+                            html = '<select class="userinput" style="width: 99%;height: 30px">';
 
                         items.forEach(function (item){
                              html += `<option value="${item.Value}" ${item.Value == selectedValue ? 'selected' : ''} ${item.Disabled ? 'disabled' : ''}">${item.Text}</option>`;

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/Table.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/Table.cshtml
@@ -172,7 +172,8 @@
                 var obj = {
                     'Data': '@column.Data',
                     'Editable': @column.Editable.ToString().ToLowerInvariant(),
-                    'Type': '@column.EditType.ToString().ToLowerInvariant()'
+                    'Type': '@column.EditType.ToString().ToLowerInvariant()',
+                    'Items': @Json.Serialize(column.DropDownItems)
                 }
                 columnData_@(tableName).push(obj);
                 </text>
@@ -217,11 +218,12 @@
 
             function setEditStateValue_@(tableName)(curRow) {
                 for (var cellName in editRowData_@(tableName)) {
-                    var columnType = 'string';
+                    var columnType = 'string', items = [];
 
                     $.each(columnData_@(tableName), function (index, element) {
                         if (element.Data == cellName) {
                             columnType = element.Type;
+                            items = element.Items;
                         }
                     });
 
@@ -240,6 +242,19 @@
                     if (columnType == 'string') {
                         var strValue = editRowData_@(tableName)[cellName];
                         $($(curRow).children("[data-columnname='" + cellName + "']")[0]).html('<input value="' + escapeQuotHtml(strValue) + '" class="userinput"  style="width: 99% " />');
+                    }
+                    if (columnType == 'select')
+                    {
+                        var selectedValue = editRowData_@(tableName)[cellName],
+                            html = '<select class="userinput" style="width: 99%;height:30px">';
+
+                        items.forEach(function (item){
+                             html += `<option value="${item.Value}" ${item.Value == selectedValue ? 'selected' : ''} ${item.Disabled ? 'disabled' : ''}">${item.Text}</option>`;
+                        });
+
+                        html += '</select>';
+
+                        $($(curRow).children("[data-columnname='" + cellName + "']")[0]).html(html);
                     }
                     $('#@Model.Name').DataTable().columns.adjust();
                 }
@@ -274,7 +289,8 @@
                 updateRowData.push({ 'pname': nameData, 'pvalue': data });
                 $.each(columnData_@(tableName), function (index, element) {
                     if (element.Editable == true) {
-                        var value = $($($(currentCells).children("[data-columnname='" + element.Data + "']")).children('input')[0]).val();
+                        var tagType = element.Type == "select" ? "select" : "input";
+                        var value = $($($(currentCells).children("[data-columnname='" + element.Data + "']")).children(tagType)[0]).val();
                         updateRowData.push({
                             'pname': element.Data, 'pvalue': value
                         });


### PR DESCRIPTION
I needed to customize a new logic in the admin panel. I added a new column I can edit after the' Edit' button click. It was the type of picture. But when I edited I could change only as string, but I needed to choose a property from select. Thought that it can be useful for other people.

How it looks:

![1](https://user-images.githubusercontent.com/38912029/235238547-7976a5c7-07ce-4329-855d-af80ff3b089c.png)

How to use it (Example):

![2](https://user-images.githubusercontent.com/38912029/235238655-78093cd6-87d1-41a3-bc7b-58dd0c4c9a04.png)
