### PR TITLE
fix (unittests) #6948 Resolve issues with tests creating a stack overflow. Upgrade to NUnit4

### DIFF
--- a/src/Tests/Nop.Tests/Nop.Services.Tests/Catalog/PriceFormatterTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Services.Tests/Catalog/PriceFormatterTests.cs
@@ -164,7 +164,7 @@ public class PriceFormatterTests : ServiceTest
         var result = await _priceFormatter.FormatBasePriceAsync(product, productPrice);
 
         //assert
-        Assert.IsNull(result);
+        Assert.That(result, Is.Null);
     }
     [Test]
     public void FormatTaxRate_ReturnsCorrectFormat()
@@ -177,6 +177,6 @@ public class PriceFormatterTests : ServiceTest
         var result = _priceFormatter.FormatTaxRate(taxRate);
 
         //assert
-        Assert.AreEqual(expectedFormat, result);
+        Assert.That(expectedFormat, Is.EqualTo(result));
     }
 }

--- a/src/Tests/Nop.Tests/Nop.Services.Tests/Customers/CustomerServiceTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Services.Tests/Customers/CustomerServiceTests.cs
@@ -10,7 +10,7 @@ public class CustomerServiceTests : ServiceTest
 {
     private ICustomerService _customerService;
 
-    [OneTimeSetUp]
+    [SetUp]
     public async Task SetUp()
     {
         _customerService = GetService<ICustomerService>();
@@ -19,7 +19,7 @@ public class CustomerServiceTests : ServiceTest
         await _customerService.UpdateCustomerRoleAsync(moderator);
     }
 
-    [OneTimeTearDown]
+    [TearDown]
     public async Task TearDown()
     {
         var moderator = await _customerService.GetCustomerRoleBySystemNameAsync(NopCustomerDefaults.ForumModeratorsRoleName);

--- a/src/Tests/Nop.Tests/Nop.Services.Tests/ExportImport/ExportManagerTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Services.Tests/ExportImport/ExportManagerTests.cs
@@ -191,7 +191,7 @@ public class ExportManagerTests : ServiceTest
             if (manager.GetDefaultProperties.Any(p => p.PropertyName == propertyInfo.Name))
                 continue;
 
-            Assert.Fail("The property \"{0}.{1}\" no present on excel file", typeof(T).Name, propertyInfo.Name);
+            Assert.Fail($"The property \"{typeof(T).Name}.{propertyInfo.Name}\" no present on excel file");
         }
 
         return obj;

--- a/src/Tests/Nop.Tests/Nop.Services.Tests/Orders/OrderProcessingServiceTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Services.Tests/Orders/OrderProcessingServiceTests.cs
@@ -14,13 +14,13 @@ namespace Nop.Tests.Nop.Services.Tests.Orders;
 public class OrderProcessingServiceTests : ServiceTest
 {
     private IOrderService _orderService;
-    private OrderProcessingService _orderProcessingService;
+    private IOrderProcessingService _orderProcessingService;
 
     [OneTimeSetUp]
     public void SetUp()
     {
         _orderService = GetService<IOrderService>();
-        _orderProcessingService = GetService<OrderProcessingService>();
+        _orderProcessingService = GetService<IOrderProcessingService>();
     }
 
     [OneTimeTearDown]

--- a/src/Tests/Nop.Tests/Nop.Services.Tests/Orders/OrderTotalCalculationServiceTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Services.Tests/Orders/OrderTotalCalculationServiceTests.cs
@@ -21,7 +21,6 @@ using NUnit.Framework;
 namespace Nop.Tests.Nop.Services.Tests.Orders;
 
 [TestFixture]
-//[Ignore("This test leads the Stack Overflow Exception")]
 public class OrderTotalCalculationServiceTests : ServiceTest
 {
     private IOrderTotalCalculationService _orderTotalCalcService;
@@ -96,7 +95,7 @@ public class OrderTotalCalculationServiceTests : ServiceTest
 
     #endregion
 
-    [OneTimeSetUp]
+    [SetUp]
     public async Task SetUp()
     {
         _settingService = GetService<ISettingService>();
@@ -141,11 +140,11 @@ public class OrderTotalCalculationServiceTests : ServiceTest
         _customer = await _customerService.GetCustomerByEmailAsync(NopTestsDefaults.AdminEmail);
         _store = (await _storeService.GetAllStoresAsync()).First();
 
-        await GetService<IGenericAttributeService>().SaveAttributeAsync(_customer,
+        await _genericAttributeService.SaveAttributeAsync(_customer,
             NopCustomerDefaults.SelectedPaymentMethodAttribute, "Payments.TestMethod", 1);
     }
 
-    [OneTimeTearDown]
+    [TearDown]
     public async Task TearDown()
     {
         var settingService = GetService<ISettingService>();
@@ -361,11 +360,11 @@ public class OrderTotalCalculationServiceTests : ServiceTest
         var role = await _customerService.GetCustomerRoleBySystemNameAsync(NopCustomerDefaults.AdministratorsRoleName);
         role.FreeShipping = true;
         await _customerService.UpdateCustomerRoleAsync(role);
-        var isFreeShipping = await _orderTotalCalcService.IsFreeShippingAsync(await GetShoppingCartAsync());
         product.IsFreeShipping = true;
         await _productService.UpdateProductAsync(product);
         role.FreeShipping = false;
         await _customerService.UpdateCustomerRoleAsync(role);
+        var isFreeShipping = await _orderTotalCalcService.IsFreeShippingAsync(await GetShoppingCartAsync());
         isFreeShipping.Should().BeTrue();
     }
 
@@ -724,7 +723,6 @@ public class OrderTotalCalculationServiceTests : ServiceTest
         _rewardPointsSettings.MinimumRewardPointsToUse = 0;
 
         await _settingService.SaveSettingAsync(_rewardPointsSettings);
-        //var orderTotalCalculationService = GetService<IOrderTotalCalculationService>();
 
         GetService<IOrderTotalCalculationService>().CheckMinimumRewardPointsToUseRequirement(0).Should().BeTrue();
         GetService<IOrderTotalCalculationService>().CheckMinimumRewardPointsToUseRequirement(1).Should().BeTrue();

--- a/src/Tests/Nop.Tests/Nop.Tests.csproj
+++ b/src/Tests/Nop.Tests/Nop.Tests.csproj
@@ -15,11 +15,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Admin/Validators/Catalog/CategoryValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Admin/Validators/Catalog/CategoryValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation.TestHelper;
+using Nop.Services.Localization;
 using Nop.Web.Areas.Admin.Models.Catalog;
 using Nop.Web.Areas.Admin.Validators.Catalog;
 using NUnit.Framework;
@@ -13,7 +14,7 @@ public class CategoryValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _validator = GetService<CategoryValidator>();
+        _validator = new CategoryValidator(GetService<ILocalizationService>());
     }
 
     [Test]

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Admin/Validators/Catalog/ManufacturerValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Admin/Validators/Catalog/ManufacturerValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation.TestHelper;
+using Nop.Services.Localization;
 using Nop.Web.Areas.Admin.Models.Catalog;
 using Nop.Web.Areas.Admin.Validators.Catalog;
 using NUnit.Framework;
@@ -13,7 +14,7 @@ public class ManufacturerValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _validator = GetService<ManufacturerValidator>();
+        _validator = new ManufacturerValidator(GetService<ILocalizationService>());
     }
 
     [Test]

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Admin/Validators/Vendors/VendorValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Admin/Validators/Vendors/VendorValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation.TestHelper;
+using Nop.Services.Localization;
 using Nop.Web.Areas.Admin.Models.Vendors;
 using Nop.Web.Areas.Admin.Validators.Vendors;
 using NUnit.Framework;
@@ -13,7 +14,7 @@ public class VendorValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _validator = GetService<VendorValidator>();
+        _validator = new VendorValidator(GetService<ILocalizationService>());
     }
 
     [Test]

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Blogs/BlogPostValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Blogs/BlogPostValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation.TestHelper;
+using Nop.Services.Localization;
 using Nop.Web.Models.Blogs;
 using Nop.Web.Validators.Blogs;
 using NUnit.Framework;
@@ -13,7 +14,7 @@ public class BlogPostValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _validator = GetService<BlogPostValidator>();
+        _validator =  new BlogPostValidator(GetService<ILocalizationService>());
     }
 
     [Test]

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Boards/EditForumPostValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Boards/EditForumPostValidatorTests.cs
@@ -1,4 +1,6 @@
 ﻿using FluentValidation.TestHelper;
