### PR TITLE
Implementing generic dependency injection configuration for consistent and scalable service registration.

### DIFF
--- a/src/Libraries/Nop.Core/Common/Interfaces/IScopedService.cs
+++ b/src/Libraries/Nop.Core/Common/Interfaces/IScopedService.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nop.Core.Common.Interfaces
+{
+    /// <summary>
+    /// Interface for a scoped service in dependency injection.
+    /// Scoped services are created once per request.
+    /// 
+    /// If an interface inherits this interface, it will be automatically registered
+    /// by a common dependency injection configuration class.
+    /// </summary>
+    public interface IScopedService
+    {
+    }
+}

--- a/src/Libraries/Nop.Core/Common/Interfaces/ISingletonService.cs
+++ b/src/Libraries/Nop.Core/Common/Interfaces/ISingletonService.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nop.Core.Common.Interfaces
+{
+    /// <summary>
+    /// Interface for a singleton service in dependency injection.
+    /// Singleton services are created once and shared throughout the application.
+    /// 
+    /// If an interface inherits this interface, it will be automatically registered
+    /// by a common dependency injection configuration class.
+    /// </summary>
+    public interface ISingletonService
+    {
+    }
+}

--- a/src/Libraries/Nop.Core/Common/Interfaces/ITransientService.cs
+++ b/src/Libraries/Nop.Core/Common/Interfaces/ITransientService.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nop.Core.Common.Interfaces
+{
+    /// <summary>
+    /// Interface for a transient service in dependency injection.
+    /// Transient services are created anew each time they are requested.
+    /// 
+    /// If an interface inherits this interface, it will be automatically registered
+    /// by a common dependency injection configuration class.
+    /// </summary>
+    public interface ITransientService
+    {
+    }
+}

--- a/src/Libraries/Nop.Core/Common/NopDependencyInjectionConfig.cs
+++ b/src/Libraries/Nop.Core/Common/NopDependencyInjectionConfig.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Nop.Core.Common
+{
+    /// <summary>
+    /// Containing extension methods for configuring dependency injection in generic way
+    /// </summary>
+    public static partial class NopDependencyInjectionConfig
+    {
+        #region Methods
+        /// <summary>
+        /// Registers all implementations of a specified interface with the provided service lifetime.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add the services to.</param>
+        /// <param name="interfaceType">The interface type whose implementations need to be registered.</param>
+        /// <param name="lifetime">The service lifetime (Transient, Scoped, Singleton).</param>
+        /// <returns>The modified <see cref="IServiceCollection"/>.</returns>
+        public static IServiceCollection RegisterImplementations(this IServiceCollection services, Type interfaceType, ServiceLifetime lifetime)
+        {
+            var implementationTypes = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(assembly => assembly.GetTypes())
+                .Where(type => interfaceType.IsAssignableFrom(type) && type.IsClass && !type.IsAbstract)
+                .Select(type => new { Interface = type.GetInterfaces().OrderByDescending(i => i.GetInterfaces().Length).FirstOrDefault(), Implementation = type })
+                .Where(type => type.Interface != null && interfaceType.IsAssignableFrom(type.Interface));
+
+            foreach (var implementationType in implementationTypes)
+                services.RegisterService(implementationType.Interface!, implementationType.Implementation, lifetime);
+
+            return services;
+        }
+        /// <summary>
+        /// Registers a service with the specified interface, implementation, and service lifetime.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
+        /// <param name="interfaceType">The interface type.</param>
+        /// <param name="implementationType">The implementation type.</param>
+        /// <param name="lifetime">The service lifetime (Transient, Scoped, Singleton).</param>
+        /// <returns>The modified <see cref="IServiceCollection"/>.</returns>
+        private static IServiceCollection RegisterService(this IServiceCollection services, Type interfaceType, Type implementationType, ServiceLifetime lifetime)
+        {
+            return lifetime switch
+            {
+                ServiceLifetime.Transient => services.AddTransient(interfaceType, implementationType),
+                ServiceLifetime.Scoped => services.AddScoped(interfaceType, implementationType),
+                ServiceLifetime.Singleton => services.AddSingleton(interfaceType, implementationType),
+                _ => throw new ArgumentException("Invalid lifetime specified", nameof(lifetime))
+            };
+        }
+        #endregion
+    }
+}

