### PR TITLE
Make ConcurrentTrie.Search not require exact hit

### DIFF
--- a/src/Libraries/Nop.Core/Infrastructure/ConcurrentTrie.cs
+++ b/src/Libraries/Nop.Core/Infrastructure/ConcurrentTrie.cs
@@ -454,7 +454,7 @@ namespace Nop.Core.Infrastructure
             if (prefix is null)
                 throw new ArgumentNullException(nameof(prefix));
 
-            if (!SearchOrPrune(prefix, false, out var node))
+            if (!Find(prefix, _root, out var node))
                 return Enumerable.Empty<KeyValuePair<string, TValue>>();
 
             // depth-first traversal
@@ -482,7 +482,7 @@ namespace Nop.Core.Infrastructure
                     yield return kv;
             }
 
-            return traverse(node, node.Label);
+            return traverse(node, prefix);
         }
 
         /// <summary>
@@ -507,23 +507,10 @@ namespace Nop.Core.Infrastructure
         /// </returns>
         public virtual bool Prune(string prefix, out IConcurrentCollection<TValue> subCollection)
         {
-            var succeeded = SearchOrPrune(prefix, true, out var subtreeRoot);
-            subCollection = succeeded ? new ConcurrentTrie<TValue>(subtreeRoot) : default;
-            return succeeded;
-        }
-
-        protected bool SearchOrPrune(string prefix, bool prune, out TrieNode subtreeRoot)
-        {
             if (prefix is null)
                 throw new ArgumentNullException(nameof(prefix));
 
-            if (prefix.Length == 0)
-            {
-                subtreeRoot = _root;
-                return true;
-            }
-
-            subtreeRoot = default;
+            subCollection = default;
             var node = _root;
             var parent = node;
             var span = prefix.AsSpan();
@@ -545,16 +532,15 @@ namespace Nop.Core.Infrastructure
 
                     if (k == span.Length - i)
                     {
-                        subtreeRoot = new TrieNode(prefix[..i] + node.Label, node);
-                        if (!prune)
-                            return true;
-
                         parentLock.EnterWriteLock();
 
                         try
                         {
                             if (parent.Children.Remove(c, out node))
+                            {
+                                subCollection = new ConcurrentTrie<TValue>(new TrieNode(prefix[..i] + node.Label, node));
                                 return true;
+                            }
                         }
                         finally
                         {

--- a/src/Tests/Nop.Tests/Nop.Core.Tests/Infrastructure/ConcurrentTrieTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Core.Tests/Infrastructure/ConcurrentTrieTests.cs
@@ -11,7 +11,7 @@ namespace Nop.Tests.Nop.Core.Tests.Infrastructure
     {
         private IConcurrentCollection<int> _sut;
 
-        private void Profile(Action action)
+        private static void Profile(Action action)
         {
             var sw = new Stopwatch();
             var memory = GC.GetTotalMemory(true) / 1024.0 / 1024.0;
@@ -21,8 +21,8 @@ namespace Nop.Tests.Nop.Core.Tests.Infrastructure
 
             sw.Stop();
             var delta = GC.GetTotalMemory(true) / 1024.0 / 1024.0 - memory;
-            Console.WriteLine("Elapsed teme: {0:F}s", sw.ElapsedMilliseconds / 1000.0);
-            Console.WriteLine("Memory usege: {0:F}Mb", delta);
+            Console.WriteLine("Elapsed time: {0:F} s", sw.ElapsedMilliseconds / 1000.0);
+            Console.WriteLine("Memory usage: {0:F} MB", delta);
         }
 
         [SetUp]
@@ -144,13 +144,13 @@ namespace Nop.Tests.Nop.Core.Tests.Infrastructure
         {
             _sut.Add("a", 1);
             _sut.Add("b", 1);
-            _sut.Add("ab", 1);
-            _sut.Add("abc", 2);
+            _sut.Add("abc", 1);
+            _sut.Add("abcd", 2);
             var keys = _sut.Keys.ToList();
             _sut.Search("ab").Should().BeEquivalentTo(new KeyValuePair<string, int>[]
             {
-                new("ab", 1),
-                new("abc", 2)
+                new("abc", 1),
+                new("abcd", 2)
             });
             _sut.Keys.Should().BeEquivalentTo(keys);
         }
@@ -184,7 +184,7 @@ namespace Nop.Tests.Nop.Core.Tests.Infrastructure
         [Test]
         [TestCase(typeof(NopConcurrentCollection<int>))]
         [TestCase(typeof(ConcurrentTrie<int>))]
-        [Ignore("Not a test, used for profiling.")]
+        [Ignore("Expensive concurrency test, enable manually.")]
         public void DoesNotBreakDuringParallelAddRemove(Type oType)
         {
             var sut = Activator.CreateInstance(oType) as IConcurrentCollection<int>;
@@ -212,7 +212,7 @@ namespace Nop.Tests.Nop.Core.Tests.Infrastructure
         [Test]
         [TestCase(typeof(NopConcurrentCollection<int>))]
         [TestCase(typeof(ConcurrentTrie<int>))]
-        [Ignore("Not a test, used for profiling.")]
+        [Ignore("Expensive concurrency test, enable manually.")]
         public void DoesNotBreakDuringParallelAddPrune(Type oType)
         {
             var sut = Activator.CreateInstance(oType) as IConcurrentCollection<int>;

--- a/src/Tests/Nop.Tests/Nop.Core.Tests/Infrastructure/ConcurrentTrieTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Core.Tests/Infrastructure/ConcurrentTrieTests.cs
@@ -11,7 +11,7 @@ namespace Nop.Tests.Nop.Core.Tests.Infrastructure
     {
         private IConcurrentCollection<int> _sut;
 
-        private static void Profile(Action action)
+        private void Profile(Action action)
         {
             var sw = new Stopwatch();
             var memory = GC.GetTotalMemory(true) / 1024.0 / 1024.0;
@@ -21,8 +21,8 @@ namespace Nop.Tests.Nop.Core.Tests.Infrastructure
 
             sw.Stop();
             var delta = GC.GetTotalMemory(true) / 1024.0 / 1024.0 - memory;
-            Console.WriteLine("Elapsed time: {0:F} s", sw.ElapsedMilliseconds / 1000.0);
-            Console.WriteLine("Memory usage: {0:F} MB", delta);
+            Console.WriteLine("Elapsed teme: {0:F}s", sw.ElapsedMilliseconds / 1000.0);
+            Console.WriteLine("Memory usege: {0:F}Mb", delta);
         }
 
         [SetUp]
@@ -144,13 +144,13 @@ namespace Nop.Tests.Nop.Core.Tests.Infrastructure
         {
             _sut.Add("a", 1);
             _sut.Add("b", 1);
-            _sut.Add("abc", 1);
-            _sut.Add("abcd", 2);
+            _sut.Add("ab", 1);
+            _sut.Add("abc", 2);
             var keys = _sut.Keys.ToList();
             _sut.Search("ab").Should().BeEquivalentTo(new KeyValuePair<string, int>[]
             {
-                new("abc", 1),
-                new("abcd", 2)
+                new("ab", 1),
+                new("abc", 2)
             });
             _sut.Keys.Should().BeEquivalentTo(keys);
         }
@@ -184,7 +184,7 @@ namespace Nop.Tests.Nop.Core.Tests.Infrastructure
         [Test]
         [TestCase(typeof(NopConcurrentCollection<int>))]
         [TestCase(typeof(ConcurrentTrie<int>))]
-        [Ignore("Expensive concurrency test, enable manually.")]
+        [Ignore("Not a test, used for profiling.")]
         public void DoesNotBreakDuringParallelAddRemove(Type oType)
         {
             var sut = Activator.CreateInstance(oType) as IConcurrentCollection<int>;
@@ -212,7 +212,7 @@ namespace Nop.Tests.Nop.Core.Tests.Infrastructure
         [Test]
         [TestCase(typeof(NopConcurrentCollection<int>))]
         [TestCase(typeof(ConcurrentTrie<int>))]
-        [Ignore("Expensive concurrency test, enable manually.")]
+        [Ignore("Not a test, used for profiling.")]
         public void DoesNotBreakDuringParallelAddPrune(Type oType)
         {
             var sut = Activator.CreateInstance(oType) as IConcurrentCollection<int>;


### PR DESCRIPTION
`ConcurrentTrie.Search` previously required the argument key to exactly match an existing key in the tree. This didn't affect any code in the core codebase, but it was unintuitive behaviour. This fix changes the behaviour to conform with the `Prune` method, so that it returns all key-value pairs starting with the supplied prefix; see changes to `ConcurrentTrieTests.CanSearch`.

Best regards,

Rickard von Haugwitz
Majako [https://majako.net/](majako.net) / [https://majako.se/](majako.se)