### PR TITLE
Feature: homepage featured blog posts

### DIFF
--- a/src/Libraries/Nop.Core/Domain/Blogs/BlogPost.cs
+++ b/src/Libraries/Nop.Core/Domain/Blogs/BlogPost.cs
@@ -77,5 +77,10 @@ namespace Nop.Core.Domain.Blogs
         /// Gets or sets the date and time of entity creation
         /// </summary>
         public DateTime CreatedOnUtc { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to show a blog post on the main page
+        /// </summary>
+        public bool ShowBlogPostOnMainPage { get; set; }
     }
 }

--- a/src/Libraries/Nop.Core/Domain/Blogs/BlogSettings.cs
+++ b/src/Libraries/Nop.Core/Domain/Blogs/BlogSettings.cs
@@ -46,5 +46,10 @@ namespace Nop.Core.Domain.Blogs
         /// Gets or sets a value indicating whether blog comments will be filtered per store
         /// </summary>
         public bool ShowBlogCommentsPerStore { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to show blogs on the main page
+        /// </summary>
+        public bool ShowBlogsOnMainPage { get; set; }
     }
 }

--- a/src/Libraries/Nop.Core/Domain/Blogs/BlogSettings.cs
+++ b/src/Libraries/Nop.Core/Domain/Blogs/BlogSettings.cs
@@ -50,6 +50,6 @@ namespace Nop.Core.Domain.Blogs
         /// <summary>
         /// Gets or sets a value indicating whether to show blogs on the main page
         /// </summary>
-        public bool ShowBlogsOnMainPage { get; set; }
+        public bool ShowBlogOnMainPage { get; set; }
     }
 }

--- a/src/Libraries/Nop.Data/Migrations/UpgradeTo470/DataMigration.cs
+++ b/src/Libraries/Nop.Data/Migrations/UpgradeTo470/DataMigration.cs
@@ -118,8 +118,8 @@ namespace Nop.Data.Migrations.UpgradeTo470
                 // delete picture column after moving data to value piture table
                 Delete.Column(columnName).FromTable(productAttributeValueTableName);
             }
-            //add all needed local string resources for new blog feature.
             
