### PR TITLE
task(Deps): Update Microsoft.Aspnet, LigerShark, Autofac.Extensions 

### DIFF
--- a/src/Libraries/Nop.Core/Nop.Core.csproj
+++ b/src/Libraries/Nop.Core/Nop.Core.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Blobs" Version="1.3.2" />
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.2" />

--- a/src/Libraries/Nop.Core/Nop.Core.csproj
+++ b/src/Libraries/Nop.Core/Nop.Core.csproj
@@ -21,11 +21,11 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.DataProtection.Keys" Version="1.2.2" />
     <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Humanizer" Version="2.14.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="8.0.1" />
     <PackageReference Include="Nito.AsyncEx.Coordination" Version="5.1.2" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/src/Plugins/Nop.Plugin.ExternalAuth.Facebook/Nop.Plugin.ExternalAuth.Facebook.csproj
+++ b/src/Plugins/Nop.Plugin.ExternalAuth.Facebook/Nop.Plugin.ExternalAuth.Facebook.csproj
@@ -58,7 +58,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Facebook" Version="8.0.1" />
   </ItemGroup>
 
   <!-- This target execute after "Build" target -->

--- a/src/Presentation/Nop.Web.Framework/Nop.Web.Framework.csproj
+++ b/src/Presentation/Nop.Web.Framework/Nop.Web.Framework.csproj
@@ -16,9 +16,9 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
-    <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.380" />
-    <PackageReference Include="WebMarkupMin.AspNetCore8" Version="2.15.2" />
-    <PackageReference Include="WebMarkupMin.NUglify" Version="2.15.1" />
+    <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.396" />
+    <PackageReference Include="WebMarkupMin.AspNetCore8" Version="2.15.3" />
+    <PackageReference Include="WebMarkupMin.NUglify" Version="2.15.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bump Microsoft.AspNetCore and Microsoft.Extensions.Caching to 8.0.1
- Release notes: https://devblogs.microsoft.com/dotnet/january-2024-updates/

Bump LigerShark.WebOptimizer.Core to 3.0.396 and WebMarkupMin to 2.15.3
- https://github.com/Taritsyn/WebMarkupMin/releases/tag/v2.15.3
- https://github.com/ligershark/WebOptimizer/commits/master/

Bump Autofac.Extensions.DependencyInjection to 9
- Release notes: https://github.com/autofac/Autofac.Extensions.DependencyInjection/releases/tag/v9.0.0

Relates to #196