### PR TITLE
Use cached customer roles to avoid SQL joins

### DIFF
--- a/src/Libraries/Nop.Services/Customers/ICustomerService.cs
+++ b/src/Libraries/Nop.Services/Customers/ICustomerService.cs
@@ -381,6 +381,14 @@ namespace Nop.Services.Customers
         Task DeleteCustomerRoleAsync(CustomerRole customerRole);
 
         /// <summary>
+        /// Gets a dictionary of all customer roles mapped by ID.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous operation and contains a dictionary of all customer roles mapped by ID.
+        /// </returns>
+        Task<IDictionary<int, CustomerRole>> GetAllCustomerRolesDictionaryAsync();
+
+        /// <summary>
         /// Gets a customer role
         /// </summary>
         /// <param name="customerRoleId">Customer role identifier</param>

--- a/src/Libraries/Nop.Services/Customers/NopCustomerServiceDefaults.cs
+++ b/src/Libraries/Nop.Services/Customers/NopCustomerServiceDefaults.cs
@@ -78,18 +78,8 @@ namespace Nop.Services.Customers
         /// </summary>
         /// <remarks>
         /// {0} : customer identifier
-        /// {1} : show hidden
         /// </remarks>
-        public static CacheKey CustomerRoleIdsCacheKey => new("Nop.customer.customerrole.ids.{0}-{1}", CustomerCustomerRolesPrefix);
-
-        /// <summary>
-        /// Gets a key for caching
-        /// </summary>
-        /// <remarks>
-        /// {0} : customer identifier
-        /// {1} : show hidden
-        /// </remarks>
-        public static CacheKey CustomerRolesCacheKey => new("Nop.customer.customerrole.{0}-{1}", CustomerCustomerRolesByCustomerPrefix, CustomerCustomerRolesPrefix);
+        public static CacheKey CustomerRolesCacheKey => new("Nop.customer.customerrole.{0}", CustomerCustomerRolesByCustomerPrefix, CustomerCustomerRolesPrefix);
 
         /// <summary>
         /// Gets a key pattern to clear cache


### PR DESCRIPTION
Recently, we had been experiencing thread-pool starvation on the (MS)SQL server during periods of unusually high traffic, resulting in extremely long response times and even timeouts. These incidents were found to have had a strong correlation with spikes in CustomerRole select queries. As you can see below, during the month leading up to the deployment of this fix, this query was the most time-consuming database operation, being responsible for nearly a third of all query time; it has since been eliminated completely from the list.

![image](https://github.com/nopSolutions/nopCommerce/assets/44768499/f700a265-42b2-4be5-88e9-405e54fc95b8)

Since all customer roles are already cached and no customer is likely to ever have more than a few roles, we could completely forego the expensive table join and limit ourselves to a single select query on CustomerRole on startup.

There is also no compelling reason to cache active and inactive roles separately - even if each customer were mapped to hundreds if not thousands of roles (which seems incredibly far-fetched), filtering them in memory wouldn't add much complexity.

The site has been exceptionally stable since we deployed this fix.

Best regards,

Rickard von Haugwitz
Majako [https://majako.net/](https://github.com/nopSolutions/nopCommerce/pull/majako.net) / [https://majako.se/](https://github.com/nopSolutions/nopCommerce/pull/majako.se)