+            //add all needed local string resources for new blog feature.
             if (!_dataProvider.GetTable<LocaleStringResource>().Any(lsr => string.Compare(lsr.ResourceName, "Admin.Configuration.Settings.Blog.ShowBlogOnMainPage", StringComparison.InvariantCultureIgnoreCase) == 0))
             {
                 var blogOnMainPageRes = _dataProvider.InsertEntity(
@@ -156,6 +156,16 @@ namespace Nop.Data.Migrations.UpgradeTo470
                     new LocaleStringResource{
                         ResourceName = "admin.configuration.settings.blog.showblogonmainpage.hint",
                         ResourceValue = "Check to show this blog post on home page",
+                        LanguageId = 1
+                    }
+                );
+            }
+            if (!_dataProvider.GetTable<LocaleStringResource>().Any(lsr => string.Compare(lsr.ResourceName, "Blog.ViewAll", StringComparison.InvariantCultureIgnoreCase) == 0))
+            {
+                var blogOnMainPageRes = _dataProvider.InsertEntity(
+                    new LocaleStringResource{
+                        ResourceName = "blog.viewall",
+                        ResourceValue = "View all blogs",
                         LanguageId = 1
                     }
                 );

--- a/src/Libraries/Nop.Data/Migrations/UpgradeTo470/DataMigration.cs
+++ b/src/Libraries/Nop.Data/Migrations/UpgradeTo470/DataMigration.cs
@@ -1,5 +1,6 @@
 ﻿using FluentMigrator;
 using Nop.Core.Domain.Catalog;
+using Nop.Core.Domain.Localization;
 using Nop.Core.Domain.Logging;
 using Nop.Core.Domain.Media;
 
@@ -116,6 +117,48 @@ namespace Nop.Data.Migrations.UpgradeTo470
 
                 // delete picture column after moving data to value piture table
                 Delete.Column(columnName).FromTable(productAttributeValueTableName);
+            }
+            //add all needed local string resources for new blog feature.
+            
+            if (!_dataProvider.GetTable<LocaleStringResource>().Any(lsr => string.Compare(lsr.ResourceName, "Admin.Configuration.Settings.Blog.ShowBlogOnMainPage", StringComparison.InvariantCultureIgnoreCase) == 0))
+            {
+                var blogOnMainPageRes = _dataProvider.InsertEntity(
+                    new LocaleStringResource{
+                        ResourceName = "admin.configuration.settings.blog.showblogonmainpage",
+                        ResourceValue = "Show blog posts on home page",
+                        LanguageId = 1
+                    }
+                );
+            }
+            if (!_dataProvider.GetTable<LocaleStringResource>().Any(lsr => string.Compare(lsr.ResourceName, "Admin.Configuration.Settings.Blog.ShowBlogOnMainPage.Hint", StringComparison.InvariantCultureIgnoreCase) == 0))
+            {
+                var blogOnMainPageRes = _dataProvider.InsertEntity(
+                    new LocaleStringResource{
+                        ResourceName = "admin.configuration.settings.blog.showblogonmainpage.hint",
+                        ResourceValue = "Check to Show featured blog posts on home page",
+                        LanguageId = 1
+                    }
+                );
+            }
+            if (!_dataProvider.GetTable<LocaleStringResource>().Any(lsr => string.Compare(lsr.ResourceName, "Admin.ContentManagement.Blog.BlogPosts.Fields.ShowBlogPostOnMainPage", StringComparison.InvariantCultureIgnoreCase) == 0))
+            {
+                var blogOnMainPageRes = _dataProvider.InsertEntity(
+                    new LocaleStringResource{
+                        ResourceName = "admin.contentManagement.blog.blogPosts.fields.showblogpostonmainpage",
+                        ResourceValue = "Show post on home page",
+                        LanguageId = 1
+                    }
+                );
+            }
+            if (!_dataProvider.GetTable<LocaleStringResource>().Any(lsr => string.Compare(lsr.ResourceName, "Admin.Configuration.Settings.Blog.ShowBlogOnMainPage.Hint", StringComparison.InvariantCultureIgnoreCase) == 0))
+            {
+                var blogOnMainPageRes = _dataProvider.InsertEntity(
+                    new LocaleStringResource{
+                        ResourceName = "admin.configuration.settings.blog.showblogonmainpage.hint",
+                        ResourceValue = "Check to show this blog post on home page",
+                        LanguageId = 1
+                    }
+                );
             }
         }
 

--- a/src/Libraries/Nop.Data/Migrations/UpgradeTo470/ShowBlogsOnMainPage.cs
+++ b/src/Libraries/Nop.Data/Migrations/UpgradeTo470/ShowBlogsOnMainPage.cs
@@ -1,0 +1,21 @@
+using FluentMigrator;
+using Nop.Core.Domain.Blogs;
+namespace Nop.Data.Migrations.UpgradeTo470{
+   
+    [NopSchemaMigration("2023-05-14 15:15:00", "Add new columns to blogPost and blogSettings")]
+    public class ShowBlogsOnMainPage:AutoReversingMigration{        
+        public override void Up()
+        {
+            if (!Schema.Table(nameof(BlogSettings)).Column(nameof(BlogSettings.ShowBlogsOnMainPage)).Exists()){
+                Alter.Table(nameof(BlogSettings))
+                    .AddColumn(nameof(BlogSettings.ShowBlogsOnMainPage)).AsBoolean().WithDefaultValue(false);
+            }
+
+            if (!Schema.Table(nameof(BlogPost)).Column(nameof(BlogPost.ShowBlogPostOnMainPage)).Exists()){
+                Alter.Table(nameof(BlogPost))
+                    .AddColumn(nameof(BlogPost.ShowBlogPostOnMainPage)).AsBoolean().WithDefaultValue(false);
+            }
+
+        }
+    }
+}

--- a/src/Libraries/Nop.Data/Migrations/UpgradeTo470/ShowBlogsOnMainPage.cs
+++ b/src/Libraries/Nop.Data/Migrations/UpgradeTo470/ShowBlogsOnMainPage.cs
@@ -1,21 +1,16 @@
-using FluentMigrator;
+﻿using FluentMigrator;
 using Nop.Core.Domain.Blogs;
