### PR TITLE
Improve upon LocalizedEntity and UrlRecord caching

### DIFF
--- a/src/Libraries/Nop.Services/Localization/LocalizedEntityService.cs
+++ b/src/Libraries/Nop.Services/Localization/LocalizedEntityService.cs
@@ -170,27 +170,28 @@ namespace Nop.Services.Localization
         /// </returns>
         public virtual async Task<string> GetLocalizedValueAsync(int languageId, int entityId, string localeKeyGroup, string localeKey)
         {
+            if (_localizationSettings.LoadAllLocalizedPropertiesOnStartup)
+            {
+                //value tuples aren't json-serializable by default, so we use a string key
+                static string formatKey(string keyGroup, string key, int id) => $"{keyGroup}:{key}:{id}";
+
+                var localizedValues = await _staticCacheManager.GetAsync(
+                    _staticCacheManager.PrepareKeyForDefaultCache(NopLocalizationDefaults.LocalizedPropertyLookupCacheKey, languageId),
+                    async () => (await GetAllLocalizedPropertiesAsync(languageId))
+                        .GroupBy(p => formatKey(p.LocaleKeyGroup, p.LocaleKey, p.EntityId))
+                        .ToDictionary(g => g.Key, g => g.First().LocaleValue));
+
+                return localizedValues.TryGetValue(formatKey(localeKeyGroup, localeKey, entityId), out var localeValue)
+                    ? localeValue
+                    : string.Empty;
+            }
+
+            //gradual loading
             var key = _staticCacheManager.PrepareKeyForDefaultCache(NopLocalizationDefaults.LocalizedPropertyCacheKey
                 , languageId, entityId, localeKeyGroup, localeKey);
 
             return await _staticCacheManager.GetAsync(key, async () =>
             {
-                if (_localizationSettings.LoadAllLocalizedPropertiesOnStartup)
-                {
-                    var lookupKey = _staticCacheManager.PrepareKeyForDefaultCache(
-                        NopLocalizationDefaults.LocalizedPropertyLookupCacheKey,
-                        languageId);
-                    var lookup = await _staticCacheManager.GetAsync(
-                        lookupKey,
-                        async () => (await GetAllLocalizedPropertiesAsync(languageId))
-                            .ToGroupedDictionary(p => p.EntityId));
-
-                    return lookup.TryGetValue(entityId, out var localizedProperties)
-                        ? localizedProperties.FirstOrDefault(p => p.LocaleKeyGroup == localeKeyGroup && p.LocaleKey == localeKey)
-                            ?.LocaleValue ?? string.Empty
-                        : string.Empty;
-                }
-
                 var query = from lp in _localizedPropertyRepository.Table
                             where lp.LanguageId == languageId &&
                                   lp.EntityId == entityId &&
@@ -199,7 +200,7 @@ namespace Nop.Services.Localization
                             select lp.LocaleValue;
 
                 //little hack here. nulls aren't cacheable so set it to ""
-                return query.FirstOrDefault() ?? string.Empty;
+                return await query.FirstOrDefaultAsync() ?? string.Empty;
             });
         }
 

--- a/src/Libraries/Nop.Services/Seo/UrlRecordService.cs
+++ b/src/Libraries/Nop.Services/Seo/UrlRecordService.cs
@@ -1173,22 +1173,23 @@ namespace Nop.Services.Seo
             if (string.IsNullOrEmpty(slug))
                 return null;
 
