### PR TITLE
fix(Security): Upgrade SqlClient to 5.1.4 to mitigate CVE-2024-0056

### DIFF
--- a/src/Libraries/Nop.Data/Nop.Data.csproj
+++ b/src/Libraries/Nop.Data/Nop.Data.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="FluentMigrator" Version="5.0.0" />
     <PackageReference Include="FluentMigrator.Runner" Version="5.0.0" />
     <PackageReference Include="linq2db" Version="5.3.2" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.2" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
     <PackageReference Include="MySqlConnector" Version="2.3.3" />
     <PackageReference Include="Npgsql" Version="8.0.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />


### PR DESCRIPTION
Upgrade SqlClient to 5.1.4 to mitigate CVE

[CVE-2024-0056](https://techcommunity.microsoft.com/t5/sql-server-blog/released-security-updates-for-microsoft-data-sqlclient-and/ba-p/4024264)

As it is a minor point release, there should be no compatability issues.

Resolves #7024 