+using MimeKit.Cryptography;
+using Nop.Services.Localization;
 using Nop.Web.Models.Boards;
 using Nop.Web.Validators.Boards;
 using NUnit.Framework;
@@ -13,7 +15,7 @@ public class EditForumPostValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _validator = GetService<EditForumPostValidator>();
+        _validator = new EditForumPostValidator(GetService<ILocalizationService>()) ;
     }
 
     [Test]

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Boards/EditForumTopicValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Boards/EditForumTopicValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation.TestHelper;
+using Nop.Services.Localization;
 using Nop.Web.Models.Boards;
 using Nop.Web.Validators.Boards;
 using NUnit.Framework;
@@ -13,7 +14,7 @@ public class EditForumTopicValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _validator = GetService<EditForumTopicValidator>();
+        _validator = new EditForumTopicValidator(GetService<ILocalizationService>());
     }
 
     [Test]

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Catalog/ProductEmailAFriendValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Catalog/ProductEmailAFriendValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation.TestHelper;
+using Nop.Services.Localization;
 using Nop.Web.Models.Catalog;
 using Nop.Web.Validators.Catalog;
 using NUnit.Framework;
@@ -13,7 +14,7 @@ public class ProductEmailAFriendValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _validator = GetService<ProductEmailAFriendValidator>();
+        _validator = new ProductEmailAFriendValidator(GetService<ILocalizationService>());
     }
 
     [Test]

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Catalog/ProductReviewsValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Catalog/ProductReviewsValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation.TestHelper;
+using Nop.Services.Localization;
 using Nop.Web.Models.Catalog;
 using Nop.Web.Validators.Catalog;
 using NUnit.Framework;
