### PR TITLE
fix (TinyMCE): Update tinymce to 5.10.9 to fix CVE-2023-48219 

### DIFF
--- a/src/Presentation/Nop.Web/package-lock.json
+++ b/src/Presentation/Nop.Web/package-lock.json
@@ -38,7 +38,7 @@
         "select2": "^4.1.0-rc.0",
         "shepherd.js": "^10.0.1",
         "swiper": "^8.3.2",
-        "tinymce": "^5.10.7",
+        "tinymce": "^5.10.9",
         "tinymce-langs": "1.0.0",
         "typeahead.js": "^0.11.1"
       },
@@ -5697,9 +5697,9 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
     },
     "node_modules/tinymce": {
-      "version": "5.10.7",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.7.tgz",
-      "integrity": "sha512-9UUjaO0R7FxcFo0oxnd1lMs7H+D0Eh+dDVo5hKbVe1a+VB0nit97vOqlinj+YwgoBDt6/DSCUoWqAYlLI8BLYA=="
+      "version": "5.10.9",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.9.tgz",
+      "integrity": "sha512-5bkrors87X9LhYX2xq8GgPHrIgJYHl87YNs+kBcjQ5I3CiUgzo/vFcGvT3MZQ9QHsEeYMhYO6a5CLGGffR8hMg=="
     },
     "node_modules/tinymce-langs": {
       "version": "1.0.0",
@@ -10201,11 +10201,6 @@
         "get-assigned-identifiers": "^1.1.0"
       }
     },
-    "select2": {
-      "version": "4.1.0-rc.0",
-      "resolved": "https://registry.npmjs.org/select2/-/select2-4.1.0-rc.0.tgz",
-      "integrity": "sha512-Hr9TdhyHCZUtwznEH2CBf7967mEM0idtJ5nMtjvk3Up5tPukOLXbHUNmh10oRfeNIhj+3GD3niu+g6sVK+gK0A=="
-    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -10767,9 +10762,9 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
     },
     "tinymce": {
-      "version": "5.10.7",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.7.tgz",
-      "integrity": "sha512-9UUjaO0R7FxcFo0oxnd1lMs7H+D0Eh+dDVo5hKbVe1a+VB0nit97vOqlinj+YwgoBDt6/DSCUoWqAYlLI8BLYA=="
+      "version": "5.10.9",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.10.9.tgz",
+      "integrity": "sha512-5bkrors87X9LhYX2xq8GgPHrIgJYHl87YNs+kBcjQ5I3CiUgzo/vFcGvT3MZQ9QHsEeYMhYO6a5CLGGffR8hMg=="
     },
     "tinymce-langs": {
       "version": "1.0.0",

--- a/src/Presentation/Nop.Web/package.json
+++ b/src/Presentation/Nop.Web/package.json
@@ -41,7 +41,7 @@
     "overlayscrollbars": "^1.13.3",
     "shepherd.js": "^10.0.1",
     "swiper": "^8.3.2",
-    "tinymce": "^5.10.7",
+    "tinymce": "^5.10.9",
     "tinymce-langs": "1.0.0",
     "typeahead.js": "^0.11.1"
   }


### PR DESCRIPTION
Upgrade tinymce lib to 5.10.9 to mitigate the vulnerability [CVE-2023-48219](https://www.cve.org/CVERecord?id=CVE-2023-48219)

Resolves #7017