--- a/src/Libraries/Nop.Core/IWebHelper.cs
+++ b/src/Libraries/Nop.Core/IWebHelper.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.AspNetCore.Http;
+using Nop.Core.Common.Interfaces;
 
 namespace Nop.Core
 {
     /// <summary>
     /// Represents a web helper
     /// </summary>
-    public partial interface IWebHelper
+    public partial interface IWebHelper: IScopedService
     {
         /// <summary>
         /// Get URL referrer if exists

--- a/src/Libraries/Nop.Core/Infrastructure/INopFileProvider.cs
+++ b/src/Libraries/Nop.Core/Infrastructure/INopFileProvider.cs
@@ -1,13 +1,14 @@
 ﻿using System.Security.AccessControl;
 using System.Text;
 using Microsoft.Extensions.FileProviders;
+using Nop.Core.Common.Interfaces;
 
 namespace Nop.Core.Infrastructure
 {
     /// <summary>
     /// A file provider abstraction
     /// </summary>
-    public interface INopFileProvider : IFileProvider
+    public interface INopFileProvider : IFileProvider,IScopedService
     {
         /// <summary>
         /// Combines an array of strings into a path

--- a/src/Presentation/Nop.Web.Framework/Infrastructure/NopStartup.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/NopStartup.cs
@@ -4,6 +4,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Nop.Core;
 using Nop.Core.Caching;
+using Nop.Core.Common.Interfaces;
+using Nop.Core.Common;
 using Nop.Core.Configuration;
 using Nop.Core.Events;
 using Nop.Core.Infrastructure;
@@ -72,11 +74,23 @@ namespace Nop.Web.Framework.Infrastructure
         /// <param name="configuration">Configuration of the application</param>
         public virtual void ConfigureServices(IServiceCollection services, IConfiguration configuration)
         {
+            // Registers all implementations of ITransientService in generic way
+            services.RegisterImplementations(typeof(ITransientService), ServiceLifetime.Transient);
+            // Registers all implementations of IScopedService in generic way
+            services.RegisterImplementations(typeof(IScopedService), ServiceLifetime.Scoped);
+            // Registers all implementations of ISingletonService in generic way
+            services.RegisterImplementations(typeof(ISingletonService), ServiceLifetime.Singleton);
+
+            // You can configure all services here in generic way by inherting IScopedService in the interface type.
+            // Example: file provider and web helper only
+
             //file provider
-            services.AddScoped<INopFileProvider, NopFileProvider>();
+            //INopFileProvider configured in generic way by inherting IScopedService in INopFileProvider.
+            //services.AddScoped<INopFileProvider, NopFileProvider>();
 
             //web helper
-            services.AddScoped<IWebHelper, WebHelper>();
+            //IWebHelper configured in generic way by inherting IScopedService in IWebHelper.
+            //services.AddScoped<IWebHelper, WebHelper>();
 
             //user agent helper
             services.AddScoped<IUserAgentHelper, UserAgentHelper>();


### PR DESCRIPTION
## Pull Request: Implementing generic dependency injection configuration

### Description
This pull request introduces a generic approach to configuring and registering services, aiming to improve consistency and scalability across the codebase. The primary goal is to enhance maintainability by utilizing dependency injection.

### Changes Proposed
I've implemented a generic service registration mechanism that streamlines the configuration and registration of dependency injections. You can configure all services in a generic way by inheriting from `ITransientService` or `IScopedService` or `ISingletonService` in the interface type.

**For the purpose of this pull request, I've made changes to the file provider and web helper service. The generic registration logic has been applied to these specific services.**

### Implementation Details
- **Generic Service Configuration**: I've created a generic method for service registration, making it easier to add and manage services.

```csharp
// Example of proposed implementation
public static IServiceCollection RegisterImplementations(this IServiceCollection services, Type interfaceType, ServiceLifetime lifetime)
{
    var implementationTypes = AppDomain.CurrentDomain.GetAssemblies()
        .SelectMany(assembly => assembly.GetTypes())
        .Where(type => interfaceType.IsAssignableFrom(type) && type.IsClass && !type.IsAbstract)
        .Select(type => new { Interface = type.GetInterfaces().OrderByDescending(i => i.GetInterfaces().Length).FirstOrDefault(), Implementation = type })
        .Where(type => type.Interface != null && interfaceType.IsAssignableFrom(type.Interface));

    foreach (var implementationType in implementationTypes)
        services.RegisterService(implementationType.Interface!, implementationType.Implementation, lifetime);

    return services;
}
private static IServiceCollection RegisterService(this IServiceCollection services, Type interfaceType, Type implementationType, ServiceLifetime lifetime)
{
    return lifetime switch
    {
        ServiceLifetime.Transient => services.AddTransient(interfaceType, implementationType),
        ServiceLifetime.Scoped => services.AddScoped(interfaceType, implementationType),
        ServiceLifetime.Singleton => services.AddSingleton(interfaceType, implementationType),
        _ => throw new ArgumentException("Invalid lifetime specified", nameof(lifetime))
    };
}

// Registers all implementations of ITransientService in generic way
services.RegisterImplementations(typeof(ITransientService), ServiceLifetime.Transient);
```
You can configure all services here in a generic manner by inheriting from either ITransientService, IScopedService, or ISingletonService in the interface type. All implementations will be automatically registered using this configuration.