@@ -13,7 +14,7 @@ public class ProductReviewsValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _validator = GetService<ProductReviewsValidator>();
+        _validator = new ProductReviewsValidator(GetService<ILocalizationService>());
     }
 
     [Test]

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Common/ContactUsValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Common/ContactUsValidatorTests.cs
@@ -1,4 +1,6 @@
 ﻿using FluentValidation.TestHelper;
+using Nop.Core.Domain.Common;
+using Nop.Services.Localization;
 using Nop.Web.Models.Common;
 using Nop.Web.Validators.Common;
 using NUnit.Framework;
@@ -13,7 +15,7 @@ public class ContactUsValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _validator = GetService<ContactUsValidator>();
+        _validator = new ContactUsValidator(GetService<ILocalizationService>(), GetService<CommonSettings>());
     }
 
     [Test]

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Common/ContactVendorValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Common/ContactVendorValidatorTests.cs
@@ -1,4 +1,6 @@
 ﻿using FluentValidation.TestHelper;
+using Nop.Core.Domain.Common;
+using Nop.Services.Localization;
 using Nop.Web.Models.Common;
 using Nop.Web.Validators.Common;
 using NUnit.Framework;
@@ -13,7 +15,7 @@ public class ContactVendorValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _validator = GetService<ContactVendorValidator>();
+        _validator =  new ContactVendorValidator(GetService<ILocalizationService>(), GetService<CommonSettings>());
     }
 
     [Test]

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Customer/ChangePasswordValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Customer/ChangePasswordValidatorTests.cs
@@ -1,4 +1,6 @@
 ﻿using FluentValidation.TestHelper;
+using Nop.Core.Domain.Customers;
+using Nop.Services.Localization;
 using Nop.Web.Models.Customer;
 using Nop.Web.Validators.Customer;
 using NUnit.Framework;
@@ -13,7 +15,7 @@ public class ChangePasswordValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _validator = GetService<ChangePasswordValidator>();
+        _validator = new ChangePasswordValidator(GetService<ILocalizationService>(), GetService<CustomerSettings>()) ;
     }
 
     [Test]

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Customer/CustomerInfoValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Customer/CustomerInfoValidatorTests.cs
@@ -21,10 +21,15 @@ public class CustomerInfoValidatorTests : BaseNopTest
         _stateProvinceService = GetService<IStateProvinceService>();
     }
 