-namespace Nop.Data.Migrations.UpgradeTo470{
-   
+namespace Nop.Data.Migrations.UpgradeTo470
+{
+
     [NopSchemaMigration("2023-05-14 15:15:00", "Add new columns to blogPost and blogSettings")]
-    public class ShowBlogsOnMainPage:AutoReversingMigration{        
+    public class ShowBlogOnMainPage:AutoReversingMigration{
         public override void Up()
         {
-            if (!Schema.Table(nameof(BlogSettings)).Column(nameof(BlogSettings.ShowBlogsOnMainPage)).Exists()){
-                Alter.Table(nameof(BlogSettings))
-                    .AddColumn(nameof(BlogSettings.ShowBlogsOnMainPage)).AsBoolean().WithDefaultValue(false);
-            }
-
             if (!Schema.Table(nameof(BlogPost)).Column(nameof(BlogPost.ShowBlogPostOnMainPage)).Exists()){
                 Alter.Table(nameof(BlogPost))
                     .AddColumn(nameof(BlogPost.ShowBlogPostOnMainPage)).AsBoolean().WithDefaultValue(false);
             }
-
         }
     }
 }

--- a/src/Libraries/Nop.Services/Blogs/BlogService.cs
+++ b/src/Libraries/Nop.Services/Blogs/BlogService.cs
@@ -158,8 +158,7 @@ namespace Nop.Services.Blogs
         /// A task that represents the asynchronous operation
         /// The task result contains the blog posts
         /// </returns>
-        public virtual async Task<IPagedList<BlogPost>> GetAllFeaturedBlogPostsAsync(int storeId = 0,
-            int languageId = 0,
+        public virtual async Task<IPagedList<BlogPost>> GetAllFeaturedBlogPostsAsync(int languageId = 0,int storeId = 0,
             int pageIndex = 0, int pageSize = int.MaxValue, bool showHidden = false)
         {
            

--- a/src/Libraries/Nop.Services/Blogs/BlogService.cs
+++ b/src/Libraries/Nop.Services/Blogs/BlogService.cs
@@ -146,6 +146,39 @@ namespace Nop.Services.Blogs
         }
 
         /// <summary>
+        /// Gets all blog posts
+        /// </summary>
+        /// <param name="storeId">The store identifier; pass 0 to load all records</param>
+        /// <param name="languageId">Language identifier. 0 if you want to get all blog posts</param>
+        /// <param name="tag">Tag</param>
+        /// <param name="pageIndex">Page index</param>
+        /// <param name="pageSize">Page size</param>
+        /// <param name="showHidden">A value indicating whether to show hidden records</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation
+        /// The task result contains the blog posts
+        /// </returns>
+        public virtual async Task<IPagedList<BlogPost>> GetAllFeaturedBlogPostsAsync(int storeId = 0,
+            int languageId = 0,
+            int pageIndex = 0, int pageSize = int.MaxValue, bool showHidden = false)
+        {
+           
+            //we load all records and only then filter them by tag
+            var blogPostsAll = await GetAllBlogPostsAsync(storeId: storeId, languageId: languageId, showHidden: showHidden);
+            var featuredBlogPosts = new List<BlogPost>();
+            foreach (var blogPost in blogPostsAll)
+            {
+                if(blogPost.ShowBlogPostOnMainPage){
+                    featuredBlogPosts.Add(blogPost);
+                }
+            }
+
+            //server-side paging
+            var result = new PagedList<BlogPost>(featuredBlogPosts, pageIndex, pageSize);
+            return result;
+        }
+
+        /// <summary>
         /// Gets all blog post tags
         /// </summary>
         /// <param name="storeId">The store identifier; pass 0 to load all records</param>

--- a/src/Libraries/Nop.Services/Blogs/IBlogService.cs
+++ b/src/Libraries/Nop.Services/Blogs/IBlogService.cs
@@ -64,6 +64,23 @@ namespace Nop.Services.Blogs
             int pageIndex = 0, int pageSize = int.MaxValue, bool showHidden = false);
 
         /// <summary>
+        /// Gets all blog posts
+        /// </summary>
+        /// <param name="storeId">The store identifier; pass 0 to load all records</param>
+        /// <param name="languageId">Language identifier. 0 if you want to get all blog posts</param>
+        /// <param name="pageIndex">Page index</param>
+        /// <param name="pageSize">Page size</param>
+        /// <param name="showHidden">A value indicating whether to show hidden records</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation
+        /// The task result contains the blog posts
+        /// </returns>
+        Task<IPagedList<BlogPost>> GetAllFeaturedBlogPostsAsync(int storeId = 0,
+            int languageId = 0,
+            int pageIndex = 0, int pageSize = int.MaxValue, bool showHidden = false);
+
+
+        /// <summary>
         /// Gets all blog post tags
         /// </summary>
         /// <param name="storeId">The store identifier; pass 0 to load all records</param>

--- a/src/Libraries/Nop.Services/Blogs/IBlogService.cs
+++ b/src/Libraries/Nop.Services/Blogs/IBlogService.cs
@@ -75,8 +75,7 @@ namespace Nop.Services.Blogs
         /// A task that represents the asynchronous operation
         /// The task result contains the blog posts
         /// </returns>
-        Task<IPagedList<BlogPost>> GetAllFeaturedBlogPostsAsync(int storeId = 0,
-            int languageId = 0,
+        Task<IPagedList<BlogPost>> GetAllFeaturedBlogPostsAsync(int languageId = 0, int storeId = 0, 
             int pageIndex = 0, int pageSize = int.MaxValue, bool showHidden = false);
 
 

--- a/src/Libraries/Nop.Services/Installation/InstallationService.cs
+++ b/src/Libraries/Nop.Services/Installation/InstallationService.cs
@@ -3339,7 +3339,8 @@ namespace Nop.Services.Installation
                 NumberOfTags = 15,
                 ShowHeaderRssUrl = false,
                 BlogCommentsMustBeApproved = false,
-                ShowBlogCommentsPerStore = false
+                ShowBlogCommentsPerStore = false,
+                ShowBlogOnMainPage = false
             });
             await settingService.SaveSettingAsync(new NewsSettings
             {

--- a/src/Presentation/Nop.Web.Framework/Infrastructure/PublicWidgetZones.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/PublicWidgetZones.cs
@@ -124,6 +124,7 @@
         public static string HomepageBeforeBestSellers => "home_page_before_best_sellers";
         public static string HomepageBeforeCategories => "home_page_before_categories";
         public static string HomepageBeforeNews => "home_page_before_news";
+        public static string HomepageBeforeFeaturedBlogPosts => "home_page_before_featured_blog_posts";
         public static string HomepageBeforePoll => "home_page_before_poll";
         public static string HomepageBeforeProducts => "home_page_before_products";
         public static string HomepageBottom => "home_page_bottom";

--- a/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
+++ b/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
@@ -5715,6 +5715,12 @@
   <LocaleResource Name="Admin.Configuration.Settings.Blog.PostsPageSize.Hint">
     <Value>Set the page size for posts.</Value>
   </LocaleResource>
+  <LocaleResource Name="Admin.Configuration.Settings.Blog.ShowBlogOnMainPage">
+    <Value>Show on home page</Value>
+  </LocaleResource>
+  <LocaleResource Name="Admin.Configuration.Settings.Blog.ShowBlogOnMainPage.Hint">
+    <Value>Set blog to be shown on home page</Value>
+  </LocaleResource>
   <LocaleResource Name="Admin.Configuration.Settings.Blog.ShowBlogCommentsPerStore">
     <Value>Blog comments per store</Value>
   </LocaleResource>
@@ -10313,6 +10319,12 @@
   </LocaleResource>
   <LocaleResource Name="Admin.ContentManagement.Blog.BlogPosts.Fields.Comments">
     <Value>View comments</Value>
+  </LocaleResource>
+  <LocaleResource Name="Admin.ContentManagement.Blog.BlogPosts.Fields.ShowBlogPostOnMainPage">
+    <Value>show on home page</Value>
+  </LocaleResource>
+  <LocaleResource Name="Admin.ContentManagement.Blog.BlogPosts.Fields.ShowBlogPostOnMainPage.Hint">
+    <Value>Set blog post to be shown on home page</Value>
   </LocaleResource>
   <LocaleResource Name="Admin.ContentManagement.Blog.BlogPosts.Fields.CreatedOn">
     <Value>Created on</Value>

--- a/src/Presentation/Nop.Web/Areas/Admin/Controllers/SettingController.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Controllers/SettingController.cs
@@ -255,6 +255,7 @@ namespace Nop.Web.Areas.Admin.Controllers
                 //this behavior can increase performance because cached settings will not be cleared 
                 //and loaded from database after each update
                 await _settingService.SaveSettingOverridablePerStoreAsync(blogSettings, x => x.Enabled, model.Enabled_OverrideForStore, storeScope, false);
+                await _settingService.SaveSettingOverridablePerStoreAsync(blogSettings, x => x.ShowBlogOnMainPage, model.ShowBlogOnMainPage_OverrideForStore, storeScope, false);
                 await _settingService.SaveSettingOverridablePerStoreAsync(blogSettings, x => x.PostsPageSize, model.PostsPageSize_OverrideForStore, storeScope, false);
                 await _settingService.SaveSettingOverridablePerStoreAsync(blogSettings, x => x.AllowNotRegisteredUsersToLeaveComments, model.AllowNotRegisteredUsersToLeaveComments_OverrideForStore, storeScope, false);
                 await _settingService.SaveSettingOverridablePerStoreAsync(blogSettings, x => x.NotifyAboutNewBlogComments, model.NotifyAboutNewBlogComments_OverrideForStore, storeScope, false);

--- a/src/Presentation/Nop.Web/Areas/Admin/Factories/SettingModelFactory.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Factories/SettingModelFactory.cs
@@ -914,6 +914,7 @@ namespace Nop.Web.Areas.Admin.Factories
             model.NumberOfTags_OverrideForStore = await _settingService.SettingExistsAsync(blogSettings, x => x.NumberOfTags, storeId);
             model.ShowHeaderRssUrl_OverrideForStore = await _settingService.SettingExistsAsync(blogSettings, x => x.ShowHeaderRssUrl, storeId);
             model.BlogCommentsMustBeApproved_OverrideForStore = await _settingService.SettingExistsAsync(blogSettings, x => x.BlogCommentsMustBeApproved, storeId);
+            model.ShowBlogOnMainPage_OverrideForStore = await _settingService.SettingExistsAsync(blogSettings, x => x.ShowBlogOnMainPage, storeId);
 
             return model;
         }

--- a/src/Presentation/Nop.Web/Areas/Admin/Infrastructure/Mapper/AdminMapperConfiguration.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Infrastructure/Mapper/AdminMapperConfiguration.cs
@@ -301,7 +301,8 @@ namespace Nop.Web.Areas.Admin.Infrastructure.Mapper
                 .ForMember(model => model.NotifyAboutNewBlogComments_OverrideForStore, options => options.Ignore())
                 .ForMember(model => model.NumberOfTags_OverrideForStore, options => options.Ignore())
                 .ForMember(model => model.PostsPageSize_OverrideForStore, options => options.Ignore())
-                .ForMember(model => model.ShowHeaderRssUrl_OverrideForStore, options => options.Ignore());
+                .ForMember(model => model.ShowHeaderRssUrl_OverrideForStore, options => options.Ignore())
+                .ForMember(model => model.ShowBlogOnMainPage_OverrideForStore, options => options.Ignore());
             CreateMap<BlogSettingsModel, BlogSettings>();
         }
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Models/Blogs/BlogPostModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Models/Blogs/BlogPostModel.cs
@@ -78,6 +78,8 @@ namespace Nop.Web.Areas.Admin.Models.Blogs
         [NopResourceDisplayName("Admin.ContentManagement.Blog.BlogPosts.Fields.CreatedOn")]
         public DateTime CreatedOn { get; set; }
 
+        [NopResourceDisplayName("Admin.ContentManagement.Blog.BlogPosts.Fields.ShowBlogPostOnMainPage")]
+        public bool ShowBlogPostOnMainPage { get; set; }
         //store mapping
         [NopResourceDisplayName("Admin.ContentManagement.Blog.BlogPosts.Fields.LimitedToStores")]
         public IList<int> SelectedStoreIds { get; set; }

--- a/src/Presentation/Nop.Web/Areas/Admin/Models/Settings/BlogSettingsModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Models/Settings/BlogSettingsModel.cs
@@ -43,6 +43,9 @@ namespace Nop.Web.Areas.Admin.Models.Settings
         [NopResourceDisplayName("Admin.Configuration.Settings.Blog.ShowBlogCommentsPerStore")]
         public bool ShowBlogCommentsPerStore { get; set; }
 
+        [NopResourceDisplayName("Admin.Configuration.Settings.Blog.ShowBlogOnMainPage")]
+        public bool ShowBlogOnMainPage { get; set; }
+        public bool ShowBlogOnMainPage_OverrideForStore { get; set; }
         #endregion
     }
 }

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Blog/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Blog/_CreateOrUpdate.Info.cshtml
@@ -85,6 +85,15 @@
     </div>
     <div class="form-group row">
         <div class="col-md-3">
