### PR TITLE
Improve test coverage for AddressService

### DIFF
--- a/src/Tests/Nop.Tests/Nop.Core.Tests/Domain/Common/AddressTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Core.Tests/Domain/Common/AddressTests.cs
@@ -1,4 +1,6 @@
 ﻿using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Nop.Core;
 using Nop.Core.Domain.Common;
 using Nop.Services.Common;
 using NUnit.Framework;
@@ -8,6 +10,14 @@ namespace Nop.Tests.Nop.Core.Tests.Domain.Common;
 [TestFixture]
 public class AddressTests : BaseNopTest
 {
+    private IAddressService _addressService;
+
+    [OneTimeSetUp]
+    public void SetUp()
+    {
+        _addressService = GetService<IAddressService>();
+    }
+
     [Test]
     public void CanCloneAddress()
     {
@@ -30,9 +40,7 @@ public class AddressTests : BaseNopTest
             CreatedOnUtc = new DateTime(2010, 01, 01),
         };
 
-        var addressService = GetService<IAddressService>();
-
-        var newAddress = addressService.CloneAddress(address);
+        var newAddress = _addressService.CloneAddress(address);
         newAddress.Should().NotBeNull();
         newAddress.Id.Should().Be(0);
         newAddress.FirstName.Should().Be("FirstName 1");
@@ -49,5 +57,101 @@ public class AddressTests : BaseNopTest
         newAddress.CreatedOnUtc.Should().Be(new DateTime(2010, 01, 01));
         newAddress.CountryId.Should().Be(3);
         newAddress.StateProvinceId.Should().Be(4);
+    }
+
+    [Test]
+    public async Task CanValidateAddressAsync()
+    {
+        //Valid address
+        var validAddress = new Address
+        {
+            Id = 1,
+            FirstName = "FirstName 1",
+            LastName = "LastName 1",
+            Email = "Email 1",
+            Company = "Company 1",
+            CountryId = 3,
+            StateProvinceId = 4,
+            City = "City 1",
+            County = "County 1",
+            Address1 = "Address1",
+            Address2 = "Address2",
+            ZipPostalCode = "ZipPostalCode 1",
+            PhoneNumber = "PhoneNumber 1",
+            FaxNumber = "FaxNumber 1",
+            CreatedOnUtc = new DateTime(2010, 01, 01),
+        };
+
+        var isAddressValid = await _addressService.IsAddressValidAsync(validAddress);
+        isAddressValid.Should().BeTrue();
+
+        //InValid address 1 - empty FirstName
+        var invalidAddress1 = new Address
+        {
+            Id = 1,
+            FirstName = "",
+            LastName = "LastName 1",
+            Email = "Email 1",
+            Company = "Company 1",
+            CountryId = 3,
+            StateProvinceId = 4,
+            City = "City 1",
+            County = "County 1",
+            Address1 = "Address1",
+            Address2 = "Address2",
+            ZipPostalCode = "ZipPostalCode 1",
+            PhoneNumber = "PhoneNumber 1",
+            FaxNumber = "FaxNumber 1",
+            CreatedOnUtc = new DateTime(2010, 01, 01),
+        };
+
+        isAddressValid = await _addressService.IsAddressValidAsync(invalidAddress1);
+        isAddressValid.Should().BeFalse();
+
+        //InValid address 2 - empty LastName
+        var invalidAddress2 = new Address
+        {
+            Id = 1,
+            FirstName = "FirstName 1",
+            LastName = "",
+            Email = "Email 1",
+            Company = "Company 1",
+            CountryId = 3,
+            StateProvinceId = 4,
+            City = "City 1",
+            County = "County 1",
+            Address1 = "Address1",
+            Address2 = "Address2",
+            ZipPostalCode = "ZipPostalCode 1",
+            PhoneNumber = "PhoneNumber 1",
+            FaxNumber = "FaxNumber 1",
+            CreatedOnUtc = new DateTime(2010, 01, 01),
+        };
+
+        isAddressValid = await _addressService.IsAddressValidAsync(invalidAddress2);
+        isAddressValid.Should().BeFalse();
+
+        //InValid address 3 - empty Email
+        var invalidAddress3 = new Address
+        {
+            Id = 1,
+            FirstName = "FirstName 1",
+            LastName = "LastName 1",
+            Email = "",
+            Company = "Company 1",
+            CountryId = 3,
+            StateProvinceId = 4,
+            City = "City 1",
+            County = "County 1",
+            Address1 = "Address1",
+            Address2 = "Address2",
+            ZipPostalCode = "ZipPostalCode 1",
+            PhoneNumber = "PhoneNumber 1",
+            FaxNumber = "FaxNumber 1",
+            CreatedOnUtc = new DateTime(2010, 01, 01),
+        };
+
+        isAddressValid = await _addressService.IsAddressValidAsync(invalidAddress3);
+        isAddressValid.Should().BeFalse();
     }
 }

--- a/src/Tests/Nop.Tests/Nop.Core.Tests/Domain/Common/AddressTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Core.Tests/Domain/Common/AddressTests.cs
@@ -1,6 +1,4 @@
 ﻿using FluentAssertions;
-using Microsoft.AspNetCore.Http;
-using Nop.Core;
 using Nop.Core.Domain.Common;
 using Nop.Services.Common;
 using NUnit.Framework;


### PR DESCRIPTION
This pull request addresses the following: 

1. Adds concise unit tests for the `IsAddressValidAsync` method in the `AddressService` class.
2. Focus is on validating essential fields (FirstName, LastName, Email).

Changes Made :

1. Added tests for the `IsAddressValidAsync` method.
2. Tests cover scenarios with valid and invalid addresses.
3. Focused on **independent fields (FirstName, LastName, Email)** to ensure robust validation.

Based off this issue : #405 
