### PR TITLE
Optimize SortCategoriesForTreeAsync

### DIFF
--- a/src/Libraries/Nop.Services/Catalog/CategoryService.cs
+++ b/src/Libraries/Nop.Services/Catalog/CategoryService.cs
@@ -117,7 +117,7 @@ namespace Nop.Services.Catalog
         /// <returns>
         /// An async-enumerable that contains the sorted categories
         /// </returns>
-        protected virtual async IAsyncEnumerable<Category> SortCategoriesForTreeAsync(
+        protected virtual IEnumerable<Category> SortCategoriesForTree(
             ILookup<int, Category> categoriesByParentId,
             int parentId = 0,
             bool ignoreCategoriesWithoutExistingParent = false)
@@ -134,7 +134,7 @@ namespace Nop.Services.Catalog
             {
                 yield return cat;
                 remaining.Remove(cat.Id);
-                await foreach (var subCategory in SortCategoriesForTreeAsync(categoriesByParentId, cat.Id, true))
+                foreach (var subCategory in SortCategoriesForTree(categoriesByParentId, cat.Id, true))
                 {
                     yield return subCategory;
                     remaining.Remove(subCategory.Id);
@@ -274,8 +274,8 @@ namespace Nop.Services.Catalog
             });
 
             //sort categories
-            var sortedCategories = await SortCategoriesForTreeAsync(unsortedCategories.ToLookup(c => c.ParentCategoryId))
-                .ToListAsync();
+            var sortedCategories = SortCategoriesForTree(unsortedCategories.ToLookup(c => c.ParentCategoryId))
+                .ToList();
 
             //paging
             return new PagedList<Category>(sortedCategories, pageIndex, pageSize);

--- a/src/Libraries/Nop.Services/Catalog/CategoryService.cs
+++ b/src/Libraries/Nop.Services/Catalog/CategoryService.cs
@@ -138,7 +138,7 @@ namespace Nop.Services.Catalog
             {
                 yield return cat;
                 remaining.Remove(cat.Id);
-                await foreach (var subCat in SortCategoriesForTreeAsync(categoriesByParentId, cat.Id))
+                await foreach (var subCat in SortCategoriesForTreeAsync(categoriesByParentId, cat.Id, true))
                 {
                     yield return subCat;
                     remaining.Remove(subCat.Id);

--- a/src/Libraries/Nop.Services/Catalog/CategoryService.cs
+++ b/src/Libraries/Nop.Services/Catalog/CategoryService.cs
@@ -115,7 +115,7 @@ namespace Nop.Services.Catalog
         /// <param name="parentId">Parent category identifier</param>
         /// <param name="ignoreCategoriesWithoutExistingParent">A value indicating whether categories without parent category in provided category list (source) should be ignored</param>
         /// <returns>
-        /// An async-enumerable that contains the sorted categories
+        /// An enumerable containing the sorted categories
         /// </returns>
         protected virtual IEnumerable<Category> SortCategoriesForTree(
             ILookup<int, Category> categoriesByParentId,


### PR DESCRIPTION
The time complexity of CategoryService.SortCategoriesForTreeAsync is currently $O(n^2)$ for $n$ categories. This is unnecessary, since we can use a lookup with $O(1)$ access instead of filtering a list in $O(n)$ on each recursion.

Although we can no longer sort entries all at once in SQL (potentially shifting execution time to the app server, if the database is hosted separately), it is much cheaper to sort many small lists instead of a single large one (unless the category tree is completely flat, in which case it's the same).

Best regards,

Rickard von Haugwitz
Majako [https://majako.net/](https://github.com/nopSolutions/nopCommerce/pull/majako.net) / [https://majako.se/](https://github.com/nopSolutions/nopCommerce/pull/majako.se)