+            <nop-label asp-for="ShowBlogPostOnMainPage" />
+        </div>
+        <div class="col-md-9">
+            <nop-editor asp-for="ShowBlogPostOnMainPage" />
+            <span asp-validation-for="ShowBlogPostOnMainPage"></span>
+        </div>
+    </div>
+    <div class="form-group row">
+        <div class="col-md-3">
             <nop-label asp-for="IncludeInSitemap" />
         </div>
         <div class="col-md-9">

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_Blog.Common.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_Blog.Common.cshtml
@@ -11,6 +11,16 @@
             <span asp-validation-for="Enabled"></span>
         </div>
     </div>
+    <div class="form-group row">
+        <div class="col-md-3">
+            <nop-override-store-checkbox asp-for="ShowBlogOnMainPage_OverrideForStore" asp-input="ShowBlogOnMainPage" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />
+            <nop-label asp-for="ShowBlogOnMainPage" />
+        </div>
+        <div class="col-md-9">
+            <nop-editor asp-for="ShowBlogOnMainPage" />
+            <span asp-validation-for="ShowBlogOnMainPage"></span>
+        </div>
+    </div>
     <div class="form-group row advanced-setting">
         <div class="col-md-3">
             <nop-override-store-checkbox asp-for="PostsPageSize_OverrideForStore" asp-input="PostsPageSize" asp-store-scope="@Model.ActiveStoreScopeConfiguration" />

