### PR TITLE
Clearing known proxies and networks of their defaults

### DIFF
--- a/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
@@ -491,9 +491,10 @@ namespace Nop.Web.Framework.Infrastructure.Extensions
 
                 if (!string.IsNullOrEmpty(appSettings.Get<HostingConfig>().ForwardedProtoHeaderName))
                     options.ForwardedProtoHeaderName = appSettings.Get<HostingConfig>().ForwardedProtoHeaderName;
-
-                if (!string.IsNullOrEmpty(appSettings.Get<HostingConfig>().KnownProxies))
+                
+                if (appSettings.Get<HostingConfig>().KnownProxies != null)
                 {
+                    options.KnownProxies.Clear();
                     foreach (var strIp in appSettings.Get<HostingConfig>().KnownProxies.Split(',', StringSplitOptions.RemoveEmptyEntries).ToList())
                     {
                         if (IPAddress.TryParse(strIp, out var ip))
@@ -501,8 +502,9 @@ namespace Nop.Web.Framework.Infrastructure.Extensions
                     }
                 }
 
-                if (!string.IsNullOrEmpty(appSettings.Get<HostingConfig>().KnownNetworks))
+                if (appSettings.Get<HostingConfig>().KnownNetworks != null)
                 {
+                    options.KnownNetworks.Clear();
                     foreach (var strIpNet in appSettings.Get<HostingConfig>().KnownNetworks.Split(',', StringSplitOptions.RemoveEmptyEntries).ToList())
                     {
                         var ipNetParts = strIpNet.Split("/");


### PR DESCRIPTION
I've been struggling, along with many others with getting the SSL configuration going, especially using some external load balancer like the AWS ALB. This change should address the problems related to getting that working with other things. According to the docs (https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer?view=aspnetcore-8.0), KnownHeaders and KnownProxies comes with some default values. Having those defaults in there means that if the incoming proxy connection doesn't match a localhost network, the ForwardedHeadersMiddleware will exclude itself from processing the request. That means that SSL won't work correctly leading to all the issues that have been reported in the forums. This change allows for KnownProxies and KnownNetworks to be completely overridden, removing the default values. Specifying a null value in the JSON will leave the default. Specifying a string (including empty) will clear the default values before adding to the list.