### PR TITLE
RedisConnectionWrapper.FlushDatabaseAsync: do not execute "FLUSHDB" on replicas

### DIFF
--- a/src/Libraries/Nop.Services/Caching/RedisConnectionWrapper.cs
+++ b/src/Libraries/Nop.Services/Caching/RedisConnectionWrapper.cs
@@ -201,7 +201,13 @@ namespace Nop.Services.Caching
         {
             var endPoints = await GetEndPointsAsync();
             await Task.WhenAll(endPoints.Select(async endPoint =>
-                await (await GetServerAsync(endPoint)).FlushDatabaseAsync()));
+            {
+                var server = await GetServerAsync(endPoint);
+                if (!server.IsReplica)
+                {
+                    await server.FlushDatabaseAsync();
+                }
+            }));
         }
 
         /// <summary>


### PR DESCRIPTION
We are running NopCommerce with a Redis Sentinel cluster.
We have been getting the following exception:

```
StackExchange.Redis.RedisCommandException: Command cannot be issued to a replica: FLUSHDB
```

The problem was that RedisConnectionWrapper.FlushDatabaseAsync was calling FlushDatabaseAsync on the replicas as well. 
I believe that the attached fix fixes the issue.