--- a/src/Presentation/Nop.Web/Components/HomepageBlogPostsViewComponent.cs
+++ b/src/Presentation/Nop.Web/Components/HomepageBlogPostsViewComponent.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+using Nop.Core.Domain.Blogs;
+using Nop.Web.Factories;
+using Nop.Web.Framework.Components;
+namespace Nop.Web.Components
+{
+    public partial class HomepageBlogPostsViewComponent : NopViewComponent{
+        protected readonly IBlogModelFactory _blogModelFactory;
+        protected readonly BlogSettings _blogSettings;
+        public HomepageBlogPostsViewComponent(IBlogModelFactory blogModelFactory, BlogSettings blogSetting){
+            _blogModelFactory = blogModelFactory;
+            _blogSettings = blogSetting;
+        }
+
+        public async Task<IViewComponentResult> InvokeAsync()
+        {
+            if (!_blogSettings.Enabled || !_blogSettings.ShowBlogOnMainPage)
+                return Content("");
+
+            var model = await _blogModelFactory.PrepareHomepageBlogPostItemsModelAsync();
+            return View(model);
+        }
+    }
+}

--- a/src/Presentation/Nop.Web/Factories/IBlogModelFactory.cs
+++ b/src/Presentation/Nop.Web/Factories/IBlogModelFactory.cs
@@ -44,7 +44,14 @@ namespace Nop.Web.Factories
         /// The task result contains the list of blog post year model
         /// </returns>
         Task<List<BlogPostYearModel>> PrepareBlogPostYearModelAsync();
