### PR TITLE
Issue #6826 SaveOrderDetailsAsync performance code modification 

### DIFF
--- a/src/Libraries/Nop.Services/Orders/OrderProcessingService.cs
+++ b/src/Libraries/Nop.Services/Orders/OrderProcessingService.cs
@@ -775,16 +775,16 @@ namespace Nop.Services.Orders
 
             //generate and set custom order number
             order.CustomOrderNumber = _customNumberFormatter.GenerateOrderCustomNumber(order);
-            await _orderService.UpdateOrderAsync(order);
 
             //reward points history
             if (details.RedeemedRewardPointsAmount <= decimal.Zero)
+            {
+                await _orderService.UpdateOrderAsync(order);
                 return order;
-
+            }
             order.RedeemedRewardPointsEntryId = await _rewardPointService.AddRewardPointsHistoryEntryAsync(details.Customer, -details.RedeemedRewardPoints, order.StoreId,
                 string.Format(await _localizationService.GetResourceAsync("RewardPoints.Message.RedeemedForOrder", order.CustomerLanguageId), order.CustomOrderNumber),
                 order, details.RedeemedRewardPointsAmount);
-            await _customerService.UpdateCustomerAsync(details.Customer);
             await _orderService.UpdateOrderAsync(order);
 
             return order;


### PR DESCRIPTION
this is the fix for #6826 
1. Remove await _orderService.UpdateOrderAsync(order); line 778 and make it inside the if statment as following:
```
if (details.RedeemedRewardPointsAmount <= decimal.Zero)
{
await _orderService.UpdateOrderAsync(order);
return order;
}
```
3. Remove await _customerService.UpdateCustomerAsync(details.Customer); as it is not needed