+            if (_localizationSettings.LoadAllUrlRecordsOnStartup)
+            {
+                var records = await _staticCacheManager.GetAsync(
+                    _staticCacheManager.PrepareKeyForDefaultCache(NopSeoDefaults.UrlRecordSlugLookupCacheKey),
+                    async () => (await GetAllUrlRecordsAsync())
+                        .GroupBy(x => x.Slug.ToLower())
+                        .ToDictionary(g => g.Key, g => g.OrderByDescending(x => x.IsActive).ThenBy(x => x.Id).First()));
+
+                return records.TryGetValue(slug.ToLower(), out var record)
+                    ? record
+                    : null;
+            }
+
             var key = _staticCacheManager.PrepareKeyForDefaultCache(NopSeoDefaults.UrlRecordBySlugCacheKey, slug);
 
             return await _staticCacheManager.GetAsync(key, async () =>
             {
-                if (_localizationSettings.LoadAllUrlRecordsOnStartup)
-                {
-                    var lookup = await _staticCacheManager.GetAsync(
-                        _staticCacheManager.PrepareKeyForDefaultCache(NopSeoDefaults.UrlRecordSlugLookupCacheKey),
-                        async () => (await GetAllUrlRecordsAsync())
-                            .ToGroupedDictionary(x => x.Slug.ToLowerInvariant()));
-
-                    return lookup.TryGetValue(slug.ToLowerInvariant(), out var records)
-                        ? records.OrderByDescending(x => x.IsActive).ThenBy(x => x.Id).FirstOrDefault()
-                        : null;
-                }
-
                 // gradual loading
                 var query = from ur in _urlRecordRepository.Table
                             where ur.Slug == slug
@@ -1249,25 +1250,28 @@ namespace Nop.Services.Seo
         /// </returns>
         public virtual async Task<string> GetActiveSlugAsync(int entityId, string entityName, int languageId)
         {
+            if (_localizationSettings.LoadAllUrlRecordsOnStartup)
+            {
+                //value tuples aren't json-serializable by default, so we use a string key
+                static string formatKey(string name, int id) => $"{name}:{id}";
+
+                var activeSlugs = await _staticCacheManager.GetAsync(
+                    _staticCacheManager.PrepareKeyForDefaultCache(NopSeoDefaults.UrlRecordEntityIdLookupCacheKey, languageId),
+                    async () => (await GetAllUrlRecordsAsync())
+                        .Where(x => x.IsActive && x.LanguageId == languageId)
+                        .GroupBy(x => formatKey(x.EntityName, x.EntityId))
+                        .ToDictionary(g => g.Key, g => g.MinBy(x => x.Id).Slug));
+
+                return activeSlugs.TryGetValue(formatKey(entityName, entityId), out var slug)
+                    ? slug
+                    : string.Empty;
+            }
+
             //gradual loading
             var key = _staticCacheManager.PrepareKeyForDefaultCache(NopSeoDefaults.UrlRecordCacheKey, entityId, entityName, languageId);
 
             return await _staticCacheManager.GetAsync(key, async () =>
             {
-                if (_localizationSettings.LoadAllUrlRecordsOnStartup)
-                {
-                    var lookup = await _staticCacheManager.GetAsync(
-                        _staticCacheManager.PrepareKeyForDefaultCache(NopSeoDefaults.UrlRecordEntityIdLookupCacheKey, languageId),
-                        async () => (await GetAllUrlRecordsAsync()) // these are cached
-                            .Where(x => x.IsActive && x.LanguageId == languageId)
-                            .ToGroupedDictionary(x => x.EntityId));
-
-                    return lookup.TryGetValue(entityId, out var records)
-                        ? records.Where(x => x.EntityName == entityName).MinBy(x => x.Id)?.Slug ?? string.Empty
-                        : string.Empty;
-                }
-
-                //gradual loading
                 var query = from ur in _urlRecordRepository.Table
                             where ur.EntityId == entityId &&
                                   ur.EntityName == entityName &&
@@ -1278,7 +1282,7 @@ namespace Nop.Services.Seo
 
                 //little hack here. nulls aren't cacheable so set it to ""
                 return await query.FirstOrDefaultAsync() ?? string.Empty;
-            }) ?? string.Empty;
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
By precomputing only the values we are interested in and removing unnecessary nested cache calls, we can avoid double-caching localised entities and URL records without sacrificing speed. Since there may be a lot of both localised entities and URL records, even the cache keys themselves take unnecessary space in memory and extra time on eviction.

Best regards,

Rickard von Haugwitz
Majako [https://majako.net/](https://github.com/nopSolutions/nopCommerce/pull/majako.net) / [https://majako.se/](https://github.com/nopSolutions/nopCommerce/pull/majako.se)