-
+        /// <summary>
+        /// Prepare the home page blog items model
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous operation
+        /// The task result contains the home page blog items model
+        /// </returns>
+        Task<HomepageBlogPostItemsModel> PrepareHomepageBlogPostItemsModelAsync();
         /// <summary>
         /// Prepare blog comment model
         /// </summary>

--- a/src/Presentation/Nop.Web/Infrastructure/Cache/NopModelCacheDefaults.cs
+++ b/src/Presentation/Nop.Web/Infrastructure/Cache/NopModelCacheDefaults.cs
@@ -257,6 +257,15 @@ namespace Nop.Web.Infrastructure.Cache
         public static string NewsPrefixCacheKey => "Nop.pres.news";
 
         /// <summary>
+        /// Key for home page news
+        /// </summary>
+        /// <remarks>
+        /// {0} : language ID
+        /// {1} : current store ID
+        /// </remarks>
+        public static CacheKey HomepageBlogModelKey => new("Nop.pres.blog.homepage-{0}-{1}", BlogPrefixCacheKey);
+        
+        /// <summary>
         /// Key for logo
         /// </summary>
         /// <remarks>

--- a/src/Presentation/Nop.Web/Models/Blogs/BlogPostModel.cs
+++ b/src/Presentation/Nop.Web/Models/Blogs/BlogPostModel.cs
@@ -20,6 +20,7 @@ namespace Nop.Web.Models.Blogs
         public string Body { get; set; }
         public string BodyOverview { get; set; }
         public bool AllowComments { get; set; }