+    private CustomerInfoValidator GetDefaultValidator()
+    {
+        return new CustomerInfoValidator(_localizationService, _stateProvinceService, GetService<CustomerSettings>());
+    }
+
     [Test]
     public void ShouldHaveErrorWhenEmailIsNullOrEmpty()
     {
-        var validator = GetService<CustomerInfoValidator>();
+        var validator = GetDefaultValidator();
 
         var model = new CustomerInfoModel
         {
@@ -38,7 +43,7 @@ public class CustomerInfoValidatorTests : BaseNopTest
     [Test]
     public void ShouldHaveErrorWhenEmailIsWrongFormat()
     {
-        var validator = GetService<CustomerInfoValidator>();
+        var validator = GetDefaultValidator();
 
         var model = new CustomerInfoModel
         {
@@ -50,7 +55,7 @@ public class CustomerInfoValidatorTests : BaseNopTest
     [Test]
     public void ShouldNotHaveErrorWhenEmailIsCorrectFormat()
     {
-        var validator = GetService<CustomerInfoValidator>();
+        var validator = GetDefaultValidator();
 
         var model = new CustomerInfoModel
         {

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Customer/LoginValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Customer/LoginValidatorTests.cs
@@ -15,7 +15,7 @@ public class LoginValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _validator = GetService<LoginValidator>();
+        _validator = new LoginValidator(GetService<ILocalizationService>(), GetService<CustomerSettings>());
     }
 
     [Test]

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Customer/PasswordRecoveryConfirmValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Customer/PasswordRecoveryConfirmValidatorTests.cs
@@ -1,4 +1,6 @@
 ﻿using FluentValidation.TestHelper;
+using Nop.Core.Domain.Customers;
+using Nop.Services.Localization;
 using Nop.Web.Models.Customer;
 using Nop.Web.Validators.Customer;
 using NUnit.Framework;
@@ -13,7 +15,7 @@ public class PasswordRecoveryConfirmValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _validator = GetService<PasswordRecoveryConfirmValidator>();
+        _validator = new PasswordRecoveryConfirmValidator(GetService<ILocalizationService>(), GetService<CustomerSettings>());
     }
 
     [Test]

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Customer/PasswordRecoveryValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Customer/PasswordRecoveryValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation.TestHelper;
+using Nop.Services.Localization;
 using Nop.Web.Models.Customer;
 using Nop.Web.Validators.Customer;
 using NUnit.Framework;
@@ -13,7 +14,7 @@ public class PasswordRecoveryValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _validator = GetService<PasswordRecoveryValidator>();
+        _validator = new PasswordRecoveryValidator(GetService<ILocalizationService>());
     }
 
     [Test]

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Customer/RegisterValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Customer/RegisterValidatorTests.cs
@@ -16,7 +16,7 @@ public class RegisterValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void SetUp()
     {
-        _validator = GetService<RegisterValidator>();
+        _validator = new RegisterValidator(GetService<ILocalizationService>(), GetService<IStateProvinceService>(), GetService<CustomerSettings>());
     }
 
     [Test]

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Install/InstallValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Install/InstallValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation.TestHelper;
+using Nop.Web.Infrastructure.Installation;
 using Nop.Web.Models.Install;
 using Nop.Web.Validators.Install;
 using NUnit.Framework;
@@ -13,7 +14,7 @@ public class InstallValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _validator = GetService<InstallValidator>();
+        _validator = new InstallValidator(GetService<IInstallationLocalizationService>());
     }
 
     [Test]

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/PrivateMessages/SendPrivateMessageValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/PrivateMessages/SendPrivateMessageValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation.TestHelper;
+using Nop.Services.Localization;
 using Nop.Web.Models.PrivateMessages;
 using Nop.Web.Validators.PrivateMessages;
 using NUnit.Framework;
@@ -13,7 +14,7 @@ public class SendPrivateMessageValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _validator = GetService<SendPrivateMessageValidator>();
+        _validator = new SendPrivateMessageValidator(GetService<ILocalizationService>());
     }
 
     [Test]

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/ShoppingCart/WishlistEmailAFriendValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/ShoppingCart/WishlistEmailAFriendValidatorTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation.TestHelper;
+using Nop.Services.Localization;
 using Nop.Web.Models.ShoppingCart;
 using Nop.Web.Validators.ShoppingCart;
 using NUnit.Framework;
@@ -13,7 +14,7 @@ public class WishlistEmailAFriendValidatorTests : BaseNopTest
     [OneTimeSetUp]
     public void Setup()
     {
-        _validator = GetService<WishlistEmailAFriendValidator>();
+        _validator = new WishlistEmailAFriendValidator(GetService<ILocalizationService>());
     }
 
     [Test]


### PR DESCRIPTION
fix (Tests): Fix Stackoverflow in tests and other issues.

- Update to NUnit 4
- Register missing services
- Change scope of IDataProviderManager (causing a stackoverflow in net8)
- Reduce state over tests by changing OneTimeSetup/Teardown to Setup/Teardown. TearDown
- Reduce coupling to DI for resolving Validators, Construct in test with dependencies (still via DI for now)
- Reduce the GetService Magic where it will construct a dependency even when it can't resolve it.  Either be explicit or register it.
- Some tests were using the implmenetation class not the interface so DI was not working (but the GetService magic filled the gap when the DI could not resolve from container.)

Resolves #6948

