### PR TITLE
Prevent Page break on line item overflow #6885

### DIFF
--- a/src/Libraries/Nop.Services/Common/Pdf/InvoiceDocument.cs
+++ b/src/Libraries/Nop.Services/Common/Pdf/InvoiceDocument.cs
@@ -187,7 +187,7 @@ namespace Nop.Services.Common.Pdf
 
                     static IContainer CellStyle(IContainer container)
                     {
-                        return container.BorderBottom(1).BorderColor(Colors.Grey.Lighten2).PaddingVertical(5);
+                        return container.BorderBottom(1).BorderColor(Colors.Grey.Lighten2).PaddingVertical(5).ShowEntire();
                     }
                 }
             });


### PR DESCRIPTION
This fixes #6885 

Prevents a line item from being broken up when line overflows and falls on a page break.