### PR TITLE
Fix product manufacturers cache

### DIFF
--- a/src/Libraries/Nop.Services/Catalog/Caching/ManufacturerCacheEventConsumer.cs
+++ b/src/Libraries/Nop.Services/Catalog/Caching/ManufacturerCacheEventConsumer.cs
@@ -20,7 +20,10 @@ namespace Nop.Services.Catalog.Caching
             await RemoveByPrefixAsync(NopDiscountDefaults.ManufacturerIdsPrefix);
 
             if (entityEventType != EntityEventType.Insert)
+            {
+                await RemoveByPrefixAsync(NopCatalogDefaults.ProductManufacturersPrefix);
                 await RemoveByPrefixAsync(NopCatalogDefaults.ManufacturersByCategoryPrefix);
+            }
 
             if (entityEventType == EntityEventType.Delete)
                 await RemoveAsync(NopCatalogDefaults.SpecificationAttributeOptionsByManufacturerCacheKey, entity);

--- a/src/Libraries/Nop.Services/Catalog/NopCatalogDefaults.cs
+++ b/src/Libraries/Nop.Services/Catalog/NopCatalogDefaults.cs
@@ -189,7 +189,12 @@ namespace Nop.Services.Catalog
         /// {2} : roles of the current user
         /// {3} : store ID
         /// </remarks>
-        public static CacheKey ProductManufacturersByProductCacheKey => new("Nop.productmanufacturer.byproduct.{0}-{1}-{2}-{3}", ProductManufacturersByProductPrefix);
+        public static CacheKey ProductManufacturersByProductCacheKey => new("Nop.productmanufacturer.byproduct.{0}-{1}-{2}-{3}", ProductManufacturersPrefix, ProductManufacturersByProductPrefix);
+
+        /// <summary>
+        /// Gets a key pattern to clear cache
+        /// </summary>
+        public static string ProductManufacturersPrefix => "Nop.productmanufacturer.";
 
         /// <summary>
         /// Gets a key pattern to clear cache


### PR DESCRIPTION
When a manufacturer is edited or deleted, the ProductManufacturersByProductCacheKey is not deleted from the cache. This fixes this error.