+        public bool ShowBlogPostOnMainPage { get; set; }
         public bool PreventNotRegisteredUsersToLeaveComments { get; set; }
         public int NumberOfComments { get; set; }
         public DateTime CreatedOn { get; set; }

--- a/src/Presentation/Nop.Web/Models/Blogs/HomepageBlogPostsItemsModel.cs
+++ b/src/Presentation/Nop.Web/Models/Blogs/HomepageBlogPostsItemsModel.cs
@@ -1,0 +1,12 @@
+using Nop.Web.Framework.Models;
+namespace Nop.Web.Models.Blogs{
+    public partial record HomepageBlogPostItemsModel : BaseNopModel{
+        public HomepageBlogPostItemsModel(){
+            BlogPostItems = new List<BlogPostModel>();
+        }
+
+        public int WorkingLanguageId { get; set; }
+        public IList<BlogPostModel> BlogPostItems { get; set; }
+    }
+
+}

--- a/src/Presentation/Nop.Web/Themes/DefaultClean/Content/css/styles.css
+++ b/src/Presentation/Nop.Web/Themes/DefaultClean/Content/css/styles.css
@@ -1011,6 +1011,7 @@ label, label + * {
 .header-logo a img {
   max-width: 100%;
   opacity: 1;
+  width: 50px;
 }
 
 .search-box form {
@@ -5686,7 +5687,22 @@ label, label + * {
   color: #4ab2f1;
 }
 
-
+.blog-post-list-homepage .title{
+  margin: 0 0 -1px;
+  border-bottom: 1px solid #ddd;
+  padding: 0 0 15px;
+  font-size: 30px;
+  font-weight: normal;
+  color: #444;
+}
+.blog-post-list-homepage .title strong{
+  font-weight: normal;
+}
+.blog-post-list-homepage .home-post .buttons{
+  float: none;
+  width: 100%;
+  text-align: center;
+}
 /*** FORUM & PROFILE ***/
 
 
@@ -8577,7 +8593,17 @@ label, label + * {
     text-align: justify;
   }
 
-
+  .blog-post-list-homepage .home-post{
+    float: left;
+    width: 31.33333%;
+    margin: 0 1% 30px;
+  }
+  .blog-post-list-homepage .blog-posts{
+    overflow: hidden;
+  }
+  .blog-post-list-homepage .home-post:nth-child(3n+1) {
+    clear: both;
+  }
   /*** FORUM & PROFILE ***/
 
 

--- a/src/Presentation/Nop.Web/Themes/DefaultClean/Content/css/styles.css
+++ b/src/Presentation/Nop.Web/Themes/DefaultClean/Content/css/styles.css
@@ -1011,7 +1011,7 @@ label, label + * {
 .header-logo a img {
   max-width: 100%;
   opacity: 1;
-  width: 50px;
+  max-height: 50px;
 }
 
 .search-box form {
@@ -5701,6 +5701,9 @@ label, label + * {
 .blog-post-list-homepage .home-post .buttons{
   float: none;
   width: 100%;
+  text-align: center;
+}
+.blog-post-list-homepage .view-all{
   text-align: center;
 }
 /*** FORUM & PROFILE ***/

--- a/src/Presentation/Nop.Web/Views/Home/Index.cshtml
+++ b/src/Presentation/Nop.Web/Views/Home/Index.cshtml
@@ -37,6 +37,7 @@
         @await Component.InvokeAsync(typeof(HomepageBestSellersViewComponent))
         @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.HomepageBeforeNews })
         @await Component.InvokeAsync(typeof(HomepageNewsViewComponent))
+        @await Component.InvokeAsync(typeof(HomepageBlogPostsViewComponent))
         @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.HomepageBeforePoll })
         @await Component.InvokeAsync(typeof(HomepagePollsViewComponent))
         @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.HomepageBottom })

