### PR TITLE
feat(Localization): Allow setting a Language resource to an empty string value #6954

### DIFF
--- a/src/Libraries/Nop.Services/Localization/LocalizationService.cs
+++ b/src/Libraries/Nop.Services/Localization/LocalizationService.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq.Expressions;
+﻿#nullable enable
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Xml;
@@ -225,7 +226,7 @@ public partial class LocalizationService : ILocalizationService
     /// A task that represents the asynchronous operation
     /// The task result contains the locale string resource
     /// </returns>
-    public virtual async Task<LocaleStringResource> GetLocaleStringResourceByNameAsync(string resourceName, int languageId,
+    public virtual async Task<LocaleStringResource?> GetLocaleStringResourceByNameAsync(string resourceName, int languageId,
         bool logIfNotFound = true)
     {
         var query = from lsr in _lsrRepository.Table
@@ -250,7 +251,7 @@ public partial class LocalizationService : ILocalizationService
     /// <returns>
     /// The locale string resource
     /// </returns>
-    public virtual LocaleStringResource GetLocaleStringResourceByName(string resourceName, int languageId,
+    public virtual LocaleStringResource? GetLocaleStringResourceByName(string resourceName, int languageId,
         bool logIfNotFound = true)
     {
         var query = from lsr in _lsrRepository.Table
@@ -273,9 +274,11 @@ public partial class LocalizationService : ILocalizationService
     /// <returns>A task that represents the asynchronous operation</returns>
     public virtual async Task InsertLocaleStringResourceAsync(LocaleStringResource localeStringResource)
     {
-        if (!string.IsNullOrEmpty(localeStringResource?.ResourceName))
-            localeStringResource.ResourceName = localeStringResource.ResourceName.Trim().ToLowerInvariant();
+        ArgumentNullException.ThrowIfNull(localeStringResource);
 
+        if (!string.IsNullOrEmpty(localeStringResource.ResourceName))
+            localeStringResource.ResourceName = localeStringResource.ResourceName.Trim().ToLowerInvariant();
+        
         await _lsrRepository.InsertAsync(localeStringResource);
     }
 
@@ -364,7 +367,7 @@ public partial class LocalizationService : ILocalizationService
     /// A task that represents the asynchronous operation
     /// The task result contains a string representing the requested resource string.
     /// </returns>
-    public virtual async Task<string> GetResourceAsync(string resourceKey)
+    public virtual async Task<string?> GetResourceAsync(string resourceKey)
     {
         var workingLanguage = await _workContext.GetWorkingLanguageAsync();
 
@@ -386,10 +389,10 @@ public partial class LocalizationService : ILocalizationService
     /// A task that represents the asynchronous operation
     /// The task result contains a string representing the requested resource string.
     /// </returns>
-    public virtual async Task<string> GetResourceAsync(string resourceKey, int languageId,
+    public virtual async Task<string?> GetResourceAsync(string? resourceKey, int languageId,
         bool logIfNotFound = true, string defaultValue = "", bool returnEmptyIfNotFound = false)
     {
-        var result = string.Empty;
+        string? result = null;
         resourceKey ??= string.Empty;
         resourceKey = resourceKey.Trim().ToLowerInvariant();
         if (_localizationSettings.LoadAllLocaleRecordsOnStartup)
@@ -418,7 +421,7 @@ public partial class LocalizationService : ILocalizationService
                 result = lsr;
         }
 
-        if (!string.IsNullOrEmpty(result))
+        if (result != null)
             return result;
 
         if (logIfNotFound)
@@ -542,7 +545,7 @@ public partial class LocalizationService : ILocalizationService
     /// A task that represents the asynchronous operation
     /// The task result contains the localized property
     /// </returns>
-    public virtual async Task<TPropType> GetLocalizedAsync<TEntity, TPropType>(TEntity entity, Expression<Func<TEntity, TPropType>> keySelector,
+    public virtual async Task<TPropType?> GetLocalizedAsync<TEntity, TPropType>(TEntity entity, Expression<Func<TEntity, TPropType>> keySelector,
         int? languageId = null, bool returnDefaultValue = true, bool ensureTwoPublishedLanguages = true)
         where TEntity : BaseEntity, ILocalizedEntity
     {
@@ -608,7 +611,7 @@ public partial class LocalizationService : ILocalizationService
     /// A task that represents the asynchronous operation
     /// The task result contains the localized property
     /// </returns>
-    public virtual async Task<string> GetLocalizedSettingAsync<TSettings>(TSettings settings, Expression<Func<TSettings, string>> keySelector,
+    public virtual async Task<string?> GetLocalizedSettingAsync<TSettings>(TSettings settings, Expression<Func<TSettings, string>> keySelector,
         int languageId, int storeId, bool returnDefaultValue = true, bool ensureTwoPublishedLanguages = true)
         where TSettings : ISettings, new()
     {
@@ -758,7 +761,7 @@ public partial class LocalizationService : ILocalizationService
     /// <param name="resourceValue">Resource value</param>
     /// <param name="languageCulture">Language culture code. If null or empty, then a resource will be added for all languages</param>
     /// <returns>A task that represents the asynchronous operation</returns>
-    public virtual async Task AddOrUpdateLocaleResourceAsync(string resourceName, string resourceValue, string languageCulture = null)
+    public virtual async Task AddOrUpdateLocaleResourceAsync(string resourceName, string resourceValue, string? languageCulture = null)
     {
         foreach (var lang in await _languageService.GetAllLanguagesAsync(true))
         {
@@ -934,7 +937,7 @@ public partial class LocalizationService : ILocalizationService
         if (string.IsNullOrEmpty(result) && returnDefaultValue)
             result = plugin.PluginDescriptor.FriendlyName;
 
-        return result;
+        return result!;
     }
 
     /// <summary>

--- a/src/Presentation/Nop.Web.Framework/Mvc/Razor/NopRazorPage.cs
+++ b/src/Presentation/Nop.Web.Framework/Mvc/Razor/NopRazorPage.cs
@@ -25,7 +25,7 @@ public abstract partial class NopRazorPage<TModel> : Microsoft.AspNetCore.Mvc.Ra
             _localizer ??= (format, args) =>
             {
                 var resFormat = _localizationService.GetResourceAsync(format).Result;
-                if (string.IsNullOrEmpty(resFormat))
+                if (resFormat == null)
                 {
                     return new LocalizedString(format);
                 }

--- a/src/Presentation/Nop.Web/Areas/Admin/Models/Localization/LocaleResourceModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Models/Localization/LocaleResourceModel.cs
@@ -1,4 +1,5 @@
 ﻿using Nop.Web.Framework.Models;
+using Nop.Web.Framework.Mvc;
 using Nop.Web.Framework.Mvc.ModelBinding;
 
 namespace Nop.Web.Areas.Admin.Models.Localization;
@@ -14,7 +15,8 @@ public partial record LocaleResourceModel : BaseNopEntityModel
     public string ResourceName { get; set; }
 
     [NopResourceDisplayName("Admin.Configuration.Languages.Resources.Fields.Value")]
-    public string ResourceValue { get; set; }
+    [NoTrim]
+    public string ResourceValue { get; set; } = string.Empty;
 
     public int LanguageId { get; set; }
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Validators/Localization/LanguageResourceValidator.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Validators/Localization/LanguageResourceValidator.cs
@@ -19,7 +19,7 @@ public partial class LanguageResourceValidator : BaseNopValidator<LocaleResource
                 .WithMessageAwait(localizationService.GetResourceAsync("Admin.Configuration.Languages.Resources.Fields.Name.Required"));
 
             RuleFor(model => model.ResourceValue)
-                .NotEmpty()
+                .NotNull()
                 .WithMessageAwait(localizationService.GetResourceAsync("Admin.Configuration.Languages.Resources.Fields.Value.Required"));
 
             SetDatabaseValidationRules<LocaleStringResource>();

--- a/src/Tests/Nop.Tests/Nop.Services.Tests/Localization/LocalizationServiceTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Services.Tests/Localization/LocalizationServiceTests.cs
@@ -116,7 +116,7 @@ public class LocalizationServiceTests : ServiceTest
     }
 
     [Test]
-    public async Task AddOrUpdateLocaleResourceShouldApdateAllResorcesIfLangIdIsNull()
+    public async Task AddOrUpdateLocaleResourceShouldUpdateAllResourcesIfLangIdIsNull()
     {
         var languageService = GetService<ILanguageService>();
         var language = new Language
@@ -152,7 +152,7 @@ public class LocalizationServiceTests : ServiceTest
     }
 
     [Test]
-    public async Task DeleteLocaleResourcesShuoldIgnoreCase()
+    public async Task DeleteLocaleResourcesShouldIgnoreCase()
     {
         await _localizationService.AddOrUpdateLocaleResourceAsync(_resources);
 
@@ -167,6 +167,16 @@ public class LocalizationServiceTests : ServiceTest
             .Where(p => p.ResourceName.StartsWith(PREFIX, StringComparison.InvariantCultureIgnoreCase)).ToList();
 
         rez.Count.Should().Be(0);
+    }
+
+    [TestCase("A Value")]
+    [TestCase("")] //empty string is valid value
+    public async Task CanGetResourceAsync(string val)
+    {
+        var resKey = $"{PREFIX}.CanGetResourceAsync";
+        await _localizationService.AddOrUpdateLocaleResourceAsync(resKey,val);
+        var resource = await _localizationService.GetResourceAsync(resKey);
+        resource.Should().Be(val);
     }
 
     public class LocaleResourceConsumer : IConsumer<EntityUpdatedEvent<LocaleStringResource>>

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Localization/LanguageResourceValidatorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Validators/Localization/LanguageResourceValidatorTests.cs
@@ -1,0 +1,60 @@
+﻿using FluentValidation.Internal;
+using FluentValidation.TestHelper;
+using Moq;
+using Nop.Services.Localization;
+using Nop.Web.Areas.Admin.Models.Localization;
+using Nop.Web.Areas.Admin.Validators.Localization;
+using NUnit.Framework;
+
+namespace Nop.Tests.Nop.Web.Tests.Public.Validators.Localization;
+
+[TestFixture]
+public class LanguageResourceValidatorTests : BaseNopTest
+{
+    private LanguageResourceValidator _validator;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var localizationServiceMock = new Mock<ILocalizationService>();
+        localizationServiceMock.Setup(x => x.GetResourceAsync(It.IsAny<string>())).ReturnsAsync("Mocked message");
+        _validator = new LanguageResourceValidator(localizationServiceMock.Object);
+    }
+
+    [Test]
+    public void ShouldHaveErrorWhenResourceNameIsEmpty()
+    {
+        var model = new LocaleResourceModel { ResourceName = string.Empty, ResourceValue = "Value" };
+        var result = _validator.TestValidate(model, DefaultValidationOptions());
+        result.ShouldHaveValidationErrorFor(x => x.ResourceName);
+    }
+
+    [Test]
+    public void ShouldNotHaveErrorWhenResourceNameIsSpecified()
+    {
+        var model = new LocaleResourceModel { ResourceName = "Name", ResourceValue = "Value" };
+        var result = _validator.TestValidate(model, DefaultValidationOptions());
+        result.ShouldNotHaveValidationErrorFor(x => x.ResourceName);
+    }
+
+    [Test]
+    public void ShouldHaveErrorWhenResourceValueIsNull()
+    {
+        var model = new LocaleResourceModel { ResourceName = "Name", ResourceValue = null };
+        var result = _validator.TestValidate(model, DefaultValidationOptions());
+        result.ShouldHaveValidationErrorFor(x => x.ResourceValue);
+    }
+
+    [Test]
+    public void ShouldNotHaveErrorWhenResourceValueIsSpecified()
+    {
+        var model = new LocaleResourceModel { ResourceName = "Name", ResourceValue = "Value" };
+        var result = _validator.TestValidate(model, DefaultValidationOptions());
+        result.ShouldNotHaveValidationErrorFor(x => x.ResourceValue);
+    }
+
+    private static Action<ValidationStrategy<LocaleResourceModel>> DefaultValidationOptions()
+    {
+        return options=>options.IncludeAllRuleSets();
+    }
+}


### PR DESCRIPTION
## Change
This change allows setting a empty string for a language resource.
If the value is `null`, it will still default to existing functionality of the resource name being shown.

`#nullable` was enabled on `LocalizationService`, methods that _may return null_ were modified to indicate this.
## Possible Breaking changes
- `InsertLocaleStringResourceAsync` may throw `ArgumentNullException` if param `localeStringResource` is null, which may be a different exception type then previous.

Resolves #6954 