--- a/src/Presentation/Nop.Web/Views/Home/Index.cshtml
+++ b/src/Presentation/Nop.Web/Views/Home/Index.cshtml
@@ -37,6 +37,7 @@
         @await Component.InvokeAsync(typeof(HomepageBestSellersViewComponent))
         @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.HomepageBeforeNews })
         @await Component.InvokeAsync(typeof(HomepageNewsViewComponent))
+        @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.HomepageBeforeFeaturedBlogPosts })
         @await Component.InvokeAsync(typeof(HomepageBlogPostsViewComponent))
         @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.HomepageBeforePoll })
         @await Component.InvokeAsync(typeof(HomepagePollsViewComponent))

--- a/src/Presentation/Nop.Web/Views/Shared/Components/HomepageBlogPosts/Default.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/Components/HomepageBlogPosts/Default.cshtml
@@ -1,0 +1,32 @@
+﻿@model HomepageBlogPostItemsModel
+
+@using Nop.Core.Domain.Blogs
+
+@if (Model.BlogPostItems.Count > 0)
+{
+    <div class="blog-post-list-homepage">
+        <div class="title">
+            <strong>@T("Blog")</strong>
+        </div>
+        <div class="blog-posts">
+            @foreach (var item in Model.BlogPostItems)
+            {
+                <div class="home-post">
+                    <div class="post-head">
+                        <a class="post-title" href="@(Url.RouteUrl<BlogPost>(new { SeName = item.SeName }))">@item.Title</a>
+                    </div>
+                    <div class="post-body">
+                        @Html.Raw(!string.IsNullOrEmpty(item.BodyOverview) ? item.BodyOverview : item.Body)
+                    </div>
+                    <div class="buttons">
+                        <a href="@(Url.RouteUrl<BlogPost>(new { SeName = item.SeName }))" class="read-more">@T("Blog.MoreInfo")</a>
+                    </div>
+                </div>
+            }
+        </div>
+        <div class="view-all">
+            <a href="@Url.RouteUrl("Blog")">@T("Blog.ViewAll")</a>
+        </div>
+    </div>
+
+}


### PR DESCRIPTION
## Ability to select blog posts to be featured on main page
I added the ability to select blog posts to be featured on main page by making below changes. 
- I added a new checkbox in **"Blog Settings"** page in **admin area**: **"Show blog posts on home page"**
- I added a new column to **"dbo.BlogPost"** table of type **"boolean"**, named: **"Show blog posts on home page"**
- I created a new component **"HomepageBlogPostsViewComponent"**
- some data migrations to add new local string resources to **[dbo].[LocaleStringResource]**. 
- database migrations ShowBlogOnMainPage:AutoReversingMigration to the new column to **"dbo.BlogPost"**. 
- the listing ui looks like home page news. 

if the user checked the **"Show blog posts on home page"** and there is one ore more blog posts with **"Show blog posts on home page"** set to **true**, those blog posts will be shown on main page. 
![msedge_MfAzOwPATC](https://github.com/nopSolutions/nopCommerce/assets/16575759/c585726f-4354-4ef5-803f-0ab32d1e900f)
@RomanovM (sorry but I couldnt find the official email to discuss new feature before making a pull request)