### PR TITLE
refactor (jQuery): Update to non-deprecated ready signature

### DIFF
--- a/src/Plugins/Nop.Plugin.DiscountRules.CustomerRoles/Views/Configure.cshtml
+++ b/src/Plugins/Nop.Plugin.DiscountRules.CustomerRoles/Views/Configure.cshtml
@@ -4,7 +4,7 @@
 }
 
     <script>
-    $(document).ready(function () {
+    $(function() {
         $('#savecustomerrolesrequirement@(Model.RequirementId)').click(function () {
             var customerRoleId = $("#@Html.IdFor(model => model.CustomerRoleId)").val();
             var discountId = @Model.DiscountId;

--- a/src/Plugins/Nop.Plugin.Misc.Brevo/Views/Configure.cshtml
+++ b/src/Plugins/Nop.Plugin.Misc.Brevo/Views/Configure.cshtml
@@ -127,7 +127,7 @@
         {
             <nop-card asp-name="brevo-synchronization" asp-icon="fas fa-exchange" asp-title="@T("Plugins.Misc.Brevo.Synchronization")" asp-hide-block-attribute-name="@BrevoDefaults.HideSynchronizationBlock" asp-hide="@Model.HideSynchronizationBlock" asp-advanced="false">
                 <script>
-                    $(document).ready(function () {
+                    $(function() {
                         //$("#progressBar").hide();
                         if (@((ViewData["synchronizationStart"] != null && (bool)ViewData["synchronizationStart"]).ToString().ToLowerInvariant())) {
                             $("#progressBar").show();
@@ -451,7 +451,7 @@
                                         </div>
                                     </div>
                                     <script>
-                                        $(document).ready(function () {
+                                        $(function() {
                                             $('#addSms').click(function () {
                                                 $('#addSms').attr('disabled', true);
                                                 var postData = {
@@ -576,7 +576,7 @@
                                 <div class="col-md-9">
                                     <nop-textarea asp-for="TrackingScript" />
                                     <script>
-                                        $(document).ready(function() {
+                                        $(function() {
                                             $('#@Html.IdFor(model => model.TrackingScript)').height($('#@Html.IdFor(model => model.TrackingScript)')[0].scrollHeight);
                                         });
                                     </script>

--- a/src/Plugins/Nop.Plugin.Misc.Zettle/Views/Configure.cshtml
+++ b/src/Plugins/Nop.Plugin.Misc.Zettle/Views/Configure.cshtml
@@ -328,7 +328,7 @@
                     })
 
                     <script>
-                        $(document).ready(function () {
+                        $(function() {
                             $('#recordsUpdate').click(function () {
                                 updateTable('#records-grid');
                                 return false;
@@ -434,7 +434,7 @@
                 @if (Model.Import.Active)
                 {
                     <script>
-                        $(document).ready(function () {
+                        $(function() {
                             $('#start-sync').prop('disabled', true);
                             updateSyncState();
                         });

--- a/src/Plugins/Nop.Plugin.Payments.CyberSource/Views/Configure.cshtml
+++ b/src/Plugins/Nop.Plugin.Payments.CyberSource/Views/Configure.cshtml
@@ -180,7 +180,7 @@
 </form>
 
 <script asp-location="Footer">
-    $(document).ready(function() {
+    $(function() {
         $('#@Html.IdFor(model => model.PaymentConnectionMethodId)').change(toggleConnectionMethod);
         toggleConnectionMethod();
     });

--- a/src/Plugins/Nop.Plugin.Payments.CyberSource/Views/CustomerToken/_CreateOrUpdateToken.cshtml
+++ b/src/Plugins/Nop.Plugin.Payments.CyberSource/Views/CustomerToken/_CreateOrUpdateToken.cshtml
@@ -18,7 +18,7 @@
 </div>
 
 <script asp-location="Footer">
-    $(document).ready(function() {
+    $(function() {
         makeCardNumberReadOnly();
     });
 

--- a/src/Plugins/Nop.Plugin.Payments.CyberSource/Views/PaymentInfo.cshtml
+++ b/src/Plugins/Nop.Plugin.Payments.CyberSource/Views/PaymentInfo.cshtml
@@ -50,7 +50,7 @@
     </div>
 
     <script asp-location="Footer">
-        $(document).ready(function () {
+        $(function() {
             toggleNewAndExistingCardSection();
         });
 
@@ -97,7 +97,7 @@ else
         <input type="hidden" asp-for="TransientToken" />
 
         <script asp-location="Footer">
-            $(document).ready(function () {
+            $(function() {
                 $('.payment-info-next-step-button').hide();
 
                 var payButton = $('#pay-button');

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Views/Buttons.cshtml
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Views/Buttons.cshtml
@@ -15,7 +15,7 @@
 else
 {
     <script asp-location="Footer">
-        $(document).ready(function () {
+        $(function() {
             $('#checkout').after('<div id="paypal-button-container"></div>');
             $('#checkout').hide();
 
@@ -25,7 +25,7 @@ else
 }
 
 <script asp-location="Footer">
-    $(document).ready(function() {
+    $(function() {
         var paymentForm = paypal.Buttons({
             fundingSource: paypal.FUNDING.PAYPAL,
             onClick: function (e, n) {

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Views/Configure.cshtml
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Views/Configure.cshtml
@@ -20,7 +20,7 @@
 }
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdFor(model => model.SetCredentialsManually)").click(toggleCredentials);
         toggleCredentials();
     });

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Views/PaymentInfo.cshtml
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Views/PaymentInfo.cshtml
@@ -20,7 +20,7 @@
     </style>
 
     <script asp-location="Footer">
-        $(document).ready(function () {
+        $(function() {
             $('.payment-info-next-step-button').hide();
 
             var paymentForm = paypal.Buttons({

--- a/src/Plugins/Nop.Plugin.Pickup.PickupInStore/Views/Configure.cshtml
+++ b/src/Plugins/Nop.Plugin.Pickup.PickupInStore/Views/Configure.cshtml
@@ -74,7 +74,7 @@
                 <button id="btnRefresh" type="submit" name="save" class="btn btn-default" style="display: none"></button>
             </div>
             <script>
-                $(document).ready(function () {
+                $(function() {
                     $('#btnRefresh').click(function () {
                         //refresh grid
                         updateTable('#pickup-points-grid');

--- a/src/Plugins/Nop.Plugin.Pickup.PickupInStore/Views/_CreateOrUpdate.cshtml
+++ b/src/Plugins/Nop.Plugin.Pickup.PickupInStore/Views/_CreateOrUpdate.cshtml
@@ -16,7 +16,7 @@
     <div class="card card-default card-popup">
 
         <script>
-            $(document).ready(function() {
+            $(function() {
                 $("#@Html.IdFor(model => model.Address.CountryId)").change(function(){
                     var selectedItem = $(this).val();
                     var ddlStates = $("#@Html.IdFor(model => model.Address.StateProvinceId)");

--- a/src/Plugins/Nop.Plugin.Shipping.FixedByWeightByTotal/Views/_ByWeightByTotal.cshtml
+++ b/src/Plugins/Nop.Plugin.Shipping.FixedByWeightByTotal/Views/_ByWeightByTotal.cshtml
@@ -16,7 +16,7 @@
 }
 
 <script asp-location="Footer">
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdFor(model => model.SearchCountryId)").change(function () {
             var selectedItem = $(this).val();
             var ddlStates = $("#@Html.IdFor(model => model.SearchStateProvinceId)");

--- a/src/Plugins/Nop.Plugin.Shipping.FixedByWeightByTotal/Views/_CreateOrUpdateRateByWeightByTotal.cshtml
+++ b/src/Plugins/Nop.Plugin.Shipping.FixedByWeightByTotal/Views/_CreateOrUpdateRateByWeightByTotal.cshtml
@@ -13,7 +13,7 @@
 }
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdFor(model => model.CountryId)").change(function () {
             var selectedItem = $(this).val();
             var ddlStates = $("#@Html.IdFor(model => model.StateProvinceId)");

--- a/src/Plugins/Nop.Plugin.Shipping.UPS/Views/Configure.cshtml
+++ b/src/Plugins/Nop.Plugin.Shipping.UPS/Views/Configure.cshtml
@@ -9,7 +9,7 @@
 
 <form asp-controller="UPSShipping" asp-action="Configure" method="post">
     <script>
-        $(document).ready(function () {
+        $(function() {
             $("#PackingType").change(togglePackingType);
             togglePackingType();
         });

--- a/src/Plugins/Nop.Plugin.Tax.Avalara/Views/Checkout/AddressValidation.cshtml
+++ b/src/Plugins/Nop.Plugin.Tax.Avalara/Views/Checkout/AddressValidation.cshtml
@@ -1,7 +1,7 @@
 ﻿@model AddressValidationModel
 
 <script asp-location="Footer">
-    $(document).ready(function () {
+    $(function() {
         @if (Model.IsError)
         {
             <text>alert('@Model.Message');</text>

--- a/src/Plugins/Nop.Plugin.Tax.Avalara/Views/Configuration/_Configuration.cshtml
+++ b/src/Plugins/Nop.Plugin.Tax.Avalara/Views/Configuration/_Configuration.cshtml
@@ -95,7 +95,7 @@
                     <span asp-validation-for="TaxOriginAddressTypeId"></span>
                 </div>
                 <script>
-                    $(document).ready(function () {
+                    $(function() {
                         $('#@Html.IdFor(model => model.TaxOriginAddressTypeId)').click(changeOriginAddressType);
                     });
 
@@ -126,7 +126,7 @@
                 </div>
             </div>
             <script>
-                $(document).ready(function () {
+                $(function() {
                     $('#@Html.IdFor(model => model.UseTaxRateTables)').click(toggleUseTaxRateTables);
                     toggleUseTaxRateTables();
                 });
@@ -166,7 +166,7 @@
                     <span asp-validation-for="EnableCertificates"></span>
                 </div>
                 <script>
-                    $(document).ready(function () {
+                    $(function() {
                         $('#@Html.IdFor(model => model.EnableCertificates)').click(changeEnableCertificates);
                     });
 
@@ -188,7 +188,7 @@
                             <div class="col-md-4">
                                 <nop-select asp-for="SelectedCustomerRoleIds" asp-items="@Model.AvailableCustomerRoles" asp-multiple="true" />
                                 <script>
-                                $(document).ready(function() {
+                                $(function() {
                                     var rolesIdsInput = $('#@Html.IdFor(model => model.SelectedCustomerRoleIds)').select2({
                                         closeOnSelect: false,
                                         @if (!Model.AvailableCustomerRoles.Any())
@@ -267,7 +267,7 @@
             </div>
             <div class="card-body">
                 <script>
-                    $(document).ready(function () {
+                    $(function() {
                         $('#@Html.IdFor(model => model.TestAddress.CountryId)').change(function () {
                             var selectedItem = $(this).val();
                             var ddlStates = $('#@Html.IdFor(model => model.TestAddress.StateProvinceId)');

--- a/src/Plugins/Nop.Plugin.Tax.Avalara/Views/EntityUseCode/EntityUseCode.cshtml
+++ b/src/Plugins/Nop.Plugin.Tax.Avalara/Views/EntityUseCode/EntityUseCode.cshtml
@@ -6,7 +6,7 @@
 
     <text>
         <script>
-            $(document).ready(function() {
+            $(function() {
                 $('#@Model.PrecedingElementId').closest('.form-group').after(`@field`);
                 $('#AvalaraEntityUseCode_label > .ico-help').css('color', '#f39c12');
             });

--- a/src/Plugins/Nop.Plugin.Tax.Avalara/Views/ItemClassification/_ItemClassificationConfiguration.cshtml
+++ b/src/Plugins/Nop.Plugin.Tax.Avalara/Views/ItemClassification/_ItemClassificationConfiguration.cshtml
@@ -26,7 +26,7 @@
                                 <nop-select asp-for="SelectedCountryIds" asp-items="@Model.AvailableCountries" asp-multiple="true" />
                                 <span asp-validation-for="SelectedCountryIds"></span>
                                 <script>
-                                    $(document).ready(function () {
+                                    $(function() {
                                         var countryIdsInput = $('#@Html.IdFor(model => model.SelectedCountryIds)').data("kendoMultiSelect");
                                         countryIdsInput.setOptions({
                                             autoClose: false,
@@ -175,7 +175,7 @@
                         })
 
                         <script>
-                            $(document).ready(function () {
+                            $(function() {
                                 $('#recordsUpdate').click(function () {
                                     updateTable('#item-classification-grid');
                                     return false;

--- a/src/Plugins/Nop.Plugin.Tax.Avalara/Views/Log/List.cshtml
+++ b/src/Plugins/Nop.Plugin.Tax.Avalara/Views/Log/List.cshtml
@@ -84,7 +84,7 @@
                     })
 
                                                <script>
-                $(document).ready(function() {
+                $(function() {
                     $('#delete-selected-action-confirmation-submit-button').bind('click', function () {
                         var postData = {
                             selectedIds: selectedIds

--- a/src/Plugins/Nop.Plugin.Tax.Avalara/Views/Product/ExportItems.cshtml
+++ b/src/Plugins/Nop.Plugin.Tax.Avalara/Views/Product/ExportItems.cshtml
@@ -9,7 +9,7 @@
 }
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $('#delete-selected').before(`@button`);
         $('#export-excel-selected-form').after(`@form`);
     });

--- a/src/Plugins/Nop.Plugin.Tax.Avalara/Views/Product/_ExportItemsForm.cshtml
+++ b/src/Plugins/Nop.Plugin.Tax.Avalara/Views/Product/_ExportItemsForm.cshtml
@@ -1,6 +1,6 @@
 ﻿<form asp-controller="AvalaraProduct" asp-action="ExportProducts" method="post" id="export-avalara-selected-form">
     <script>
-        $(document).ready(function () {
+        $(function() {
             $('#export-avalara-selected').click(function (e) {
                 e.preventDefault();
                 var ids = selectedIds.join(',');

--- a/src/Plugins/Nop.Plugin.Tax.Avalara/Views/Tax/Categories.cshtml
+++ b/src/Plugins/Nop.Plugin.Tax.Avalara/Views/Tax/Categories.cshtml
@@ -147,7 +147,7 @@
                                     </div>
                                 </div>
                                 <script>
-                                    $(document).ready(function () {
+                                    $(function() {
                                         $('#addTaxCategory').click(function () {
                                             $('#addTaxCategory').attr('disabled', true);
                                             var postData = {

--- a/src/Plugins/Nop.Plugin.Tax.FixedOrByCountryStateZip/Views/Configure.cshtml
+++ b/src/Plugins/Nop.Plugin.Tax.FixedOrByCountryStateZip/Views/Configure.cshtml
@@ -43,7 +43,7 @@
         }
     }
     checkAdvancedSettingsMode($("#advanced-settings-mode").is(':checked'));
-    $(document).ready(function() {
+    $(function() {
         $("#advanced-settings-mode").click(function() {
             checkAdvancedSettingsMode($(this).is(':checked'));
 

--- a/src/Plugins/Nop.Plugin.Widgets.FacebookPixel/Views/Configuration/_CreateOrUpdate.cshtml
+++ b/src/Plugins/Nop.Plugin.Widgets.FacebookPixel/Views/Configuration/_CreateOrUpdate.cshtml
@@ -223,7 +223,7 @@
                             <span asp-validation-for="DisableForUsersNotAcceptingCookieConsent"></span>
                         </div>
                         <script>
-                            $(document).ready(function () {
+                            $(function() {
                                 $("#@Html.IdFor(model => model.DisableForUsersNotAcceptingCookieConsent)").click(toggleCheckbox);
                                 $("#@Html.IdFor(model => model.ConversionsApiEnabled)").click(toggleConversionsApiFormField);
                                 toggleCheckbox();
@@ -338,7 +338,7 @@
                                     asp-items="@Model.CustomEventSearchModel.AddCustomEvent.AvailableWidgetZones"
                                     asp-multiple="true" />
                                 <script>
-                                    $(document).ready(function () {
+                                    $(function() {
                                         var input = $('#@Html.IdFor(model => model.CustomEventSearchModel.AddCustomEvent.WidgetZonesIds)').select2({
                                             closeOnSelect: false,
                                         });
@@ -354,7 +354,7 @@
                         </div>
 
                         <script>
-                            $(document).ready(function () {
+                            $(function() {
                                 $('#add').click(function () {
                                     $('#add').attr('disabled', true);
                                     var postData = {

--- a/src/Plugins/Nop.Plugin.Widgets.What3words/Views/PublicInfo.cshtml
+++ b/src/Plugins/Nop.Plugin.Widgets.What3words/Views/PublicInfo.cshtml
@@ -23,7 +23,7 @@
 </div>
 
 <script asp-location="Footer">
-    $(document).ready(function() {
+    $(function() {
         $("#@(Model.Prefix)_CountryId").change(function(){
             var selectedItem = $(this).children("option:selected").val();
             var w3w = $("#what3words-autosuggest_@(Model.Prefix)");

--- a/src/Presentation/Nop.Web.Framework/Extensions/HtmlExtensions.cs
+++ b/src/Presentation/Nop.Web.Framework/Extensions/HtmlExtensions.cs
@@ -135,7 +135,7 @@ public static class HtmlExtensions
         //render tabs script
         var script = new TagBuilder("script");
         script.InnerHtml.AppendHtml(
-            "$(document).ready(function () {" +
+            "$(function() {" +
             "bindBootstrapTabSelectEvent('" + name + "', 'selected-tab-name-" + name + "');" +
             "});");
         var scriptTag = await script.RenderHtmlContentAsync();
@@ -201,7 +201,7 @@ public static class HtmlExtensions
     {
         return new HtmlString($@"
                 <script>
-                    $(document).ready(function() {{
+                    $(function() {{
                         $('<li><a data-tab-name='{tabId}' data-toggle='tab' href='#{tabId}'>{tabName}</a></li>').appendTo('#{eventMessage.TabStripName} .nav-tabs:first');
                         $.get('{url}', function(result) {{
                             $(`<div class='tab-pane' id='{tabId}'>` + result + `</div>`).appendTo('#{eventMessage.TabStripName} .tab-content:first');
@@ -222,7 +222,7 @@ public static class HtmlExtensions
     {
         return new HtmlString($@"
                 <script>
-                    $(document).ready(function() {{
+                    $(function() {{
                         $(`<li><a data-tab-name='{tabId}' data-toggle='tab' href='#{tabId}'>{tabName}</a></li>`).appendTo('#{eventMessage.TabStripName} .nav-tabs:first');
                         $(`<div class='tab-pane' id='{tabId}'>{contentModel}</div>`).appendTo('#{eventMessage.TabStripName} .tab-content:first');
                     }});

--- a/src/Presentation/Nop.Web.Framework/TagHelpers/Admin/NopActionConfirmationTagHelper.cs
+++ b/src/Presentation/Nop.Web.Framework/TagHelpers/Admin/NopActionConfirmationTagHelper.cs
@@ -83,7 +83,7 @@ public partial class NopActionConfirmationTagHelper : TagHelper
         //modal script
         var script = new TagBuilder("script");
         script.InnerHtml.AppendHtml(
-            "$(document).ready(function () {" +
+            "$(function() {" +
             $"$('#{ButtonId}').attr(\"data-toggle\", \"modal\").attr(\"data-target\", \"#{modalId}\");" +
             $"$('#{modalId}-submit-button').attr(\"name\", $(\"#{ButtonId}\").attr(\"name\"));" +
             $"$(\"#{ButtonId}\").attr(\"name\", \"\");" +

--- a/src/Presentation/Nop.Web.Framework/TagHelpers/Admin/NopAlertTagHelper.cs
+++ b/src/Presentation/Nop.Web.Framework/TagHelpers/Admin/NopAlertTagHelper.cs
@@ -79,7 +79,7 @@ public partial class NopAlertTagHelper : TagHelper
         //modal script
         var script = new TagBuilder("script");
         script.InnerHtml.AppendHtml(
-            "$(document).ready(function () {" +
+            "$(function() {" +
             $"$('#{AlertId}').attr(\"data-toggle\", \"modal\").attr(\"data-target\", \"#{modalId}\")" +
             "});");
         var scriptTag = await script.RenderHtmlContentAsync();

--- a/src/Presentation/Nop.Web.Framework/TagHelpers/Admin/NopDeleteConfirmationTagHelper.cs
+++ b/src/Presentation/Nop.Web.Framework/TagHelpers/Admin/NopDeleteConfirmationTagHelper.cs
@@ -87,7 +87,7 @@ public partial class NopDeleteConfirmationTagHelper : TagHelper
         //modal script
         var script = new TagBuilder("script");
         script.InnerHtml.AppendHtml(
-            "$(document).ready(function () {" +
+            "$(function() {" +
             $"$('#{ButtonId}').attr(\"data-toggle\", \"modal\").attr(\"data-target\", \"#{modalId}\")" +
             "});");
         var scriptTag = await script.RenderHtmlContentAsync();

--- a/src/Presentation/Nop.Web.Framework/TagHelpers/Admin/NopNestedSettingTagHelper.cs
+++ b/src/Presentation/Nop.Web.Framework/TagHelpers/Admin/NopNestedSettingTagHelper.cs
@@ -65,7 +65,7 @@ public partial class NopNestedSettingTagHelper : TagHelper
         var isNot = IsConditionInvert ? "!" : "";
 
         script.InnerHtml.AppendHtml(
-            "$(document).ready(function () {" +
+            "$(function() {" +
             $"initNestedSetting('{parentSettingName}', '{parentSettingId}', '{nestedSettingId}');"
         );
 

--- a/src/Presentation/Nop.Web.Framework/TagHelpers/Admin/NopTabsTagHelper.cs
+++ b/src/Presentation/Nop.Web.Framework/TagHelpers/Admin/NopTabsTagHelper.cs
@@ -119,7 +119,7 @@ public partial class NopTabsTagHelper : TagHelper
             {
                 var script = new TagBuilder("script");
                 script.InnerHtml.AppendHtml(
-                    "$(document).ready(function () {" +
+                    "$(function() {" +
                     "bindBootstrapTabSelectEvent('" + output.Attributes["id"].Value + "', 'selected-tab-name');" +
                     "});");
                 var scriptTag = await script.RenderHtmlContentAsync();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/AddressAttribute/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/AddressAttribute/_CreateOrUpdate.Info.cshtml
@@ -67,7 +67,7 @@
 
 
 <script>
-    $(document).ready(function() {
+    $(function() {
         $("#@Html.IdFor(model => model.AttributeControlTypeId)").change(toggleAttributeControlType);
         toggleAttributeControlType();
     });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/AddressAttribute/_CreateOrUpdate.Values.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/AddressAttribute/_CreateOrUpdate.Values.cshtml
@@ -56,7 +56,7 @@
                     return '<button onclick=\"javascript:OpenWindow(\'@Url.Content("~/Admin/AddressAttribute/ValueEditPopup/")' + data + '?btnId=btnRefresh&formId=addressattribute-form\', 800, 800, true); return false;\" class="btn btn-default"><i class="fas fa-pencil-alt"></i>@T("Admin.Common.Edit").Text</button>';
                 }
 
-                $(document).ready(function () {
+                $(function() {
                     $('#btnRefresh').click(function () {
                         //refresh grid
                         updateTable('#addressattributevalues-grid');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Blog/BlogComments.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Blog/BlogComments.cshtml
@@ -186,7 +186,7 @@
                             })
 
                             <script>
-                        $(document).ready(function() {
+                        $(function() {
                             //"delete selected" button
                             $("#delete-selected-action-confirmation-submit-button").bind("click", function () {
                                 var postData = {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Blog/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Blog/_CreateOrUpdate.Info.cshtml
@@ -7,7 +7,7 @@
 
 <script asp-location="Footer">
     //tags
-    $(document).ready(function() {
+    $(function() {
         @Html.Raw(Model.InitialBlogTags)
         $("#@Html.IdFor(model => model.Tags)").tagEditor({
             autocomplete: {
@@ -117,7 +117,7 @@
         <div class="col-md-9">
             <nop-select asp-for="SelectedStoreIds" asp-items="Model.AvailableStores" asp-multiple="true" />
             <script>
-                $(document).ready(function() {
+                $(function() {
                     var storesIdsInput = $('#@Html.IdFor(model => model.SelectedStoreIds)').select2({
                         closeOnSelect: false,
                         @if (!Model.AvailableStores.Any())

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Blog/_CreateOrUpdate.Seo.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Blog/_CreateOrUpdate.Seo.cshtml
@@ -38,7 +38,7 @@
         </div>
     </div>
     <script>
-        $(document).ready(function () {
+        $(function() {
             $('#@Html.IdFor(model => model.SeName)').on('input change', function () {
                 var parameters = {
                     entityId: '@Model.Id',

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Campaign/_CreateOrUpdate.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Campaign/_CreateOrUpdate.cshtml
@@ -101,7 +101,7 @@
                                     <nop-textarea asp-for="Body" asp-required="true"></nop-textarea>
                                     <text>
                                         <script>
-                                        $(document).ready(function () {
+                                        $(function() {
                                             $('#@Html.IdFor(model => model.Body)').height($('#@Html.IdFor(model => model.Body)')[0].scrollHeight);
                                         });
                                         </script>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Category/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Category/List.cshtml
@@ -164,7 +164,7 @@
                         })
 
                         <script>
-                            $(document).ready(function () {
+                            $(function() {
                                 $('#delete-selected-action-confirmation-submit-button').bind('click', function () {
                                     var postData = {
                                         selectedIds: selectedIds

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Category/_CreateOrUpdate.Display.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Category/_CreateOrUpdate.Display.cshtml
@@ -118,7 +118,7 @@
 </div>
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdFor(model => model.AllowCustomersToSelectPageSize)").click(togglePageSize);
 
         togglePageSize();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Category/_CreateOrUpdate.Mappings.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Category/_CreateOrUpdate.Mappings.cshtml
@@ -8,7 +8,7 @@
         <div class="col-md-9">
             <nop-select asp-for="SelectedDiscountIds" asp-items="Model.AvailableDiscounts" asp-multiple="true" />
             <script>
-				$(document).ready(function() {
+				$(function() {
 					var discountsIdsInput = $('#@Html.IdFor(model => model.SelectedDiscountIds)').select2({
                         closeOnSelect: false,
                         @if (!Model.AvailableDiscounts.Any())
@@ -32,7 +32,7 @@
                 <div class="col-md-4">
                     <nop-select asp-for="SelectedCustomerRoleIds" asp-items="Model.AvailableCustomerRoles" asp-multiple="true" />
                     <script>
-						$(document).ready(function() {
+						$(function() {
 							var rolesIdsInput = $('#@Html.IdFor(model => model.SelectedCustomerRoleIds)').select2({
                                 closeOnSelect: false,
                                 @if (!Model.AvailableCustomerRoles.Any())
@@ -61,7 +61,7 @@
                 <div class="col-md-4">
                     <nop-select asp-for="SelectedStoreIds" asp-items="Model.AvailableStores" asp-multiple="true" />
                     <script>
-						$(document).ready(function() {
+						$(function() {
 							var storesIdsInput = $('#@Html.IdFor(model => model.SelectedStoreIds)').select2({
                                 closeOnSelect: false,
                                 @if (!Model.AvailableStores.Any())

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Category/_CreateOrUpdate.Products.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Category/_CreateOrUpdate.Products.cshtml
@@ -66,7 +66,7 @@
         </button>
         <button type="submit" id="btnRefreshProducts" style="display: none"></button>
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#btnRefreshProducts').click(function () {
                     //refresh grid
                     updateTable('#products-grid');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Category/_CreateOrUpdate.Seo.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Category/_CreateOrUpdate.Seo.cshtml
@@ -40,7 +40,7 @@
             </div>
         </div>
         <script>
-			$(document).ready(function () {
+			$(function() {
 				$('#@Html.IdFor(model => model.Locales[item].SeName)').on('input change', function () {
 					var parameters = {
 					    entityId: '@Model.Id',
@@ -92,7 +92,7 @@
             </div>
         </div>
         <script>
-    		$(document).ready(function () {
+    		$(function() {
     			$('#@Html.IdFor(model => model.SeName)').on('input change', function () {
     				var parameters = {
     				    entityId: '@Model.Id',

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/CheckoutAttribute/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/CheckoutAttribute/List.cshtml
@@ -83,7 +83,7 @@
                         })
 
                         <script>
-                    $(document).ready(function () {
+                    $(function() {
                         $('#delete-selected-action-confirmation-submit-button').bind('click', function () {
                             var postData = {
                                 selectedIds: selectedIds

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/CheckoutAttribute/_CreateOrUpdate.Condition.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/CheckoutAttribute/_CreateOrUpdate.Condition.cshtml
@@ -24,7 +24,7 @@
                         <nop-select asp-for="ConditionModel.SelectedAttributeId" asp-items="@(Model.ConditionModel.ConditionAttributes.Select(x => new SelectListItem() {Text = x.Name, Value = x.Id.ToString()}))" />
 
                         <script>
-                            $(document).ready(function() {
+                            $(function() {
                                 $("#@Html.IdFor(model => model.ConditionModel.SelectedAttributeId)")
                                     .change(toggleConditionAttributes);
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/CheckoutAttribute/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/CheckoutAttribute/_CreateOrUpdate.Info.cshtml
@@ -178,7 +178,7 @@
                 <div class="col-md-4">
                     <nop-select asp-for="SelectedStoreIds" asp-items="Model.AvailableStores" asp-multiple="true" />
                     <script>
-                    $(document).ready(function() {
+                    $(function() {
                         var storesIdsInput = $('#@Html.IdFor(model => model.SelectedStoreIds)').select2({
                             closeOnSelect: false,
                             @if (!Model.AvailableStores.Any())
@@ -201,7 +201,7 @@
 </div>
 
 <script>
-    $(document).ready(function() {
+    $(function() {
 
         $("#@Html.IdFor(model => model.IsTaxExempt)").click(toggleTax);
         $("#@Html.IdFor(model => model.AttributeControlTypeId)").change(toggleAttributeControlType);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/CheckoutAttribute/_CreateOrUpdate.Values.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/CheckoutAttribute/_CreateOrUpdate.Values.cshtml
@@ -65,7 +65,7 @@
         </button>
         <button type="submit" id="btnRefresh" style="display: none"></button>
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#btnRefresh').click(function () {
                     //refresh grid
                     updateTable('#checkoutattributevalues-grid');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/CheckoutAttribute/_CreateOrUpdateValue.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/CheckoutAttribute/_CreateOrUpdateValue.cshtml
@@ -64,7 +64,7 @@
                                 <nop-editor asp-for="ColorSquaresRgb"/>
                                 <div id="color-picker"></div>
                                 <script>
-                                    $(document).ready(function(){
+                                    $(function(){
                                         $('#color-picker').farbtastic('#@Html.IdFor(model => model.ColorSquaresRgb)');
                     });
                                 </script>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Common/SeNames.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Common/SeNames.cshtml
@@ -162,7 +162,7 @@
     }
 </script>
 <script>
-    $(document).ready(function() {
+    $(function() {
         //"delete selected" button
         $("#delete-selected-action-confirmation-submit-button").bind("click", function () {
             var postData = {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Common/_Maintenance.DBBackups.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Common/_Maintenance.DBBackups.cshtml
@@ -60,7 +60,7 @@
             showThrobber('@Html.Raw(JavaScriptEncoder.Default.Encode(T("Admin.System.Maintenance.BackupDatabase.Progress").Text))');
         };
 
-        $(document).ready(function () {
+        $(function() {
             $("#backup-database").on("click", function () {
                 showProgress();
             });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Common/_Maintenance.ReindexDatabaseTables.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Common/_Maintenance.ReindexDatabaseTables.cshtml
@@ -13,7 +13,7 @@
                     @T("Admin.System.Maintenance.ReIndexTables.ReIndexNow")
                 </button>
                 <script>
-                    $(document).ready(function() {
+                    $(function() {
                         $("button[name='re-index']").on("click", function () {
                             $("html, body").animate({ scrollTop: 0 }, 400);
                             showThrobber('@Html.Raw(JavaScriptEncoder.Default.Encode(T("Admin.System.Maintenance.ReIndexTables.Progress").Text))');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Country/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Country/List.cshtml
@@ -132,7 +132,7 @@
 
 
                     <script>
-                        $(document).ready(function () {
+                        $(function() {
                             //"publish selected" button
                             $('#publish-selected').click(function (e) {
                                 e.preventDefault();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Country/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Country/_CreateOrUpdate.Info.cshtml
@@ -92,7 +92,7 @@
                 <div class="col-md-4">
                     <nop-select asp-for="SelectedStoreIds" asp-items="Model.AvailableStores" asp-multiple="true"/>
                     <script>
-                        $(document).ready(function() {
+                        $(function() {
                             var storesIdsInput = $('#@Html.IdFor(model => model.SelectedStoreIds)').select2({
                                 closeOnSelect: false,
                                 @if (!Model.AvailableStores.Any())

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Country/_CreateOrUpdate.States.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Country/_CreateOrUpdate.States.cshtml
@@ -61,7 +61,7 @@
             </button>
             <button type="submit" id="btnRefresh" style="display: none"></button>
             <script>
-                $(document).ready(function () {
+                $(function() {
                     $('#btnRefresh').click(function () {
                         //refresh grid
                         updateTable('#states-grid');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Currency/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Currency/List.cshtml
@@ -144,7 +144,7 @@
                                 <script>
                         var selectedId;
 
-                        $(document).ready(function () {
+                        $(function() {
 
                             $("#btnMarkPSC-action-confirmation-submit-button").bind("click", function () {
                                 var postData = {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Currency/_CreateOrUpdate.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Currency/_CreateOrUpdate.cshtml
@@ -98,7 +98,7 @@
                                     <div class="col-md-4">
                                         <nop-select asp-for="SelectedStoreIds" asp-items="Model.AvailableStores" asp-multiple="true"/>
                                         <script>
-                                        $(document).ready(function() {
+                                        $(function() {
                                             var storesIdsInput = $('#@Html.IdFor(model => model.SelectedStoreIds)').select2({
                                                 closeOnSelect: false,
                                                 @if (!Model.AvailableStores.Any())

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Customer/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Customer/List.cshtml
@@ -231,7 +231,7 @@
                                             <div class="col-md-8">                                               
                                                     <nop-select asp-for="SelectedCustomerRoleIds" asp-items="Model.AvailableCustomerRoles" asp-multiple="true" />                                                                                                                                              
                                                 <script>
-                                                    $(document).ready(function() {
+                                                    $(function() {
                                                         var rolesIdsInput =
                                                             $('#@Html.IdFor(model => model.SelectedCustomerRoleIds)').select2({
                                                                 closeOnSelect: false,
@@ -379,7 +379,7 @@
     <input type="hidden" id="selectedIds" name="selectedIds" value="" />
 </form>
 <script>
-    $(document).ready(function () {
+    $(function() {
         $('#exportxml-selected').click(function (e) {
             e.preventDefault();
             var ids = selectedIds.join(",");
@@ -446,7 +446,7 @@
     <input type="hidden" id="selectedIds" name="selectedIds" value="" />
 </form>
 <script>
-    $(document).ready(function () {
+    $(function() {
         $('#exportexcel-selected').click(function (e) {
             e.preventDefault();
             var ids = selectedIds.join(",");

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Customer/_CreateOrUpdate.CurrentShoppingCart.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Customer/_CreateOrUpdate.CurrentShoppingCart.cshtml
@@ -62,7 +62,7 @@
     })
 
     <script>
-        $(document).ready(function() {
+        $(function() {
             $('#@Html.IdFor(model => model.CustomerShoppingCartSearchModel.ShoppingCartTypeId)').change(function() {
                 updateTable('#currentshoppingcart-grid');
             });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Customer/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Customer/_CreateOrUpdate.Info.cshtml
@@ -4,7 +4,7 @@
 @if (Model.CountryEnabled && Model.StateProvinceEnabled)
 {
     <script>
-        $(document).ready(function() {
+        $(function() {
             $("#@Html.IdFor(model => model.CountryId)").change(function() {
                 var selectedItem = $(this).val();
                 var ddlStates = $("#@Html.IdFor(model => model.StateProvinceId)");
@@ -319,7 +319,7 @@
                     <div class="input-group-btn"></div>
                 </div>
                 <script>
-                $(document).ready(function() {
+                $(function() {
                     var newsletterSubscriptionStoreIdsInput = $('#@Html.IdFor(model => model.SelectedNewsletterSubscriptionStoreIds)').select2();
                 });
                 </script>
@@ -341,7 +341,7 @@
                 </div>
             </div>
             <script>
-                $(document).ready(function() {
+                $(function() {
                     var customerRoleIdsInput = $('#@Html.IdFor(model => model.SelectedCustomerRoleIds)').select2({
                         closeOnSelect: false,
                         @if (!Model.AvailableCustomerRoles.Any())

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Customer/_CreateOrUpdate.RewardPoints.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Customer/_CreateOrUpdate.RewardPoints.cshtml
@@ -115,7 +115,7 @@
             </div>
         </div>
         <script>
-        $(document).ready(function () {
+        $(function() {
             $("#@Html.IdFor(model => Model.AddRewardPoints.ActivatePointsImmediately)").click(activatePointsImmediately);
             activatePointsImmediately();
             $('#addRewardPoints').click(function () {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/CustomerAttribute/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/CustomerAttribute/_CreateOrUpdate.Info.cshtml
@@ -3,7 +3,7 @@
 @using Nop.Services
 
 <script>
-    $(document).ready(function() {
+    $(function() {
         $("#@Html.IdFor(model => model.AttributeControlTypeId)").change(toggleAttributeControlType);
         toggleAttributeControlType();
     });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/CustomerAttribute/_CreateOrUpdate.Values.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/CustomerAttribute/_CreateOrUpdate.Values.cshtml
@@ -58,7 +58,7 @@
         </button>
         <button type="submit" id="btnRefresh" style="display: none"></button>
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#btnRefresh').click(function () {
                     //refresh grid
                     updateTable('#customerattributevalues-grid');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/CustomerRole/_CreateOrUpdate.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/CustomerRole/_CreateOrUpdate.cshtml
@@ -4,7 +4,7 @@
 <input asp-for="Id" type="hidden" />
 
 <script>
-    $(document).ready(function() {
+    $(function() {
         toggleRemoveButton();
     });
     
@@ -106,7 +106,7 @@
                                 <button type="submit" id="btnRefreshPurchasedWithProduct" style="display: none"></button>
 
                                 <script>
-                                $(document).ready(function () {
+                                $(function() {
                                     $('#purchased-with-product-name-remove').click(function () {
                                         $('#purchased-with-product-name').text('');
                                         $("#@Html.IdFor(model => model.PurchasedWithProductId)").val(0);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Discount/_CreateOrUpdate.AppliedToCategories.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Discount/_CreateOrUpdate.AppliedToCategories.cshtml
@@ -40,7 +40,7 @@
         </button>
         <button type="submit" id="btnRefreshCategories" style="display: none"></button>
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#btnRefreshCategories').click(function () {
                     //refresh grid
                     updateTable('#categories-grid');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Discount/_CreateOrUpdate.AppliedToManufacturers.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Discount/_CreateOrUpdate.AppliedToManufacturers.cshtml
@@ -40,7 +40,7 @@
         </button>
         <button type="submit" id="btnRefreshManufacturers" style="display: none"></button>
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#btnRefreshManufacturers').click(function () {
                     //refresh grid
                     updateTable('#manufacturers-grid');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Discount/_CreateOrUpdate.AppliedToProducts.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Discount/_CreateOrUpdate.AppliedToProducts.cshtml
@@ -40,7 +40,7 @@
         </button>
         <button type="submit" id="btnRefreshProducts" style="display: none"></button>
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#btnRefreshProducts').click(function () {
                     //refresh grid
                     updateTable('#products-grid');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Discount/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Discount/_CreateOrUpdate.Info.cshtml
@@ -3,7 +3,7 @@
 @using Nop.Services
 
 <script>
-    $(document).ready(function() {
+    $(function() {
         $("#@Html.IdFor(model => model.DiscountTypeId)").change(toggleDiscountType);
         $("#@Html.IdFor(model => model.UsePercentage)").click(toggleUsePercentage);
         $("#@Html.IdFor(model => model.RequiresCouponCode)").click(toggleRequiresCouponCode);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Discount/_CreateOrUpdate.Requirements.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Discount/_CreateOrUpdate.Requirements.cshtml
@@ -10,7 +10,7 @@
             </p>
 
             <script>
-            $(document).ready(function() {
+            $(function() {
                 $("#@Html.IdFor(model => model.AddDiscountRequirement)").change(loadNewRequirementBox);
 
                 //load add requirement box

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/GiftCard/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/GiftCard/_CreateOrUpdate.Info.cshtml
@@ -63,7 +63,7 @@
                 <div class="input-group-append">
                     <button type="button" id="generateCouponCode" class="btn btn-info">@T("Admin.GiftCards.Fields.GiftCardCouponCode.Generate")</button>
                     <script>
-                        $(document).ready(function() {
+                        $(function() {
                             $('#generateCouponCode').click(function() {
                                 var postData = {};
 
@@ -170,7 +170,7 @@
 <nop-alert asp-alert-id="generateCouponCodeFailed" asp-alert-message="@T("Admin.GiftCards.Fields.GiftCardCouponCode.Alert.FailedGenerate")" />
 
 <script>
-    $(document).ready(function() {
+    $(function() {
         $("#@Html.IdFor(model => model.GiftCardTypeId)").change(toggleGiftCardType);
         toggleGiftCardType();
     });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_BestsellersBriefReportByAmount.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_BestsellersBriefReportByAmount.cshtml
@@ -26,7 +26,7 @@
         </div>
     </div>
     <script>
-        $(document).ready(function () {
+        $(function() {
             var collapsed = !$('#@cardId').hasClass('collapsed-card');
             if (collapsed) {
                 $('#bestsellersBriefReportByAmount').load('@Url.Action("GetBestsellersBriefReportByAmount", "Home")');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_BestsellersBriefReportByQuantity.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_BestsellersBriefReportByQuantity.cshtml
@@ -26,7 +26,7 @@
         </div>
     </div>
     <script>
-        $(document).ready(function () {
+        $(function() {
             var collapsed = !$('#@cardId').hasClass('collapsed-card');
             if (collapsed) {
                 $('#bestsellersBriefReportByQuantity').load('@Url.Action("GetBestsellersBriefReportByQuantity", "Home")');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_ConfigurationSteps.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_ConfigurationSteps.cshtml
@@ -41,7 +41,7 @@
         </div>
     </div>
     <script>
-        $(document).ready(function () {
+        $(function() {
             $('#@cardId').on('click', 'button[data-card-widget="collapse"]', function () {
                 var collapsed = !$('#@cardId').hasClass('collapsed-card');
                 saveUserPreferences('@(Url.Action("SavePreference", "Preferences"))', '@NopCustomerDefaults.HideConfigurationStepsAttribute', collapsed);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_CustomerStatistics.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_CustomerStatistics.cshtml
@@ -38,7 +38,7 @@
 </div>
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         var csCurrentPeriod;
 
         $('#@(prefix)-card').on('click',  'button[data-card-widget="collapse"]', function () {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_LatestOrders.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_LatestOrders.cshtml
@@ -27,7 +27,7 @@
         </div>
     </div>
     <script>
-        $(document).ready(function () {
+        $(function() {
             var collapsed = !$('#@cardId').hasClass('collapsed-card');
             if (collapsed) {
                 $('#latestOrdersReport').load('@Url.Action("GetLatestOrders", "Home")');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_OrderAverageReport.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_OrderAverageReport.cshtml
@@ -26,7 +26,7 @@
         </div>
     </div>
     <script>
-        $(document).ready(function () {
+        $(function() {
             var collapsed = !$('#@cardId').hasClass('collapsed-card');
             if (collapsed) {
                 $('#orderAverageReport').load('@Url.Action("GetOrderAverage", "Home")');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_OrderIncompleteReport.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_OrderIncompleteReport.cshtml
@@ -26,7 +26,7 @@
         </div>
     </div>
     <script>
-        $(document).ready(function () {
+        $(function() {
             var collapsed = !$('#@cardId').hasClass('collapsed-card');
             if (collapsed) {
                 $('#orderIncompleteReport').load('@Url.Action("GetOrderIncomplete", "Home")');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_OrderStatistics.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_OrderStatistics.cshtml
@@ -38,7 +38,7 @@
 </div>
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         var osCurrentPeriod;
 
         $('#@(prefix)-card').on('click', 'button[data-card-widget="collapse"]', function () {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_PopularSearchTermsReport.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_PopularSearchTermsReport.cshtml
@@ -26,7 +26,7 @@
         </div>
     </div>
     <script>
-        $(document).ready(function () {
+        $(function() {
             var collapsed = !$('#@cardId').hasClass('collapsed-card');
             if (collapsed) {
                 $('#popularSearchTermsReport').load('@Url.Action("GetPopularSearchTerm", "Home")');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Language/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Language/_CreateOrUpdate.Info.cshtml
@@ -27,7 +27,7 @@
             <nop-select asp-for="LanguageCulture" asp-items="@cultures" />
             <span asp-validation-for="LanguageCulture"></span>
             <script>
-                $(document).ready(function() {
+                $(function() {
                     $('#@Html.IdFor(model => model.LanguageCulture)').on('input change', function () {
                         warningValidation('@Url.Action("LanguageCultureWarning")', '@Html.NameFor(model => model.LanguageCulture)', { currentCulture: '@(Model.LanguageCulture)', changedCulture: $(this).val() });
                     });
@@ -97,7 +97,7 @@
                 <div class="col-md-3">
                     <nop-select asp-for="SelectedStoreIds" asp-items="Model.AvailableStores" asp-multiple="true" />
                     <script>
-                        $(document).ready(function() {
+                        $(function() {
                             var storesIdsInput = $('#@Html.IdFor(model => model.SelectedStoreIds)').select2({
                                 closeOnSelect: false,
                                 @if (!Model.AvailableStores.Any())

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Language/_CreateOrUpdate.Resources.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Language/_CreateOrUpdate.Resources.cshtml
@@ -125,7 +125,7 @@
                                 </div>
                             </div>
                             <script>
-                    $(document).ready(function () {
+                    $(function() {
                         $('#addResourceString').click(function () {
                             $('#addResourceString').attr('disabled', true);
                             var postData = {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Log/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Log/List.cshtml
@@ -157,7 +157,7 @@
                             })
 
                             <script>
-                                $(document).ready(function() {
+                                $(function() {
                                     //"delete selected" button
                                     $("#delete-selected-action-confirmation-submit-button").bind("click", function () {
                                         var postData = {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Manufacturer/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Manufacturer/List.cshtml
@@ -166,7 +166,7 @@
 
 
                     <script>
-                        $(document).ready(function () {
+                        $(function() {
                             $('#delete-selected-action-confirmation-submit-button').bind('click', function () {
                                 var postData = {
                                     selectedIds: selectedIds

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Manufacturer/_CreateOrUpdate.Display.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Manufacturer/_CreateOrUpdate.Display.cshtml
@@ -100,7 +100,7 @@
 </div>
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdFor(model => model.AllowCustomersToSelectPageSize)").click(togglePageSize);
 
         togglePageSize();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Manufacturer/_CreateOrUpdate.Mappings.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Manufacturer/_CreateOrUpdate.Mappings.cshtml
@@ -8,7 +8,7 @@
         <div class="col-md-9">
             <nop-select asp-for="SelectedDiscountIds" asp-items="Model.AvailableDiscounts" asp-multiple="true" />
             <script>
-                $(document).ready(function() {
+                $(function() {
                     var discountsIdsInput = $('#@Html.IdFor(model => model.SelectedDiscountIds)').select2({
                         closeOnSelect: false,
                         @if (!Model.AvailableDiscounts.Any())
@@ -33,7 +33,7 @@
                 <div class="col-md-4">
                     <nop-select asp-for="SelectedCustomerRoleIds" asp-items="Model.AvailableCustomerRoles" asp-multiple="true" />
                     <script>
-                        $(document).ready(function() {
+                        $(function() {
                             var rolesIdsInput = $('#@Html.IdFor(model => model.SelectedCustomerRoleIds)').select2({
                                 closeOnSelect: false,
                                 @if (!Model.AvailableCustomerRoles.Any())
@@ -63,7 +63,7 @@
                 <div class="col-md-4">
                     <nop-select asp-for="SelectedStoreIds" asp-items="Model.AvailableStores" asp-multiple="true" />
                     <script>
-                        $(document).ready(function() {
+                        $(function() {
                             var storesIdsInput = $('#@Html.IdFor(model => model.SelectedStoreIds)').select2({
                                 closeOnSelect: false,
                                 @if (!Model.AvailableStores.Any())

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Manufacturer/_CreateOrUpdate.Products.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Manufacturer/_CreateOrUpdate.Products.cshtml
@@ -65,7 +65,7 @@
     </button>
     <button type="submit" id="btnRefreshProducts" style="display: none"></button>
     <script>
-        $(document).ready(function () {
+        $(function() {
             $('#btnRefreshProducts').click(function () {
                 //refresh grid
                 updateTable('#products-grid');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Manufacturer/_CreateOrUpdate.Seo.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Manufacturer/_CreateOrUpdate.Seo.cshtml
@@ -40,7 +40,7 @@
             </div>
         </div>
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#@Html.IdFor(model => model.Locales[item].SeName)').on('input change', function () {
                     var parameters = {
                         entityId: '@Model.Id',
@@ -92,7 +92,7 @@
             </div>
         </div>
         <script>
-              $(document).ready(function () {
+              $(function() {
                   $('#@Html.IdFor(model => model.SeName)').on('input change', function () {
                       var parameters = {
                           entityId: '@Model.Id',

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Measure/Dimensions.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Measure/Dimensions.cshtml
@@ -80,7 +80,7 @@
                 $("#btnMarkAsPrimaryDimension").click();
             };
 
-            $(document).ready(function () {
+            $(function() {
                 $("#btnMarkAsPrimaryDimension-action-confirmation-submit-button").bind("click", function () {
                     var postData = {
                         id: selectedId
@@ -151,7 +151,7 @@
                 </div>
             </div>
             <script>
-                $(document).ready(function () {
+                $(function() {
                     $('#addMeasureDimension').click(function () {
                         $('#addMeasureDimension').attr('disabled', true);
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Measure/Weights.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Measure/Weights.cshtml
@@ -79,7 +79,7 @@
                 $("#btnMarkAsPrimaryWeight").click();
             };
 
-            $(document).ready(function () {
+            $(function() {
                 $("#btnMarkAsPrimaryWeight-action-confirmation-submit-button").bind("click", function () {
                     var postData = {
                         id: selectedId
@@ -150,7 +150,7 @@
                 </div>
             </div>
             <script>
-                $(document).ready(function () {
+                $(function() {
                     $('#addMeasureWeight').click(function () {
                         $('#addMeasureWeight').attr('disabled', true);
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/MessageTemplate/_CreateOrUpdate.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/MessageTemplate/_CreateOrUpdate.cshtml
@@ -73,7 +73,7 @@
                                                 <nop-textarea asp-for="@Model.Locales[item].Body"/>
                                                 <text>
                                                     <script>
-                                                        $(document).ready(function() {
+                                                        $(function() {
                                                             $('#@Html.IdFor(model => model.Locales[item].Body)').height('auto');
                                                         });
                                                     </script>
@@ -146,7 +146,7 @@
                                             <nop-textarea asp-for="Body" asp-required="true" />
                                             <text>
                                                 <script>
-                                                    $(document).ready(function() {
+                                                    $(function() {
                                                         $('#@Html.IdFor(model => model.Body)').height('auto');
                                                     });
                                                 </script>
@@ -262,7 +262,7 @@
                                     <div class="col-md-4">
                                         <nop-select asp-for="SelectedStoreIds" asp-items="Model.AvailableStores" asp-multiple="true" />
                                         <script>
-                                            $(document).ready(function() {
+                                            $(function() {
                                                 var storesIdsInput = $('#@Html.IdFor(model => model.SelectedStoreIds)').select2({
                                                     closeOnSelect: false,
                                                     @if (!Model.AvailableStores.Any())
@@ -287,7 +287,7 @@
                 @await Component.InvokeAsync(typeof(AdminWidgetViewComponent), new { widgetZone = AdminWidgetZones.MessageTemplateDetailsBottom, additionalData = Model })
             </div>
             <script>
-                $(document).ready(function() {
+                $(function() {
                     $("#@Html.IdFor(model => model.HasAttachedDownload)").change(toggleHasAttachedDownload);
                     $("#@Html.IdFor(model => model.SendImmediately)").click(sendImmediately);
                     toggleHasAttachedDownload();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/News/NewsComments.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/News/NewsComments.cshtml
@@ -190,7 +190,7 @@
                     })
 
                     <script>
-                        $(document).ready(function() {
+                        $(function() {
                             //"delete selected" button
                             $("#delete-selected-action-confirmation-submit-button").bind("click",
                                 function() {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/News/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/News/_CreateOrUpdate.Info.cshtml
@@ -81,7 +81,7 @@
                 <div class="col-md-4">
                     <nop-select asp-for="SelectedStoreIds" asp-items="Model.AvailableStores" asp-multiple="true" />
                     <script>
-                        $(document).ready(function() {
+                        $(function() {
                             var storesIdsInput = $('#@Html.IdFor(model => model.SelectedStoreIds)').select2({
                                 closeOnSelect: false,
                                 @if (!Model.AvailableStores.Any())

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/News/_CreateOrUpdate.Seo.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/News/_CreateOrUpdate.Seo.cshtml
@@ -38,7 +38,7 @@
         </div>
     </div>
     <script>
-        $(document).ready(function () {
+        $(function() {
             $('#@Html.IdFor(model => model.SeName)').on('input change', function () {
                 var parameters = {
                     entityId: '@Model.Id',

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/AddShipment.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/AddShipment.cshtml
@@ -107,7 +107,7 @@
                             }
                         </div>
                         <script>
-                            $(document).ready(function () {
+                            $(function() {
                                 $("#shipment-save").bind("focus", function () {
                                     if (validateWarehouseAvailability("save")) {
                                         $("#shipment-save-action-confirmation").remove();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/Edit.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/Edit.cshtml
@@ -45,7 +45,7 @@
                 }
                 <button type="submit" id="btnRefreshPage" style="display: none"></button>
                 <script>
-                    $(document).ready(function () {
+                    $(function() {
                         $('#btnRefreshPage').click(function () {
                             //refresh pageed
                             location.reload();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/List.cshtml
@@ -136,7 +136,7 @@
                                                     <button type="button" id="search-product-clear" class="btn bg-gray" style="display: none; margin-top: 5px;">@T("Admin.Common.Clear")</button>
                                                     <input asp-for="ProductId" autocomplete="off" style="display: none;" />
                                                     <script>
-                                                    $(document).ready(function() {
+                                                    $(function() {
                                                         $('#search-product-name').autocomplete({
                                                             delay: 500,
                                                             minLength: 3,
@@ -418,7 +418,7 @@
                                     return `${row.CustomerFullName}<br /><a href="${link}">${data}</a>`;
                                 }
 
-                                $(document).ready(function() {
+                                $(function() {
                                     $("#@Html.IdFor(model => model.GoDirectlyToCustomOrderNumber)").keydown(
                                         function(event) {
                                             if (event.keyCode === 13) {
@@ -479,7 +479,7 @@
 }
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         var displayModal = @((Model.LicenseCheckModel.DisplayWarning == true || Model.LicenseCheckModel?.BlockPages == true).ToString().ToLower());
         if (displayModal){
             $('#license-window').modal({
@@ -524,7 +524,7 @@
 </form>
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $('#exportxml-selected').click(function (e) {
             e.preventDefault();
             var ids = selectedIds.join(",");
@@ -549,7 +549,7 @@
 </form>
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $('#exportexcel-selected').click(function (e) {
             e.preventDefault();
             var ids = selectedIds.join(",");
@@ -574,7 +574,7 @@
 </form>
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $('#pdf-invoice-selected').click(function (e) {
             e.preventDefault();
             var ids = selectedIds.join(",");

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/ShipmentDetails.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/ShipmentDetails.cshtml
@@ -11,7 +11,7 @@
 
 <form asp-controller="Order" asp-action="ShipmentDetails" method="post">
     <script>
-        $(document).ready(function() {
+        $(function() {
             toggleShippedDate(false);
             toggleReadyForPickupDate(false);
             toggleDeliveryDate(false);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/ShipmentList.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/ShipmentList.cshtml
@@ -313,7 +313,7 @@
                             </div>
                         </div>
                         <script>
-                            $(document).ready(function() {
+                            $(function() {
                                 //load states when changing a country dropdownlist
                                 $("#@Html.IdFor(model => model.CountryId)").change(function() {
                                     var selectedItem = $(this).val();
@@ -378,7 +378,7 @@
 </form>
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $('#exportpackagingslips-selected').click(function (e) {
             e.preventDefault();
             var ids = selectedIds.join(",");

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.BillingShipping.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.BillingShipping.cshtml
@@ -367,7 +367,7 @@
                         @if (!Model.IsLoggedInAsVendor)
                         {
                             <script>
-                                $(document).ready(function () {
+                                $(function() {
                                     toggleEditShippingMethod(false);
                                 });
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.Info.cshtml
@@ -7,7 +7,7 @@
 @if (!Model.IsLoggedInAsVendor)
 {
     <script>
-        $(document).ready(function () {
+        $(function() {
             toggleChangeOrderStatus(false);
             toggleOrderTotals(false);
             toggleCC(false);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.Notes.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.Notes.cshtml
@@ -53,7 +53,7 @@
 
     <div class="card card-default">
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $("#@Html.IdFor(model => model.AddOrderNoteHasDownload)").change(toggleAddOrderNoteHasDownload);
                 toggleAddOrderNoteHasDownload();
             });
@@ -118,7 +118,7 @@
 </div>
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $('#addOrderNote').click(function() {
             var orderNoteMessage = $("#@Html.IdFor(model => model.AddOrderNoteMessage)").val();
             var orderNoteDownloadId = 0;

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.Products.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.Products.cshtml
@@ -9,7 +9,7 @@
             @foreach (var item in Model.Items)
             {
                 <script>
-                    $(document).ready(function () {
+                    $(function() {
                         toggleOrderItemEdit@(item.Id)(false);
                     });
                 </script>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_ProductAddAttributes.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_ProductAddAttributes.cshtml
@@ -59,7 +59,7 @@
                                             </div>
                                         }
                                         <script>
-                                            $(document).ready(function() {
+                                            $(function() {
                                                 showHideDropdownQuantity("@controlId");
                                             });
                                         </script>
@@ -87,7 +87,7 @@
                                                 }
                                             </div>
                                             <script>
-                                                $(document).ready(function() {
+                                                $(function() {
                                                     showHideRadioQuantity("@controlId");
                                                 });
                                             </script>
@@ -112,7 +112,7 @@
                                                         <label class="margin-l-10 margin-r-5" for="@(controlId)_@(attributeValue.Id)_qty">@(T("Products.ProductAttributes.PriceAdjustment.Quantity").Text)</label>
                                                         <input class="qty-box form-control" type="text" name="@(controlId)_@(attributeValue.Id)_qty" id="@(controlId)_@(attributeValue.Id)_qty" value="@(attributeValue.Quantity)" />
                                                         <script>
-                                                            $(document).ready(function() {
+                                                            $(function() {
                                                                 showHideCheckboxQuantity('@(controlId)_@(attributeValue.Id)');
                                                             })
                                                         </script>
@@ -188,7 +188,7 @@
                                             </div>
                                         </script>
                                         <script>
-                                            $(document).ready(function() {
+                                            $(function() {
                                                 $("#@(controlId)uploader").fineUploader({
                                                     request: {
                                                         endpoint: '@(Url.RouteUrl("UploadFileProductAttribute", new {attributeId = attribute.Id}))'
@@ -311,7 +311,7 @@
                     });
                 }
 
-                $(document).ready(function() {
+                $(function() {
                     @(attributeChangeHandlerFuncName)();
                     @Html.Raw(attributeChangeScriptsBuilder.ToString())
                 });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_ProductAddRentalInfo.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_ProductAddRentalInfo.cshtml
@@ -27,7 +27,7 @@
                             </div>
                         </div>
                         <script>
-                            $(document).ready(function() {
+                            $(function() {
                                 $("#@(startDateControlId)").datepicker({ dateFormat: "@datePickerFormat" });
                             });
                         </script>
@@ -49,7 +49,7 @@
                             </div>
                         </div>
                         <script>
-                            $(document).ready(function() {
+                            $(function() {
                                 $("#@(endDateControlId)").datepicker({ dateFormat: "@datePickerFormat" });
                             });
                         </script>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Payment/MethodRestrictions.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Payment/MethodRestrictions.cshtml
@@ -48,7 +48,7 @@
                                 else
                                 {
                                     <script>
-                                $(document).ready(function () {
+                                $(function() {
                                     @foreach (var pm in Model.PaymentMethodRestriction.AvailablePaymentMethods)
                                     {
                                         var systemNameWithoutDot = pm.SystemName.Replace(".", "");

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Plugin/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Plugin/List.cshtml
@@ -27,7 +27,7 @@
 
             <button type="submit" name="plugin-reload-grid" class="btn btn-primary">@T("Admin.Configuration.Plugins.ReloadList")</button>
             <script>
-                $(document).ready(function() {
+                $(function() {
                     $("button[name='plugin-reload-grid']").on("click",
                         function(e) {
                             showThrobber(
@@ -57,7 +57,7 @@
     <div class="container-fluid">
         <div class="form-horizontal">
             <script>
-                $(document).ready(function () {
+                $(function() {
                     //install a plugin
                     $("#plugins-local-grid").on("click", ".install-plugin-link", function (e) {
                         $("html, body").animate({ scrollTop: 0 }, 400);
@@ -308,7 +308,7 @@
                     <div>
                         <button type="submit" id="btnRefreshList" style="display: none"></button>
                         <script>
-                            $(document).ready(function () {
+                            $(function() {
                                 $('#btnRefreshList').click(function () {
                                     //refresh grid
                                     updateTable('#plugins-local-grid');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Plugin/OfficialFeed.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Plugin/OfficialFeed.cshtml
@@ -151,7 +151,7 @@
                             <div>
                                 <button type="submit" id="btnRefresh" style="display: none"></button>
                                 <script>
-                                    $(document).ready(function () {
+                                    $(function() {
                                         $('#btnRefresh').click(function () {
                                             //refresh grid
                                             updateTable('#plugins-grid');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Plugin/_CreateOrUpdatePlugin.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Plugin/_CreateOrUpdatePlugin.cshtml
@@ -76,7 +76,7 @@
                                     <div class="col-sm-4">
                                         <nop-select asp-for="SelectedCustomerRoleIds" asp-items="Model.AvailableCustomerRoles" asp-multiple="true" />
                                         <script>
-                                            $(document).ready(function() {
+                                            $(function() {
                                                 var rolesIdsInput = $('#@Html.IdFor(model => model.SelectedCustomerRoleIds)').select2({
                                                     closeOnSelect: false,
                                                     @if (!Model.AvailableCustomerRoles.Any())
@@ -105,7 +105,7 @@
                                     <div class="col-sm-4">
                                         <nop-select asp-for="SelectedStoreIds" asp-items="Model.AvailableStores" asp-multiple="true" />
                                         <script>
-                                            $(document).ready(function() {
+                                            $(function() {
                                                 var storesIdsInput = $('#@Html.IdFor(model => model.SelectedStoreIds)').select2({
                                                     closeOnSelect: false,
                                                     @if (!Model.AvailableStores.Any())

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Poll/_CreateOrUpdate.Answers.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Poll/_CreateOrUpdate.Answers.cshtml
@@ -79,7 +79,7 @@
                 </div>
             </div>
             <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#addPollAnswer').click(function () {
                     $('#addPollAnswer').attr('disabled', true);
                     var postData = {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Poll/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Poll/_CreateOrUpdate.Info.cshtml
@@ -71,7 +71,7 @@
         <div class="col-md-9">
             <nop-select asp-for="SelectedStoreIds" asp-items="Model.AvailableStores" asp-multiple="true" />
             <script>
-                $(document).ready(function() {
+                $(function() {
                     var storesIdsInput = $('#@Html.IdFor(model => model.SelectedStoreIds)').select2({
                         closeOnSelect: false,
                         @if (!Model.AvailableStores.Any())

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/List.cshtml
@@ -282,7 +282,7 @@
                                 return (row.ProductTypeId != @((int)ProductType.GroupedProduct) ) ? data : null;
                             }
 
-                            $(document).ready(function () {
+                            $(function() {
                                 $('#delete-selected-action-confirmation-submit-button').bind('click', function () {
                                     var postData = {
                                         selectedIds: selectedIds
@@ -320,7 +320,7 @@
         </div>
       </section>
     <script>
-        $(document).ready(function () {
+        $(function() {
             $("#@Html.IdFor(model => model.GoDirectlyToSku)").keydown(function (event) {
                 if (event.keyCode === 13) {
                     $("#go-to-product-by-sku").click();
@@ -333,7 +333,7 @@
 }
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         var displayModal = @((Model.LicenseCheckModel?.DisplayWarning == true || Model.LicenseCheckModel?.BlockPages == true).ToString().ToLower());
         if (displayModal) {
             $('#license-window').modal({
@@ -421,7 +421,7 @@
     </form>
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $('#exportxml-selected').click(function (e) {
             e.preventDefault();
             var ids = selectedIds.join(",");
@@ -446,7 +446,7 @@
     </form>
 
     <script>
-        $(document).ready(function () {
+        $(function() {
             $('#exportexcel-selected').click(function (e) {
                 e.preventDefault();
                 var ids = selectedIds.join(",");

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/ProductSpecAttributeAddOrEdit.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/ProductSpecAttributeAddOrEdit.cshtml
@@ -111,7 +111,7 @@
                             </div>
 
                             <script>
-                                $(document).ready(function() {
+                                $(function() {
                                     var valueContainers = {
                                         @((int) SpecificationAttributeType.Option): $('#AttributeValueOptionSection'),
                                         @((int) SpecificationAttributeType.CustomText): $('#AttributeValueCustomTextSection'),
@@ -149,7 +149,7 @@
                             @if (Model.SpecificationId == 0)
                             {
                                 <script>
-                                    $(document).ready(function() {
+                                    $(function() {
                                         $("#@Html.IdFor(model => model.AttributeId)").change(function() {
                                             var selectedAttributeId = $(this).val();
                                             //get options list

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/ProductTags.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/ProductTags.cshtml
@@ -110,7 +110,7 @@
                             })
 
                             <script>
-                        $(document).ready(function() {
+                        $(function() {
                             $('#delete-selected-action-confirmation-submit-button').bind('click', function () {
                                 var postData = {
                                     selectedIds: selectedIds

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.CrossSellsProducts.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.CrossSellsProducts.cshtml
@@ -44,7 +44,7 @@
             </button>
             <button type="submit" id="btnRefreshCrossSellProducts" style="display: none"></button>
             <script>
-                $(document).ready(function () {
+                $(function() {
                     $('#btnRefreshCrossSellProducts').click(function () {
                         //refresh grid
                         updateTable('#crosssellproducts-grid');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.DownloadableProduct.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.DownloadableProduct.cshtml
@@ -2,7 +2,7 @@
 @using Nop.Core.Domain.Catalog;
 @using Nop.Services
 <script>
-    $(document).ready(function() {
+    $(function() {
         $("#@Html.IdFor(model => model.IsDownload)").click(toggleDownloadableProduct);
         $("#@Html.IdFor(model => model.UnlimitedDownloads)").click(toggleDownloadableProduct);
         $("#@Html.IdFor(model => model.HasSampleDownload)").click(toggleDownloadableProduct);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.Info.cshtml
@@ -16,7 +16,7 @@
 
 
     <script asp-location="Footer">
-    $(document).ready(function() {
+    $(function() {
         @if (!Model.IsLoggedInAsVendor)
         {
             <text>
@@ -107,11 +107,11 @@
     }
 
     //required product friendly names
-    $(document).ready(function() {
+    $(function() {
         loadRequiredProductFriendlyNames();
     });
 
-    $(document).ready(function() {
+    $(function() {
         $('#@Html.IdFor(model => model.RequiredProductIds)')
             .data('timeout', null)
             .keyup(function() {
@@ -153,7 +153,7 @@
         }
     }
 
-    $(document).ready(function () {
+    $(function() {
         if ('@Model.Sku') {
             warningValidation('@Url.Action("SkuReservedWarning")', '@Html.NameFor(model => model.Sku)', { productId: @Model.Id, sku: '@Model.Sku' });
         }
@@ -249,7 +249,7 @@
                 </div>
             </div>
             <script>
-                $(document).ready(function() {
+                $(function() {
 					var categoryIdsInput = $('#@Html.IdFor(model => model.SelectedCategoryIds)').select2({
                         closeOnSelect: false,
                         @if (!Model.AvailableCategories.Any())
@@ -271,7 +271,7 @@
         <div class="col-md-9">
             <nop-select asp-for="SelectedManufacturerIds" asp-items="Model.AvailableManufacturers" asp-multiple="true" />
             <script>
-                $(document).ready(function() {
+                $(function() {
                     var manufacturersIdsInput = $('#@Html.IdFor(model => model.SelectedManufacturerIds)').select2({
                         closeOnSelect: false,
                         @if (!Model.AvailableManufacturers.Any())
@@ -431,7 +431,7 @@
                 </button>
                 <button type="submit" id="btnRefreshAssociatedProducts" style="display: none"></button>
                 <script>
-                    $(document).ready(function () {
+                    $(function() {
                         $('#btnRefreshAssociatedProducts').click(function () {
                             //refresh grid
                             updateTable('#associatedproducts-grid');
@@ -477,7 +477,7 @@
                 <div class="col-md-4">
                     <nop-select asp-for="SelectedCustomerRoleIds" asp-items="Model.AvailableCustomerRoles" asp-multiple="true"/>
                     <script>
-                        $(document).ready(function() {
+                        $(function() {
                                 var rolesIdsInput = $('#@Html.IdFor(model => model.SelectedCustomerRoleIds)').select2({
                                 closeOnSelect: false,
                                 @if (!Model.AvailableCustomerRoles.Any())
@@ -506,7 +506,7 @@
                 <div class="col-md-4">
                     <nop-select asp-for="SelectedStoreIds" asp-items="Model.AvailableStores" asp-multiple="true" />
                     <script>
-                        $(document).ready(function() {
+                        $(function() {
                                 var storesIdsInput = $('#@Html.IdFor(model => model.SelectedStoreIds)').select2({
                                 closeOnSelect: false,
                                 @if (!Model.AvailableStores.Any())
@@ -558,7 +558,7 @@
                     <div class="input-group-append">
                         <button type="submit" id="btnRefreshRequiredProducts" style="display: none"></button>
                         <script>
-                            $(document).ready(function () {
+                            $(function() {
                                 $('#btnRefreshRequiredProducts').click(function () {
                                     //refresh product list
                                     loadRequiredProductFriendlyNames();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.Inventory.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.Inventory.cshtml
@@ -2,7 +2,7 @@
 @using Nop.Core.Domain.Catalog;
 @using Nop.Services
 <script>
-    $(document).ready(function() {
+    $(function() {
         $("#@Html.IdFor(model => model.ManageInventoryMethodId)").change(toggleManageStock);
         $("#@Html.IdFor(model => model.UseMultipleWarehouses)").click(toggleManageStock);
         $("#@Html.IdFor(model => model.BackorderModeId)").change(toggleManageStock);
@@ -181,7 +181,7 @@
                                     <td style="width: 10%;">
                                         <input type="checkbox" id="warehouse_used_@(item.WarehouseId)" name="warehouse_used_@(item.WarehouseId)" value="@item.WarehouseId" checked="@item.WarehouseUsed" />
                                         <script>
-                                        $(document).ready(function() {
+                                        $(function() {
                                             $("#warehouse_used_@(item.WarehouseId)").change(toggleWarehouseUsed_@(item.WarehouseId));
                                             toggleWarehouseUsed_@(item.WarehouseId)();
                                         });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.Multimedia.Videos.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.Multimedia.Videos.cshtml
@@ -82,7 +82,7 @@
             </div>
         </div>
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#addProductVideo').click(function () {
                     $('#addProductVideo').attr('disabled', true);
                     var postData = {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.Prices.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.Prices.cshtml
@@ -6,7 +6,7 @@
     var stores = await storeService.GetAllStoresAsync();
 }
 <script>
-    $(document).ready(function() {
+    $(function() {
         $("#@Html.IdFor(model => model.IsTaxExempt)").click(toggleTax);
 
         toggleTax();
@@ -178,7 +178,7 @@
         <div class="col-md-9">
             <nop-select asp-for="SelectedDiscountIds" asp-items="Model.AvailableDiscounts" asp-multiple="true" />
             <script>
-                $(document).ready(function() {
+                $(function() {
                     var discountsIdsInput = $('#@Html.IdFor(model => model.SelectedDiscountIds)').select2({
                         closeOnSelect: false,
                         @if (!Model.AvailableDiscounts.Any())
@@ -288,7 +288,7 @@
                 </button>
                 <button type="submit" id="btnRefreshTierPrices" style="display: none"></button>
                 <script>
-                    $(document).ready(function () {
+                    $(function() {
                         $('#btnRefreshTierPrices').click(function () {
                             updateTable('#tierprices-grid');
                             //return false to don't reload a page

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.ProductAttributes.Combinations.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.ProductAttributes.Combinations.cshtml
@@ -113,7 +113,7 @@
             <nop-action-confirmation asp-button-id="btnGenerateAllCombinations" />
             <button type="submit" id="btnRefreshCombinations" style="display: none"></button>
             <script>
-                $(document).ready(function() {
+                $(function() {
                     $('#btnRefreshCombinations').click(function() {
                         //refresh grid
                         $("#attributecombinations-grid").DataTable().ajax.reload();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.RelatedProducts.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.RelatedProducts.cshtml
@@ -60,7 +60,7 @@
                 </button>
                 <button type="submit" id="btnRefreshRelatedProducts" style="display: none"></button>
                 <script>
-                    $(document).ready(function () {
+                    $(function() {
                         $('#btnRefreshRelatedProducts').click(function () {
                             //refresh grid
                             updateTable('#relatedproducts-grid');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.Seo.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.Seo.cshtml
@@ -41,7 +41,7 @@
                         </div>
                     </div>
                     <script>
-                $(document).ready(function () {
+                $(function() {
                     $('#@Html.IdFor(model => model.Locales[item].SeName)').on('input change', function () {
                         var parameters = {
                             entityId: '@Model.Id',
@@ -95,7 +95,7 @@
                                 </div>
                             </div>
                             <script>
-                $(document).ready(function () {
+                $(function() {
                     $('#@Html.IdFor(model => model.SeName)').on('input change', function () {
                         var parameters = {
                             entityId: '@Model.Id',

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdateProductAttributeCombination.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdateProductAttributeCombination.cshtml
@@ -10,7 +10,7 @@
 }
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $('#@Html.IdFor(model => model.Sku)').on('input change', function () {
             warningValidation('@Url.Action("SkuReservedWarning")', '@Html.NameFor(model => model.Sku)', { productId: @Model.ProductId, sku: $(this).val() });
         });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdateProductAttributeMapping.Condition.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdateProductAttributeMapping.Condition.cshtml
@@ -5,7 +5,7 @@
 @if(Model.Id > 0)
 {
     <script>
-    $(document).ready(function() {
+    $(function() {
         $("#@Html.IdFor(model => model.ConditionModel.EnableCondition)").click(toggleEnableCondition);
         toggleEnableCondition();
     });
@@ -49,7 +49,7 @@
                         <nop-select asp-for="ConditionModel.SelectedProductAttributeId" asp-items="@attributesList" />
 
                         <script>
-                        $(document).ready(function() {
+                        $(function() {
                             $("#@Html.IdFor(model => model.ConditionModel.SelectedProductAttributeId)")
                                 .change(toggleProductAttributes);
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdateProductAttributeMapping.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdateProductAttributeMapping.Info.cshtml
@@ -4,7 +4,7 @@
 @using Nop.Services
 
 <script>
-    $(document).ready(function() {
+    $(function() {
         $("#@Html.IdFor(model => model.AttributeControlTypeId)").change(toggleAttributeControlType);
 
         toggleAttributeControlType();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdateProductAttributeMapping.Values.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdateProductAttributeMapping.Values.cshtml
@@ -85,7 +85,7 @@
         </button>
         <button type="submit" id="btnRefresh" style="display: none"></button>
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#btnRefresh').click(function () {
                     //refresh grid
                     updateTable('#productattributevalues-grid');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdateProductAttributeValue.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdateProductAttributeValue.cshtml
@@ -22,7 +22,7 @@
 }
 
 <script>
-    $(document).ready(function() {
+    $(function() {
         $("#@Html.IdFor(model => model.AttributeValueTypeId)").change(toggleProductType);
         $("#@Html.IdFor(model => model.CustomerEntersQty)").change(toggleCustomerEntersQty);
         toggleProductType();
@@ -88,7 +88,7 @@
                                         @T("Admin.Catalog.Products.ProductAttributes.Attributes.Values.Fields.AssociatedProduct.AddNew")
                                     </button>
                                     <script>
-                                $(document).ready(function () {
+                                $(function() {
                                     if (@Model.AssociatedProductId > 0) {
                                         warningValidation('@Url.Action("AssociatedProductGetWarnings", "Product")', '@Html.NameFor(model => model.AssociatedProductId)', { productId: '@Model.AssociatedProductId' });
                                     }
@@ -160,7 +160,7 @@
                                         <nop-editor asp-for="ColorSquaresRgb" />
                                         <div id="color-picker"></div>
                                         <script>
-                                    $(document).ready(function(){
+                                    $(function(){
                                         $('#color-picker').farbtastic('#@Html.IdFor(model => model.ColorSquaresRgb)');
                                     });
                                         </script>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_ProductEditorSettingsModal.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_ProductEditorSettingsModal.cshtml
@@ -651,7 +651,7 @@
                     </div>
                 </form>
                 <script>
-                    $(document).ready(function () {
+                    $(function() {
                         $('input[type=checkbox].select-all-fields').each(function (index, value) {
                             if ($('input[type=checkbox]:checked', $(this).closest('.card')).length > 0) {
                                 $(this).prop('checked', true);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/ProductAttribute/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/ProductAttribute/List.cshtml
@@ -65,7 +65,7 @@
                 })
 
                 <script>
-                    $(document).ready(function () {
+                    $(function() {
                         $('#delete-selected-action-confirmation-submit-button').bind('click', function () {
                             var postData = {
                                 selectedIds: selectedIds

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/ProductAttribute/_CreateOrUpdate.PredefinedValues.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/ProductAttribute/_CreateOrUpdate.PredefinedValues.cshtml
@@ -72,7 +72,7 @@
         </button>
         <button type="submit" id="btnRefresh" style="display: none"></button>
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#btnRefresh').click(function () {
                     //refresh grid
                     updateTable('#productattributevalues-grid');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/ProductReview/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/ProductReview/List.cshtml
@@ -95,7 +95,7 @@
                                     <div class="col-md-8">
                                         <input type="text" class="form-control" id="search-product-name" autocomplete="off" />
                                         <script>
-                                        $(document).ready(function() {
+                                        $(function() {
                                             $('#search-product-name').autocomplete({
                                                 delay: 500,
                                                 minLength: 3,
@@ -241,7 +241,7 @@
                     })
 
                     <script>
-                        $(document).ready(function() {
+                        $(function() {
 
                             //"approve selected" button
                             $('#approve-selected').click(function(e) {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/QueuedEmail/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/QueuedEmail/List.cshtml
@@ -210,7 +210,7 @@
                         })
 
                         <script>
-                            $(document).ready(function() {
+                            $(function() {
                                 $("#@Html.IdFor(model => model.GoDirectlyToNumber)").keydown(function (event) {
                                     if (event.keyCode === 13) {
                                         $("#go-to-email-by-number").click();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/QueuedEmail/_CreateOrUpdate.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/QueuedEmail/_CreateOrUpdate.cshtml
@@ -207,7 +207,7 @@
                     </div>
 
                     <script>
-                    $(document).ready(function () {
+                    $(function() {
                         $("#@Html.IdFor(model => model.SendImmediately)").click(sendImmediately);
                         sendImmediately();
                     });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Report/SalesSummary.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Report/SalesSummary.cshtml
@@ -120,7 +120,7 @@
                                         <button type="button" id="search-product-clear" class="btn bg-gray" style="display: none; margin-top: 5px;">@T("Admin.Common.Clear")</button>
                                         <input asp-for="ProductId" autocomplete="off" style="display: none;" />
                                         <script>
-                                            $(document).ready(function() {
+                                            $(function() {
                                                 $('#search-product-name').autocomplete({
                                                     delay: 500,
                                                     minLength: 3,

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/ScheduleTask/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/ScheduleTask/List.cshtml
@@ -18,7 +18,7 @@
 </div>
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $("#schedule-tasks-grid").on("click", ".run-now", function (e) {
             showThrobber('@Html.Raw(JavaScriptEncoder.Default.Encode(T("Admin.System.ScheduleTasks.RunNow.Progress").Text))');
         });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Security/Permissions.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Security/Permissions.cshtml
@@ -42,7 +42,7 @@
                             else
                             {
                                 <script>
-                                $(document).ready(function () {
+                                $(function() {
                                     @foreach (var cr in Model.AvailableCustomerRoles)
                                     {
                                         <text>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/AllSettings.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/AllSettings.cshtml
@@ -167,7 +167,7 @@
                         </div>
                     </div>
                     <script>
-                        $(document).ready(function () {
+                        $(function() {
                             $('#addSetting').click(function () {
                                 $('#addSetting').attr('disabled', true);
                                 var postData = {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/AppSettings.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/AppSettings.cshtml
@@ -70,7 +70,7 @@
         </div>
     </div>
     <script>
-        $(document).ready(function () {
+        $(function() {
             checkEnvironmentVariables();
         });
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/CustomerUser.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/CustomerUser.cshtml
@@ -61,7 +61,7 @@
         </div>
     </section>
     <script>
-        $(document).ready(function () {
+        $(function() {
             $("#@Html.IdFor(model => model.MultiFactorAuthenticationSettings.ForceMultifactorAuthentication)").click(toggleForceMultifactorAuthentication);
             toggleForceMultifactorAuthentication();
         });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/GeneralCommon.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/GeneralCommon.cshtml
@@ -102,7 +102,7 @@
     </section>
 
     <script>
-        $(document).ready(function () {
+        $(function() {
             $("#@Html.IdFor(model => model.LocalizationSettings.LoadAllLocaleRecordsOnStartup)").click(toggleLoadAllLocaleRecordsOnStartup);
             toggleLoadAllLocaleRecordsOnStartup();
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_AppSettings.DistributedCache.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_AppSettings.DistributedCache.cshtml
@@ -68,7 +68,7 @@
     </nop-nested-setting>
 </div>
 <script>
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdFor(model => model.DistributedCacheConfigModel.Enabled)").click(toggleDistributedCache);
         $(@Html.IdFor(model => model.DistributedCacheConfigModel.DistributedCacheType)).change(toggleDistributedCache);
         toggleDistributedCache();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_Catalog.AdditionalSections.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_Catalog.AdditionalSections.cshtml
@@ -136,7 +136,7 @@
 </div>
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdFor(model => model.NewProductsEnabled)").click(toggleNewProductsEnabled);
         toggleNewProductsEnabled();
         $("#@Html.IdFor(model => model.NewProductsAllowCustomersToSelectPageSize)").click(toggleNewProductsPageSize);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_Catalog.Search.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_Catalog.Search.cshtml
@@ -161,7 +161,7 @@
     </div>
 </div>
 <script>
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdFor(model => model.SearchPageAllowCustomersToSelectPageSize)").click(toggleSearchPagePageSize);
 
         toggleSearchPagePageSize();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_Catalog.Tags.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_Catalog.Tags.cshtml
@@ -90,7 +90,7 @@
 </div>
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdFor(model => model.ProductsByTagAllowCustomersToSelectPageSize)").click(toggleProductsByTagPageSize);
 
         toggleProductsByTagPageSize();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_CreateOrUpdateGdprConsent.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_CreateOrUpdateGdprConsent.cshtml
@@ -93,7 +93,7 @@
                             </div>
                         }
                         <script>
-                        $(document).ready(function () {
+                        $(function() {
                             $("#@Html.IdFor(model => model.IsRequired)").click(toggleIsRequired);
 
                             toggleIsRequired();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_CustomerUser.CustomerFormFields.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_CustomerUser.CustomerFormFields.cshtml
@@ -1,7 +1,7 @@
 @model CustomerUserSettingsModel
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdFor(model => model.CustomerSettings.DateOfBirthRequired)").click(toggleCustomerRequiredFormField);
         $("#@Html.IdFor(model => model.CustomerSettings.CountryEnabled)").click(toggleCustomerCountryFormField);
         $("#@Html.IdFor(model => model.CustomerSettings.StateProvinceEnabled)").click(toggleCustomerStateProvinceFormField);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_Gdpr.Common.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_Gdpr.Common.cshtml
@@ -55,7 +55,7 @@
     </nop-nested-setting>
 </div>
 <script>
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdFor(model => model.GdprEnabled)").click(toggleGdprEnabled);
 
         toggleGdprEnabled();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_GeneralCommon.Captcha.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_GeneralCommon.Captcha.cshtml
@@ -187,7 +187,7 @@
     </nop-nested-setting>
 </div>
 <script>
-    $(document).ready(function () {
+    $(function() {
         $('#@Html.IdFor(model => model.CaptchaSettings.CaptchaType)').change(toggleReCaptchaV3ScoreThreshold);
         $("#@Html.IdFor(model => model.CaptchaSettings.Enabled)").click(toggleReCaptcha);
         toggleReCaptcha();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_GeneralCommon.RobotsTxt.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_GeneralCommon.RobotsTxt.cshtml
@@ -50,7 +50,7 @@
                 <div class="col-md-9">
                     <nop-select asp-for="RobotsTxtSettings.DisallowLanguages" asp-items="Model.RobotsTxtSettings.AvailableLanguages" asp-multiple="true"/>
                     <script>
-                        $(document).ready(function() {
+                        $(function() {
                             var languageIds = $('#@Html.IdFor(model => model.RobotsTxtSettings.DisallowLanguages)').select2({
                                 closeOnSelect: false
                             });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_RewardPoints.EarningRewardPoints.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_RewardPoints.EarningRewardPoints.cshtml
@@ -118,7 +118,7 @@
 </div>
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdFor(model => model.ActivatePointsImmediately)").click(activatePointsImmediately);
         activatePointsImmediately();
     });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_Tax.Common.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_Tax.Common.cshtml
@@ -54,7 +54,7 @@
     </div>
 </div>
 <script>
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdFor(model => model.TaxBasedOn)").click(toggleBasedOnMethod);
         toggleBasedOnMethod();
     });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_Tax.TaxDisplaying.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Setting/_Tax.TaxDisplaying.cshtml
@@ -73,7 +73,7 @@
     </div>
 </div>
 <script>
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdFor(model => model.AllowCustomersToSelectTaxDisplayType)").click(toggleTaxDisplayType);
         toggleTaxDisplayType();
     });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/Components/CommonStatistics/Default.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/Components/CommonStatistics/Default.cshtml
@@ -90,7 +90,7 @@
                 </div>
 
                 <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#@cardId').on('click', 'button[data-card-widget="collapse"]', function () {
                     var collapsed = !$('#@cardId').hasClass('collapsed-card');
                     saveUserPreferences('@(Url.Action("SavePreference", "Preferences"))', '@hideCardAttributeName', collapsed);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/Components/NopCommerceNews/Default.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/Components/NopCommerceNews/Default.cshtml
@@ -57,7 +57,7 @@
             </div>
 
             <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#@cardId').on('click', 'button[data-widget="collapse"]', function () {
                     var collapsed = !$('#@cardId').hasClass('collapsed-box');
                     saveUserPreferences('@(Url.Action("SavePreference", "Preferences"))', '@hideCardAttributeName', collapsed);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/Components/SettingMode/Default.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/Components/SettingMode/Default.cshtml
@@ -22,7 +22,7 @@
                 }
             }
             checkAdvancedSettingsMode($("#advanced-settings-mode").is(':checked'));
-            $(document).ready(function() {
+            $(function() {
                 $("#advanced-settings-mode").click(function() {
                     checkAdvancedSettingsMode($(this).is(':checked'));
                     saveUserPreferences('@(Url.Action("SavePreference", "Preferences"))', '@Model.ModeName', $(this).is(':checked'));

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/Address.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/Address.cshtml
@@ -1,7 +1,7 @@
 ﻿@model AddressModel
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdFor(model => model.CountryId)").change(function () {
             var selectedItem = $(this).val();
             var ddlStates = $("#@Html.IdFor(model => model.StateProvinceId)");

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/Download.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/Download.cshtml
@@ -16,7 +16,7 @@
 <script asp-exclude-from-bundle="true" src="~/lib_npm/fine-uploader/jquery.fine-uploader/jquery.fine-uploader.min.js" asp-location="Footer"></script>
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $('#cbUseDownloadURL@(randomNumber)').click(toggleDownloadRecordType@(randomNumber));
 
         $('#saveDownloadUrl@(randomNumber)').click(function () {
@@ -162,7 +162,7 @@
 
                 <script>
 
-                    $(document).ready(function () {
+                    $(function() {
                         $("#@clientId").fineUploader({
                             request: {
                                 endpoint: '@(Url.Action("AsyncUpload", "Download", new { area = AreaNames.ADMIN }))'

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/MultiPicture.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/MultiPicture.cshtml
@@ -60,7 +60,7 @@
     </div>
 </script>
 <script>
-    $(document).ready(function() {
+    $(function() {
         
         var allowedExtensions = ["bmp", "gif", "jpeg", "jpg", "jpe", "jfif", "pjpeg", "pjp", "png", "tiff", "tif", "webp"];
         

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/MultiSelect.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/MultiSelect.cshtml
@@ -3,7 +3,7 @@
     <select asp-for="@Model" asp-items="@((IEnumerable<SelectListItem>)ViewData["SelectList"])" multiple="multiple" class="form-control select2" data-dropdown-css-class="select2-blue"></select>
 </div>
 <script>
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdForModel()").select2();
     });
 </script>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/MultiSelectString.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/MultiSelectString.cshtml
@@ -3,7 +3,7 @@
     <select asp-for="@Model" asp-items="@((IEnumerable<SelectListItem>)ViewData["SelectList"])" multiple="multiple" class="form-control select2" data-dropdown-css-class="select2-blue"></select>
 </div>
 <script>
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdForModel()").select2({
             tags: true,
             createTag: function(params) {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/Picture.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/Picture.cshtml
@@ -79,7 +79,7 @@
     </div>
 </script>
 <script>
-    $(document).ready(function() {
+    $(function() {
         
         var allowedExtensions = ["bmp", "gif", "jpeg", "jpg", "jpe", "jfif", "pjpeg", "pjp", "png", "tiff", "tif", "webp"];
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/RichEditor.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/RichEditor.cshtml
@@ -44,7 +44,7 @@
 <script src="~/lib_npm/tinymce/tinymce.min.js" asp-location="Head"></script>
 
 <script>
-    $(document).ready(function() {
+    $(function() {
         @* wooncherk contribution *@
         function RoxyFileBrowser@(random)(callback, value, type) {
             //we manually generate the configuration file to ensure that it works fine in virtual directory

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/RestartApplication.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/RestartApplication.cshtml
@@ -2,7 +2,7 @@
 @inject CommonSettings commonSettings
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         showThrobber('@Html.Raw(JavaScriptEncoder.Default.Encode(T("Admin.Header.RestartApplication.Progress").Text))');
         $.ajax({
             type: "GET",

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/Table.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/Table.cshtml
@@ -53,7 +53,7 @@
 }
 
 <script asp-location="Footer">
-    $(document).ready(function () {
+    $(function() {
         $('#@Model.Name').DataTable({
             @await Html.PartialAsync("_Table.Definition", Model)
         });
@@ -371,7 +371,7 @@
                 function getchild_@(tableName)(d) {
                     return '<table id="child' + d.@(curModel.PrimaryKeyColumn) + '_@(tableName)' + '" class="table table-bordered table-hover dataTable" width="100%">@(Html.Raw(footerHtml))</table>';
                 }
-                $(document).ready(function () {
+                $(function() {
                     // Add event listener for opening and closing childs
                     $('#@curModel.Name tbody').on('click', 'td.child-control', function () {
                         var tr = $(this).closest('tr');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/_AdminLayout.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/_AdminLayout.cshtml
@@ -129,7 +129,7 @@
                                                 <span>@T("Admin.Header.RestartApplication")</span>
                                             </button>
                                             <script>
-                                                $(document).ready(function () {
+                                                $(function() {
                                                     $("#restart-application").click(function (e) {
                                                         showThrobber('@Html.Raw(JavaScriptEncoder.Default.Encode(T("Admin.Header.RestartApplication.Progress").Text))');
                                                     });
@@ -168,7 +168,7 @@
                     <nav class="mt-2">
                         @await Component.InvokeAsync(typeof(AdminWidgetViewComponent), new { widgetZone = AdminWidgetZones.SearchBoxBefore })
                         <script>
-                            $(document).ready(function () {
+                            $(function() {
                                 Admin.Search.init();
                             });
                         </script>
@@ -234,7 +234,7 @@
     }
     <a id="backTop" class="btn btn-back-top bg-teal"></a>
     <script>
-        $(document).ready(function () {
+        $(function() {
             //enable "back top" arrow
             $('#backTop').backTop();
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/_AdminPopupLayout.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/_AdminPopupLayout.cshtml
@@ -32,7 +32,7 @@
     </div>
 
     <script>
-        $(document).ready(function () {
+        $(function() {
             //enable tooltips
             $('[data-toggle="tooltip"]').tooltip();
         });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shipping/Restrictions.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shipping/Restrictions.cshtml
@@ -44,7 +44,7 @@
                             else
                             {
                                 <script>
-                                $(document).ready(function () {
+                                $(function() {
                                     @foreach (var sm in Model.AvailableShippingMethods)
                                     {
                                         <text>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/ShoppingCart/CurrentCarts.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/ShoppingCart/CurrentCarts.cshtml
@@ -69,7 +69,7 @@
                                         <button type="button" id="search-product-clear" class="btn bg-gray" style="display: none; margin-top: 5px;">@T("Admin.Common.Clear")</button>
                                         <input asp-for="ProductId" autocomplete="off" style="display: none;" />
                                         <script>
-                                        $(document).ready(function() {
+                                        $(function() {
                                             $('#search-product-name').autocomplete({
                                                 delay: 500,
                                                 minLength: 3,

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/SpecificationAttribute/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/SpecificationAttribute/List.cshtml
@@ -113,7 +113,7 @@
                     return row.Id ? '<a href="@Url.Action("EditSpecificationAttributeGroup", "SpecificationAttribute")/' + row.Id +'">' + name + '</a>' : name;
                 }
 
-                $(document).ready(function () {
+                $(function() {
                     $('#delete-selected-specification-attributes-action-confirmation-submit-button').bind('click', function () {
                         var postData = {
                             selectedIds: selectedIds

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/SpecificationAttribute/_CreateOrUpdateOption.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/SpecificationAttribute/_CreateOrUpdateOption.cshtml
@@ -25,7 +25,7 @@
 }
 
 <script>
-    $(document).ready(function() {
+    $(function() {
         $("#@Html.IdFor(model => model.EnableColorSquaresRgb)").click(toggleEnableColorSquaresRgb);
         toggleEnableColorSquaresRgb();
     });
@@ -89,7 +89,7 @@
                                     <nop-editor asp-for="ColorSquaresRgb" />
                                     <div id="color-picker"></div>
                                     <script>
-                                        $(document).ready(function(){
+                                        $(function(){
                                             $('#color-picker').farbtastic('#@Html.IdFor(model => model.ColorSquaresRgb)');
                                         });
                                     </script>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/SpecificationAttribute/_CreateOrUpdateSpecificationAttribute.Options.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/SpecificationAttribute/_CreateOrUpdateSpecificationAttribute.Options.cshtml
@@ -58,7 +58,7 @@
         </button>
         <button type="submit" id="btnRefresh" style="display: none"></button>
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#btnRefresh').click(function () {
                     //refresh grid
                     updateTable('#specificationattributeoptions-grid');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Tax/Categories.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Tax/Categories.cshtml
@@ -94,7 +94,7 @@
                             </div>
                         </div>
                         <script>
-                            $(document).ready(function () {
+                            $(function() {
                                 $('#addTaxCategory').click(function () {
                                     $('#addTaxCategory').attr('disabled', true);
                                     var postData = {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Template/_List.Category.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Template/_List.Category.cshtml
@@ -91,7 +91,7 @@
             </div>
         </div>
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#addCategoryTemplate').click(function () {
                     $('#addCategoryTemplate').attr('disabled', true);
                     var postData = {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Template/_List.Manufacturer.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Template/_List.Manufacturer.cshtml
@@ -91,7 +91,7 @@
             </div>
         </div>
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#addManufacturerTemplate').click(function () {
                     $('#addManufacturerTemplate').attr('disabled', true);
                     var postData = {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Template/_List.Product.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Template/_List.Product.cshtml
@@ -107,7 +107,7 @@
             </div>
         </div>
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#addProductTemplate').click(function () {
                     $('#addProductTemplate').attr('disabled', true);
                     var postData = {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Template/_List.Topic.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Template/_List.Topic.cshtml
@@ -91,7 +91,7 @@
                 </div>
             </div>
             <script>
-                $(document).ready(function () {
+                $(function() {
                     $('#addTopicTemplate').click(function () {
                         $('#addTopicTemplate').attr('disabled', true);
                         var postData = {

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Topic/_CreateOrUpdate.Display.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Topic/_CreateOrUpdate.Display.cshtml
@@ -84,7 +84,7 @@
                 <div class="col-md-4">
                     <nop-select asp-for="SelectedCustomerRoleIds" asp-items="Model.AvailableCustomerRoles" asp-multiple="true" />
                     <script>
-                        $(document).ready(function() {
+                        $(function() {
                             var rolesIdsInput = $('#@Html.IdFor(model => model.SelectedCustomerRoleIds)').select2({
                                 closeOnSelect: false,
                                 @if (!Model.AvailableCustomerRoles.Any())
@@ -113,7 +113,7 @@
                 <div class="col-md-4">
                     <nop-select asp-for="SelectedStoreIds" asp-items="Model.AvailableStores" asp-multiple="true" />
                     <script>
-                        $(document).ready(function() {
+                        $(function() {
                             var storesIdsInput = $('#@Html.IdFor(model => model.SelectedStoreIds)').select2({
                                 closeOnSelect: false,
                                 @if (!Model.AvailableStores.Any())

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Topic/_CreateOrUpdate.Seo.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Topic/_CreateOrUpdate.Seo.cshtml
@@ -40,7 +40,7 @@
             </div>
         </div>
         <script>
-                  $(document).ready(function () {
+                  $(function() {
                       $('#@Html.IdFor(model => model.Locales[item].SeName)').on('input change', function () {
                           var parameters = {
                               entityId: '@Model.Id',
@@ -92,7 +92,7 @@
             </div>
         </div>
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#@Html.IdFor(model => model.SeName)').on('input change', function () {
                     var parameters = {
                         entityId: '@Model.Id',

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Vendor/_CreateOrUpdate.Display.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Vendor/_CreateOrUpdate.Display.cshtml
@@ -84,7 +84,7 @@
 </div>
 
 <script>
-    $(document).ready(function() {
+    $(function() {
         $("#@Html.IdFor(model => model.AllowCustomersToSelectPageSize)").click(togglePageSize);
 
         togglePageSize();

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Vendor/_CreateOrUpdate.Notes.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Vendor/_CreateOrUpdate.Notes.cshtml
@@ -54,7 +54,7 @@
     </div>
 </div>
 <script>
-    $(document).ready(function() {
+    $(function() {
         $('#addVendorNote').click(function() {
             var vendorNoteMessage = $("#@Html.IdFor(model => model.AddVendorNoteMessage)").val();
             $('#addVendorNote').attr('disabled', true);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Vendor/_CreateOrUpdate.Seo.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Vendor/_CreateOrUpdate.Seo.cshtml
@@ -40,7 +40,7 @@
             </div>
          </div>
         <script>
-          $(document).ready(function () {
+          $(function() {
               $('#@Html.IdFor(model => model.Locales[item].SeName)').on('input change', function () {
                   var parameters = {
                       entityId: '@Model.Id',
@@ -92,7 +92,7 @@
             </div>
         </div>
         <script>
-              $(document).ready(function () {
+              $(function() {
                   $('#@Html.IdFor(model => model.SeName)').on('input change', function () {
                       var parameters = {
                           entityId: '@Model.Id',

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/VendorAttribute/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/VendorAttribute/_CreateOrUpdate.Info.cshtml
@@ -3,7 +3,7 @@
 @using Nop.Services
 
 <script>
-    $(document).ready(function() {
+    $(function() {
         $("#@Html.IdFor(model => model.AttributeControlTypeId)").change(toggleAttributeControlType);
         toggleAttributeControlType();
     });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/VendorAttribute/_CreateOrUpdate.Values.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/VendorAttribute/_CreateOrUpdate.Values.cshtml
@@ -56,7 +56,7 @@
         </button>
         <button type="submit" id="btnRefresh" style="display: none"></button>
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $('#btnRefresh').click(function () {
                     //refresh grid
                     updateTable('#vendorattributevalues-grid');

--- a/src/Presentation/Nop.Web/Views/BackInStockSubscription/CustomerSubscriptions.cshtml
+++ b/src/Presentation/Nop.Web/Views/BackInStockSubscription/CustomerSubscriptions.cshtml
@@ -27,7 +27,7 @@
                 @T("Account.BackInStockSubscriptions.Description")
             </div>
             <script asp-location="Footer">
-                $(document).ready(function () {
+                $(function() {
                     $('#selectall').on('click', function () {
                         $('.subscription-list .rowcheckbox').prop('checked', $(this).is(':checked')).trigger('change');
                     });

--- a/src/Presentation/Nop.Web/Views/BackInStockSubscription/SubscribePopup.cshtml
+++ b/src/Presentation/Nop.Web/Views/BackInStockSubscription/SubscribePopup.cshtml
@@ -42,7 +42,7 @@
             </button>
             <nop-antiforgery-token />
             <script>
-                $(document).ready(function () {
+                $(function() {
                     $("#back-in-stock-notify-me").on('click', function () {
                         var subscribeButton = this;
                         var postData = {};

--- a/src/Presentation/Nop.Web/Views/Boards/CustomerForumSubscriptions.cshtml
+++ b/src/Presentation/Nop.Web/Views/Boards/CustomerForumSubscriptions.cshtml
@@ -24,7 +24,7 @@
                 @T("Account.ForumSubscriptions.Description")
             </div>
             <script asp-location="Footer">
-                $(document).ready(function () {
+                $(function() {
                     $('#selectall').on('click', function () {
                         $('.subscription-list .rowcheckbox').prop('checked', $(this).is(':checked')).trigger('change');
                     });

--- a/src/Presentation/Nop.Web/Views/Boards/Forum.cshtml
+++ b/src/Presentation/Nop.Web/Views/Boards/Forum.cshtml
@@ -33,7 +33,7 @@
             {
                 <a class="watch-forum" href="#" id="watch-forum">@Model.WatchForumText</a>
                 <script asp-location="Footer">
-                    $(document).ready(function() {
+                    $(function() {
                         $('#watch-forum').on('click', function () {
                             var postData = {};
                             addAntiForgeryToken(postData);

--- a/src/Presentation/Nop.Web/Views/Boards/Search.cshtml
+++ b/src/Presentation/Nop.Web/Views/Boards/Search.cshtml
@@ -14,7 +14,7 @@
     NopHtml.AppendPageCssClassParts("html-forum-search-page");
 }
 <script asp-location="Footer">
-    $(document).ready(function () {
+    $(function() {
         toggleAdvancedSearch();
         $('#advs').on('click', function () {
             toggleAdvancedSearch();

--- a/src/Presentation/Nop.Web/Views/Boards/Topic.cshtml
+++ b/src/Presentation/Nop.Web/Views/Boards/Topic.cshtml
@@ -59,7 +59,7 @@
             {
                 <a class="watch-topic-button" href="#" id="watch-topic-top">@Model.WatchTopicText</a>
                 <script asp-location="Footer">
-                    $(document).ready(function () {
+                    $(function() {
                         $('#watch-topic-top').on('click', function () {
                             var postData = {};
                             addAntiForgeryToken(postData);
@@ -117,7 +117,7 @@
             {
                 <a class="watch-topic-button" href="#" id="watch-topic-bottom">@Model.WatchTopicText</a>
                 <script asp-location="Footer">
-                    $(document).ready(function() {
+                    $(function() {
                         $('#watch-topic-bottom').on('click', function() {
                             var postData = {};
                             addAntiForgeryToken(postData);

--- a/src/Presentation/Nop.Web/Views/Boards/_ForumPost.cshtml
+++ b/src/Presentation/Nop.Web/Views/Boards/_ForumPost.cshtml
@@ -98,7 +98,7 @@
             @if (Model.AllowPostVoting)
             {
                 <script asp-location="Footer">
-                    $(document).ready(function () {
+                    $(function() {
                         var post = '#post-vote-' + @Model.Id;
                         $(post + ' span.vote').on('click', function () {
                             var postData = {

--- a/src/Presentation/Nop.Web/Views/Catalog/Search.cshtml
+++ b/src/Presentation/Nop.Web/Views/Catalog/Search.cshtml
@@ -8,7 +8,7 @@
     NopHtml.AppendPageCssClassParts("html-search-page");
 }
 <script asp-location="Footer">
-    $(document).ready(function () {
+    $(function() {
         $("#@Html.IdFor(model => model.advs)").on('click', toggleAdvancedSearch);
         toggleAdvancedSearch();
     });
@@ -95,7 +95,7 @@
             }
             @await Html.PartialAsync("_CatalogProducts", Model.CatalogProductsModel, catalogProductsViewData)
             <script asp-location="Footer">
-                $(document).ready(function () {
+                $(function() {
                     $(CatalogProducts).on('before', function (e) {
                         var isAdvanced = $('#@Html.IdFor(model => model.advs)').is(':checked');
 

--- a/src/Presentation/Nop.Web/Views/Catalog/_CatalogFilters.cshtml
+++ b/src/Presentation/Nop.Web/Views/Catalog/_CatalogFilters.cshtml
@@ -25,7 +25,7 @@
 </div>
 
 <script asp-location="Footer">
-    $(document).ready(function () {
+    $(function() {
         $('.block .filter-title').on('click', function () {
             var e = window, a = 'inner';
             if (!('innerWidth' in window)) {

--- a/src/Presentation/Nop.Web/Views/Catalog/_CatalogProducts.cshtml
+++ b/src/Presentation/Nop.Web/Views/Catalog/_CatalogProducts.cshtml
@@ -9,7 +9,7 @@
     </div>
 </div>
 <script asp-location="Footer">
-    $(document).ready(function () {
+    $(function() {
         CatalogProducts.init({
             ajax: @Model.UseAjaxLoading.ToString().ToLowerInvariant(),
             browserPath: '@Context.Request.Path',

--- a/src/Presentation/Nop.Web/Views/Catalog/_CatalogSelectors.cshtml
+++ b/src/Presentation/Nop.Web/Views/Catalog/_CatalogSelectors.cshtml
@@ -24,7 +24,7 @@
             }
         </div>
         <script asp-location="Footer">
-            $(document).ready(function () {
+            $(function() {
                 var $viewModeEls = $('[data-viewmode]');
                 $viewModeEls.on('click', function () {
                     if (!$(this).hasClass('selected')) {
@@ -52,7 +52,7 @@
             @Html.DropDownList("products-orderby", Model.AvailableSortOptions, new { aria_label = T("Catalog.OrderBy.Label") })
         </div>
         <script asp-location="Footer">
-            $(document).ready(function () {
+            $(function() {
                 var $orderByEl = $('#products-orderby');
                 $orderByEl.on('change', function () {
                     CatalogProducts.getProducts();
@@ -74,7 +74,7 @@
             <span>@T("Catalog.PageSize.PerPage")</span>
         </div>
         <script asp-location="Footer">
-            $(document).ready(function () {
+            $(function() {
                 var $pageSizeEl = $('#products-pagesize');
                 $pageSizeEl.on('change', function () {
                     CatalogProducts.getProducts();

--- a/src/Presentation/Nop.Web/Views/Catalog/_FilterManufacturerBox.cshtml
+++ b/src/Presentation/Nop.Web/Views/Catalog/_FilterManufacturerBox.cshtml
@@ -19,7 +19,7 @@
     </div>
 </div>
 <script asp-location="Footer">
-    $(document).ready(function () {
+    $(function() {
         var $msEls = $('[data-manufacturer-id]');
         $msEls.on('change', function () {
             CatalogProducts.getProducts();

--- a/src/Presentation/Nop.Web/Views/Catalog/_FilterPriceBox.cshtml
+++ b/src/Presentation/Nop.Web/Views/Catalog/_FilterPriceBox.cshtml
@@ -13,7 +13,7 @@
         </div>
         <div id="price-range-slider"></div>
         <script asp-location="Footer">
-            $(document).ready(function () {
+            $(function() {
                 var $priceRangeEl = $("#price-range-slider");
                 $priceRangeEl.slider({
                     range: true,

--- a/src/Presentation/Nop.Web/Views/Catalog/_FilterSpecsBox.cshtml
+++ b/src/Presentation/Nop.Web/Views/Catalog/_FilterSpecsBox.cshtml
@@ -35,7 +35,7 @@
     </div>
 </div>
 <script asp-location="Footer">
-    $(document).ready(function () {
+    $(function() {
         var $optionEls = $('[data-option-id]');
         $optionEls.on('change', function () {
             CatalogProducts.getProducts();

--- a/src/Presentation/Nop.Web/Views/Checkout/Confirm.cshtml
+++ b/src/Presentation/Nop.Web/Views/Checkout/Confirm.cshtml
@@ -19,7 +19,7 @@
         <div class="section confirm-order">
             <form asp-route="CheckoutConfirm" method="post" id="confirm-order-form">
                 <script asp-location="Footer">
-                    $(document).ready(function () {
+                    $(function() {
                         $('.confirm-order-next-step-button').on('click', function () {
                             //terms of service
                             var termOfServiceOk = true;
@@ -60,7 +60,7 @@
                             {
                                 <a class="read" id="read-terms">@T("Checkout.TermsOfService.Read")</a>
                                 <script asp-location="Footer">
-                                    $(document).ready(function() {
+                                    $(function() {
                                         $('#read-terms').on('click',
                                             function(e) {
                                                 e.preventDefault();

--- a/src/Presentation/Nop.Web/Views/Checkout/OpcConfirmOrder.cshtml
+++ b/src/Presentation/Nop.Web/Views/Checkout/OpcConfirmOrder.cshtml
@@ -40,7 +40,7 @@
             {
                 <a class="read" id="read-terms">@T("Checkout.TermsOfService.Read")</a>
                 <script>
-                    $(document).ready(function() {
+                    $(function() {
                         $('#read-terms').on('click', function(e) {
                             e.preventDefault();
                             displayPopupContentFromUrl('@Url.RouteUrl("TopicPopup", new {SystemName = "conditionsofuse"})', '@T("Checkout.TermsOfService")');

--- a/src/Presentation/Nop.Web/Views/Checkout/OpcPaymentMethods.cshtml
+++ b/src/Presentation/Nop.Web/Views/Checkout/OpcPaymentMethods.cshtml
@@ -17,7 +17,7 @@
                 @if (Model.RewardPointsEnoughToPayForOrder)
                 {
                     <script>
-                        $(document).ready(function() {
+                        $(function() {
                             PaymentMethod.toggleUseRewardPoints($('#@Html.IdFor(model => model.UseRewardPoints)'));
                         });
                     </script>

--- a/src/Presentation/Nop.Web/Views/Checkout/OpcShippingAddress.cshtml
+++ b/src/Presentation/Nop.Web/Views/Checkout/OpcShippingAddress.cshtml
@@ -10,7 +10,7 @@
     {
         @await Html.PartialAsync("_PickupPoints", Model.PickupPointsModel)
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $(document).unbind('checkout_toggle_pickup_in_store');
                 $(document).on('checkout_toggle_pickup_in_store', function (e) {
                     if (e.checked) {

--- a/src/Presentation/Nop.Web/Views/Checkout/OpcShippingMethods.cshtml
+++ b/src/Presentation/Nop.Web/Views/Checkout/OpcShippingMethods.cshtml
@@ -5,7 +5,7 @@
     {
         @await Html.PartialAsync("_PickupPoints", Model.PickupPointsModel)
         <script>
-            $(document).ready(function () {
+            $(function() {
                 $(document).unbind('checkout_toggle_pickup_in_store');
                 $(document).on('checkout_toggle_pickup_in_store', function (e) {
                     if (e.checked)

--- a/src/Presentation/Nop.Web/Views/Checkout/PaymentMethod.cshtml
+++ b/src/Presentation/Nop.Web/Views/Checkout/PaymentMethod.cshtml
@@ -25,7 +25,7 @@
                         @if (Model.RewardPointsEnoughToPayForOrder)
                         {
                         <script asp-location="Footer">
-                                $(document).ready(function() {
+                                $(function() {
                                     $("#@Html.IdFor(model => model.UseRewardPoints)")
                                         .on('change', toggleUseRewardPoints);
                                     toggleUseRewardPoints();

--- a/src/Presentation/Nop.Web/Views/Checkout/ShippingAddress.cshtml
+++ b/src/Presentation/Nop.Web/Views/Checkout/ShippingAddress.cshtml
@@ -28,7 +28,7 @@
             {
                 @await Html.PartialAsync("_PickupPoints", Model.PickupPointsModel)
                 <script asp-location="Footer">
-                    $(document).ready(function () {
+                    $(function() {
                         $(document).unbind('checkout_toggle_pickup_in_store');
                         $(document).on('checkout_toggle_pickup_in_store', function (e) {                            
                             if (e.checked)

--- a/src/Presentation/Nop.Web/Views/Checkout/_PickupPoints.cshtml
+++ b/src/Presentation/Nop.Web/Views/Checkout/_PickupPoints.cshtml
@@ -13,7 +13,7 @@
             @T("Checkout.PickupPoints.Description")
         </div>
         <script asp-location="Footer">
-            $(document).ready(function () {
+            $(function() {
                 togglePickupInStore($("#@Html.IdFor(model => model.PickupInStore)")[0]);
 
                 $(document).on('checkout_toggle_pickup_in_store', function (e) {
@@ -111,7 +111,7 @@
                 <script asp-location="Footer">
                     var markers = new Map();
                     var googleMap = null;
-                    $(document).ready(function () {
+                    $(function() {
                         $.getScript("@src", function( data, textStatus, jqxhr ) {
                             google.maps.visualRefresh = true;
                             googleMap = new google.maps.Map(document.getElementById("map"), {

--- a/src/Presentation/Nop.Web/Views/Customer/CheckGiftCardBalance.cshtml
+++ b/src/Presentation/Nop.Web/Views/Customer/CheckGiftCardBalance.cshtml
@@ -64,7 +64,7 @@
             <div class="buttons">
                 <button type="submit" name="checkbalancegiftcard" id="checkbalancegiftcard" class="button-1 check-gift-card-balance-button">@T("CheckGiftCard.GiftCardCouponCode.Button")</button>
                 <script asp-location="Footer">
-                    $(document).ready(function () {
+                    $(function() {
                         $('#giftcardcouponcode').keydown(function (event) {
                             if (event.keyCode == 13) {
                                 $('#checkbalancegiftcard').click();

--- a/src/Presentation/Nop.Web/Views/Customer/GdprTools.cshtml
+++ b/src/Presentation/Nop.Web/Views/Customer/GdprTools.cshtml
@@ -47,7 +47,7 @@
                     <button type="submit" id="delete-account" name="delete-account" class="button-1 gdpr-delete-account-button">@T("Account.Gdpr.Delete.Button")</button>
 
                     <script asp-location="Footer">
-                        $(document).ready(function() {
+                        $(function() {
                             $('#delete-account').on('click', function() {
                                 return confirm('@T("Common.AreYouSure")');
                             });

--- a/src/Presentation/Nop.Web/Views/Customer/Info.cshtml
+++ b/src/Presentation/Nop.Web/Views/Customer/Info.cshtml
@@ -439,7 +439,7 @@
                             if (consent.IsRequired)
                             {
                                 <script asp-location="Footer">
-                                    $(document).ready(function() {
+                                    $(function() {
                                         $('#save-info-button').on('click', function() {
                                             if ($('#consent@(consent.Id)').is(':checked')) {
                                                     //do some stuff

--- a/src/Presentation/Nop.Web/Views/Customer/Register.cshtml
+++ b/src/Presentation/Nop.Web/Views/Customer/Register.cshtml
@@ -363,7 +363,7 @@
                         @if (Model.AcceptPrivacyPolicyEnabled)
                         {
                             <script asp-location="Footer">
-                                $(document).ready(function() {
+                                $(function() {
                                     $('#register-button').on('click', function() {
                                         if ($('#accept-consent').is(':checked')) {
                                             //do some stuff
@@ -383,7 +383,7 @@
                                 {
                                     <span class="read" id="read-privacyinfo">@T("Account.Fields.AcceptPrivacyPolicy.Read")</span>
                                     <script asp-location="Footer">
-                                    $(document).ready(function() {
+                                    $(function() {
                                         $('#read-privacyinfo').on('click',
                                             function(e) {
                                                 displayPopupContentFromUrl(
@@ -407,7 +407,7 @@
                                 if (consent.IsRequired)
                                 {
                                     <script asp-location="Footer">
-                                    $(document).ready(function() {
+                                    $(function() {
                                         $('#register-button').on('click', function() {
                                             if ($('#consent@(consent.Id)').is(':checked')) {
                                                     //do some stuff

--- a/src/Presentation/Nop.Web/Views/Customer/UserAgreement.cshtml
+++ b/src/Presentation/Nop.Web/Views/Customer/UserAgreement.cshtml
@@ -6,7 +6,7 @@
     NopHtml.AppendPageCssClassParts("html-user-agreement-page");
 }
 <script asp-location="Footer">
-    $(document).ready(function () {
+    $(function() {
         $("#agreement-agree").on('click', toggleContinueButton);
         toggleContinueButton();
     });

--- a/src/Presentation/Nop.Web/Views/Customer/_CheckUsernameAvailability.cshtml
+++ b/src/Presentation/Nop.Web/Views/Customer/_CheckUsernameAvailability.cshtml
@@ -1,5 +1,5 @@
 ﻿<script asp-location="Footer">
-    $(document).ready(function () {
+    $(function() {
         $('#check-availability-button').before('<span id="username-availabilty"></span>');
         $('#Username').on({
             keydown: function () {

--- a/src/Presentation/Nop.Web/Views/Install/Index.cshtml
+++ b/src/Presentation/Nop.Web/Views/Install/Index.cshtml
@@ -56,7 +56,7 @@
                         }, 1000);
                     }
 
-                    $(document).ready(function () {
+                    $(function() {
                         $('#installation-form').submit(function () {
                             if ($('#installation-form').valid()) {
                                 $("html, body").animate({ scrollTop: 0 }, 400);
@@ -66,7 +66,7 @@
                         });
                     });
 
-                    $(document).ready(function () {
+                    $(function() {
                         $('#restart-form').submit(function () {
                             $("html, body").animate({ scrollTop: 0 }, 400);
                             showThrobber('@Html.Raw(JavaScriptEncoder.Default.Encode(ILS.GetResource("RestartProgress")))');
@@ -74,7 +74,7 @@
                         });
                     });
 
-                    $(document).ready(function () {
+                    $(function() {
                         $('#@Html.IdFor(x => x.ConnectionStringRaw)').click(toggleSqlConnectionInfo);
 
                         $("input:checkbox[name=UseCustomCollation]").click(toggleCollation);
@@ -83,7 +83,7 @@
                         toggleCollation();
                     });
 
-                    $(document).ready(function () {
+                    $(function() {
                         $('#@Html.IdFor(m => m.DataProvider)').on('change', function() {
                             var integratedSecurityProviders = ['@((int)DataProviderType.SqlServer)']
                             if(!integratedSecurityProviders.includes($(this).val())) {
@@ -122,7 +122,7 @@
                     @if (!string.IsNullOrEmpty(Model.RestartUrl))
                     {
                         <text>
-                            $(document).ready(function () {
+                            $(function() {
                                 showThrobber('@Html.Raw(JavaScriptEncoder.Default.Encode(ILS.GetResource("RestartProgress")))');
                                 $.ajax({
                                     type: "GET",

--- a/src/Presentation/Nop.Web/Views/Install/_Install.ConnectionString.cshtml
+++ b/src/Presentation/Nop.Web/Views/Install/_Install.ConnectionString.cshtml
@@ -50,7 +50,7 @@
     </div>
 
 <script>
-    $(document).ready(function () {
+    $(function() {
         $('#@Html.IdFor(x => x.IntegratedSecurity)').click(toggleSqlAuthenticationType);
 
         toggleSqlAuthenticationType();

--- a/src/Presentation/Nop.Web/Views/Order/Details.cshtml
+++ b/src/Presentation/Nop.Web/Views/Order/Details.cshtml
@@ -22,7 +22,7 @@
 @if (Model.PrintMode)
 {
     <script asp-location="Footer">
-        $(document).ready(function () {
+        $(function() {
             window.print();
         });
     </script>

--- a/src/Presentation/Nop.Web/Views/PrivateMessages/Index.cshtml
+++ b/src/Presentation/Nop.Web/Views/PrivateMessages/Index.cshtml
@@ -17,7 +17,7 @@
             var selectSentTab = Model.SentItemsTabSelected ? ".tabs( 'option', 'active', 1 )" : "";
         }
         <script asp-location="Footer">
-            $(document).ready(function () {
+            $(function() {
                 $("#tabs").tabs()@Html.Raw(selectSentTab);
             });
         </script>

--- a/src/Presentation/Nop.Web/Views/Product/_AddToCart.cshtml
+++ b/src/Presentation/Nop.Web/Views/Product/_AddToCart.cshtml
@@ -32,7 +32,7 @@
                 {
                     <select asp-for="EnteredQuantity" asp-items="Model.AllowedQuantities" id="product_enteredQuantity_@Model.ProductId" class="qty-dropdown" aria-label=@T("Products.Qty.AriaLabel")></select>
                     <script asp-location="Footer">
-                        $(document).ready(function () {
+                        $(function() {
                             $("#product_enteredQuantity_@Model.ProductId").on("change", function () {
                                 var data = {
                                     productId: @Model.ProductId,
@@ -48,7 +48,7 @@
                     <input asp-for="EnteredQuantity" id="product_enteredQuantity_@Model.ProductId" class="qty-input" type="text" aria-label=@T("Products.Qty.AriaLabel")/>
                     <script asp-location="Footer">
                         //when a customer clicks 'Enter' button we submit the "add to cart" button (if visible)
-                        $(document).ready(function() {
+                        $(function() {
                             $("#@Html.IdFor(model => model.EnteredQuantity)").on("keydown", function(event) {
                                 if (event.keyCode == 13) {
                                     $("#add-to-cart-button-@Model.ProductId").trigger("click");

--- a/src/Presentation/Nop.Web/Views/Product/_BackInStockSubscription.cshtml
+++ b/src/Presentation/Nop.Web/Views/Product/_BackInStockSubscription.cshtml
@@ -5,7 +5,7 @@
     <button type="button" id="back-in-stock-subscribe-@Model.Id" class="button-2 subscribe-button">@T("BackInStockSubscriptions.NotifyMeWhenAvailable")</button>
 
     <script asp-location="Footer">
-            $(document).ready(function () {
+            $(function() {
                 $("#back-in-stock-subscribe-@Model.Id").on('click', function() {
                     displayPopupContentFromUrl('@Url.RouteUrl("BackInStockSubscribePopup", new { productId = Model.Id })', '@T("BackInStockSubscriptions.NotifyMeWhenAvailable")');
                 });

--- a/src/Presentation/Nop.Web/Views/Product/_ProductAttributes.cshtml
+++ b/src/Presentation/Nop.Web/Views/Product/_ProductAttributes.cshtml
@@ -54,7 +54,7 @@
                                     </div>
                                 }
                                 <script asp-location="Footer">
-                                    $(document).ready(function() {
+                                    $(function() {
                                         showHideDropdownQuantity("@controlId");
                                     });
                                 </script>
@@ -85,7 +85,7 @@
                                     }
                                 </ul>
                                 <script asp-location="Footer">
-                                    $(document).ready(function() {
+                                    $(function() {
                                         showHideRadioQuantity("@controlId");
                                     });
                                 </script>
@@ -112,7 +112,7 @@
                                                     <label for="@(controlId)_@(attributeValue.Id)_qty">@(T("Products.ProductAttributes.PriceAdjustment.Quantity").Text)</label>
                                                     <input type="text" name="@(controlId)_@(attributeValue.Id)_qty" id="@(controlId)_@(attributeValue.Id)_qty" value="@(attributeValue.Quantity)" />
                                                     <script asp-location="Footer">
-                                                        $(document).ready(function() {
+                                                        $(function() {
                                                             showHideCheckboxQuantity('@(controlId)_@(attributeValue.Id)');
                                                         })
                                                     </script>
@@ -201,7 +201,7 @@
                                     </div>
                                 </script>
                                 <script asp-location="Footer">
-                                    $(document).ready(function() {
+                                    $(function() {
                                         $("#@(controlId)uploader").fineUploader({
                                             request: {
                                                 endpoint: '@(Url.RouteUrl("UploadFileProductAttribute", new { attributeId = attribute.Id }))'
@@ -278,7 +278,7 @@
                                     </div>
                                 }
                                 <script asp-location="Footer">
-                                    $(document).ready(function() {
+                                    $(function() {
                                         $('.attributes #color-squares-@(attribute.Id)').on('click', 'input', function(event) {
                                             $('.attributes #color-squares-@(attribute.Id)').find('li').removeClass('selected-value');
                                             $(this).closest('li').addClass('selected-value');
@@ -320,7 +320,7 @@
                                     </div>
                                 }
                                 <script asp-location="Footer">
-                                    $(document).ready(function() {
+                                    $(function() {
                                         $('.attributes #image-squares-@(attribute.Id)').on('click', 'input', function(event) {
                                             $('.attributes #image-squares-@(attribute.Id)').find('li').removeClass('selected-value');
                                             $(this).closest('li').addClass('selected-value');
@@ -364,7 +364,7 @@
 
         <script asp-location="Footer">
             var combinationsBehavior_@(Model.Id);
-            $(document).ready(function () {
+            $(function() {
                 combinationsBehavior_@(Model.Id) = createCombinationsBehavior({
                     contentEl: '[data-productid="@Model.Id"]',
                     fetchUrl: '@Html.Raw(Url.RouteUrl("GetProductCombinations", new { productId = Model.Id }))'
@@ -384,7 +384,7 @@
         if (Model.AllowAddingOnlyExistingAttributeCombinations && catalogSettings.AttributeValueOutOfStockDisplayType == AttributeValueOutOfStockDisplayType.Disable)
         {
             <script asp-location="Footer">
-                $(document).ready(function () {
+                $(function() {
                     $(combinationsBehavior_@(Model.Id)).on('processed', function () {
                         @(attributeChangeHandlerFuncName)();
                     });
@@ -514,7 +514,7 @@
                     }
                 });
             }
-            $(document).ready(function() {
+            $(function() {
                 @(attributeChangeHandlerFuncName)();
                 @Html.Raw(attributeChangeScriptsBuilder.ToString())
             });

--- a/src/Presentation/Nop.Web/Views/Product/_ProductDetailsPictures.cshtml
+++ b/src/Presentation/Nop.Web/Views/Product/_ProductDetailsPictures.cshtml
@@ -12,7 +12,7 @@
                 <img alt="@Model.DefaultPictureModel.AlternateText" src="@Model.DefaultPictureModel.ImageUrl" title="@Model.DefaultPictureModel.Title" id="main-product-img-@Model.Id" />
             </a>
             <script asp-location="Footer">
-                $(document).ready(function() {
+                $(function() {
                     $('#main-product-img-lightbox-anchor-@Model.Id').magnificPopup({ type: 'image' });
                 });
             </script>
@@ -33,7 +33,7 @@
             }
         </div>
         <script asp-location="Footer">
-            $(document).ready(function() {
+            $(function() {
                 $('.picture-thumbs').magnificPopup(
                     {
                         type: 'image',
@@ -53,7 +53,7 @@
             });
         </script>
         <script asp-location="Footer">
-            $(document).ready(function() {
+            $(function() {
                 $('.thumb-item > img').on('click',
                     function() {
                         $('#main-product-img-@Model.Id').attr('src', $(this).attr('data-defaultsize'));
@@ -78,7 +78,7 @@
                 }
             </div>
             <script asp-location="Footer">
-                $(document).ready(function() {
+                $(function() {
                     $('.thumb-item img').on('click',
                         function() {
                             $('#main-product-img-@Model.Id').attr('src', $(this).attr('data-defaultsize'));

--- a/src/Presentation/Nop.Web/Views/Product/_ProductEstimateShipping.cshtml
+++ b/src/Presentation/Nop.Web/Views/Product/_ProductEstimateShipping.cshtml
@@ -15,7 +15,7 @@
 
     <script asp-location="Footer">
 
-        $(document).ready(function () {
+        $(function() {
             var popUp = {};
             var reloadPopUp = false;
             var initialized = false;

--- a/src/Presentation/Nop.Web/Views/Product/_ProductReviewHelpfulness.cshtml
+++ b/src/Presentation/Nop.Web/Views/Product/_ProductReviewHelpfulness.cshtml
@@ -11,7 +11,7 @@
     <span id="helpfulness-vote-result-@(Model.ProductReviewId)" class="result"></span>
 
     <script asp-location="Footer">
-        $(document).ready(function () {
+        $(function() {
             $('#vote-yes-@(Model.ProductReviewId)').on('click', function () {
                 setProductReviewHelpfulness@(Model.ProductReviewId)('true');
             });

--- a/src/Presentation/Nop.Web/Views/Product/_RentalInfo.cshtml
+++ b/src/Presentation/Nop.Web/Views/Product/_RentalInfo.cshtml
@@ -25,7 +25,7 @@
                 <div class="attribute-data">
                     <input id="@(startDateControlId)" name="@(startDateControlId)" type="text" class="datepicker" value="@(Model.RentalStartDate.HasValue ? Model.RentalStartDate.Value.ToShortDateString() : null)" @if(isMobileDevice){<text>readonly</text>}/>
                     <script asp-location="Footer">
-                        $(document).ready(function () {
+                        $(function() {
                             $("#@(startDateControlId)").datepicker({ dateFormat: "@datePickerFormat", onSelect: @(dateControlChangeHandlerFuncName) });
                         });
                     </script>
@@ -41,7 +41,7 @@
                 <div class="attribute-data">
                     <input id="@(endDateControlId)" name="@(endDateControlId)" type="text" class="datepicker" value="@(Model.RentalEndDate.HasValue ? Model.RentalEndDate.Value.ToShortDateString() : null)" @if(isMobileDevice){<text>readonly</text>}/>
                     <script asp-location="Footer">
-                        $(document).ready(function () {
+                        $(function() {
                             $("#@(endDateControlId)").datepicker({ dateFormat: "@datePickerFormat", onSelect: @(dateControlChangeHandlerFuncName) });
                         });
                     </script>

--- a/src/Presentation/Nop.Web/Views/Profile/Index.cshtml
+++ b/src/Presentation/Nop.Web/Views/Profile/Index.cshtml
@@ -16,7 +16,7 @@
             var selectPostsTab = Model.ForumsEnabled && Model.PagingPosts ? ".tabs( 'option', 'active', 1 )" : "";
         }
         <script asp-location="Footer">
-            $(document).ready(function () {
+            $(function() {
                 $("#tabs").tabs()@Html.Raw(selectPostsTab);
             });
         </script>

--- a/src/Presentation/Nop.Web/Views/ReturnRequest/ReturnRequest.cshtml
+++ b/src/Presentation/Nop.Web/Views/ReturnRequest/ReturnRequest.cshtml
@@ -158,7 +158,7 @@
                                     </div>
                                 </script>
                                 <script asp-location="Footer">
-                                    $(document).ready(function() {
+                                    $(function() {
                                         $("#@(controlId)uploader").fineUploader({
                                             request: {
                                                 endpoint: '@(Url.RouteUrl("UploadFileReturnRequest"))'

--- a/src/Presentation/Nop.Web/Views/Shared/Components/EuCookieLaw/Default.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/Components/EuCookieLaw/Default.cshtml
@@ -1,6 +1,6 @@
 ﻿
 <script asp-location="Footer">
-    $(document).ready(function () {
+    $(function() {
         $('#eu-cookie-bar-notification').show();
 
         $('#eu-cookie-ok').on('click', function () {

--- a/src/Presentation/Nop.Web/Views/Shared/Components/Footer/Default.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/Components/Footer/Default.cshtml
@@ -139,7 +139,7 @@
     @await Component.InvokeAsync(typeof(WidgetViewComponent), new { widgetZone = PublicWidgetZones.Footer, additionalData = Model })
 </div>
 <script asp-location="Footer">
-    $(document).ready(function () {
+    $(function() {
         $('.footer-block .title').on('click', function () {
             var e = window, a = 'inner';
             if (!('innerWidth' in window)) {
@@ -154,7 +154,7 @@
     });
 </script>
 <script asp-location="Footer">
-    $(document).ready(function () {
+    $(function() {
         $('.block .title').on('click', function () {
             var e = window, a = 'inner';
             if (!('innerWidth' in window)) {

--- a/src/Presentation/Nop.Web/Views/Shared/Components/HeaderLinks/Default.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/Components/HeaderLinks/Default.cshtml
@@ -55,7 +55,7 @@
     {
         //new private message notification
         <script asp-location="Footer">
-            $(document).ready(function () {
+            $(function() {
                 displayPopupNotification('@Html.Raw(JavaScriptEncoder.Default.Encode(Model.AlertMessage))', 'success', false);
             });
         </script>
@@ -63,7 +63,7 @@
     @if (Model.ShoppingCartEnabled)
     {
         <script asp-location="Footer">
-            $(document).ready(function () {
+            $(function() {
                 $('.header').on('mouseenter', '#topcartlink', function () {
                     $('#flyout-cart').addClass('active');
                 });

--- a/src/Presentation/Nop.Web/Views/Shared/Components/NewsletterBox/Default.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/Components/NewsletterBox/Default.cshtml
@@ -89,7 +89,7 @@
             });
         }
 
-        $(document).ready(function () {
+        $(function() {
             $('#newsletter-subscribe-button').on('click', function () {
                 @if (Model.AllowToUnsubscribe)
                 {

--- a/src/Presentation/Nop.Web/Views/Shared/Components/OrderSummary/Default.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/Components/OrderSummary/Default.cshtml
@@ -184,7 +184,7 @@
                                                 <div class="quantity down" id="quantity-down-@(item.Id)"></div>
                                             </div>
                                             <script asp-location="Footer">
-                                                $(document).ready(function () {
+                                                $(function() {
                                                     $('#quantity-up-@(item.Id)').on('click',
                                                         function (e) {
                                                             var input = $(document).find('#itemquantity@(item.Id)');
@@ -309,7 +309,7 @@
                             {
                                 <a class="read" id="read-terms">@T("Checkout.TermsOfService.Read")</a>
                                 <script asp-location="Footer">
-                                        $(document).ready(function() {
+                                        $(function() {
                                             $('#read-terms').on('click',
                                                 function(e) {
                                                     e.preventDefault();
@@ -330,7 +330,7 @@
                         @if (string.IsNullOrEmpty(Model.MinOrderSubtotalWarning) && !Model.HideCheckoutButton)
                         {
                             <script asp-location="Footer">
-                                $(document).ready(function () {
+                                $(function() {
                                     $('#checkout').on('click', function () {
                                         //terms of service
                                         var termOfServiceOk = true;

--- a/src/Presentation/Nop.Web/Views/Shared/Components/PrivateMessagesInbox/Default.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/Components/PrivateMessagesInbox/Default.cshtml
@@ -1,7 +1,7 @@
 ﻿@model PrivateMessageListModel 
 <div class="private-messages-box">
     <script asp-location="Footer">
-        $(document).ready(function () {
+        $(function() {
             $('#select-all-inbox').on('click', function () {
                 $('#pm-inbox-table .rowcheckbox').prop('checked', $(this).is(':checked')).trigger('change');
             });

--- a/src/Presentation/Nop.Web/Views/Shared/Components/PrivateMessagesSentItems/Default.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/Components/PrivateMessagesSentItems/Default.cshtml
@@ -1,7 +1,7 @@
 ﻿@model PrivateMessageListModel
 <div class="private-messages-box">
     <script asp-location="Footer">
-        $(document).ready(function () {
+        $(function() {
 
             $('#selectall-sent').on('click', function () {
                 $('#pm-sent-table .rowcheckbox').prop('checked', $(this).is(':checked')).trigger('change');

--- a/src/Presentation/Nop.Web/Views/Shared/Components/SearchBox/Default.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/Components/SearchBox/Default.cshtml
@@ -26,7 +26,7 @@
         @if (Model.AutoCompleteEnabled)
         {
             <script asp-location="Footer">
-                $(document).ready(function() {
+                $(function() {
                     var showLinkToResultSearch;
                     var searchText;
                     $('#small-searchterms').autocomplete({

--- a/src/Presentation/Nop.Web/Views/Shared/Components/ShoppingCartEstimateShipping/Default.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/Components/ShoppingCartEstimateShipping/Default.cshtml
@@ -12,7 +12,7 @@
 
 <script asp-location="Footer">
 
-    $(document).ready(function () {
+    $(function() {
         var popUp = {};
         var settings = {
             opener: '#open-estimate-shipping-popup',

--- a/src/Presentation/Nop.Web/Views/Shared/Components/TopMenu/Default.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/Components/TopMenu/Default.cshtml
@@ -154,7 +154,7 @@
     @if (Model.UseAjaxMenu)
     {
         <script asp-location="Footer">
-        $(document).ready(function () {
+        $(function() {
             $('.menu-toggle').on('click', function () {
                 $(this).siblings('.top-menu.mobile').slideToggle('slow');
             $('.menu-toggle').on('keydown', function (event) {
@@ -176,7 +176,7 @@
     else
     {
         <script asp-location="Footer">
-            $(document).ready(function () {
+            $(function() {
                 $('.menu-toggle').on('click', function () {
                     $(this).siblings('.top-menu.mobile').slideToggle('slow');
                 });

--- a/src/Presentation/Nop.Web/Views/Shared/Components/TopicBlock/Default.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/Components/TopicBlock/Default.cshtml
@@ -2,7 +2,7 @@
 @if (Model.IsPasswordProtected)
 {
 <script asp-location="Footer">
-        $(document).ready(function () {
+        $(function() {
             $('#button-password-@Model.Id').on('click', function() {
                 var postData = {
                     id: $("#topic-@Model.Id").val(),
@@ -37,7 +37,7 @@
             });
         });
 
-        $(document).ready(function() {
+        $(function() {
             $('#ph-topic-@Model.Id').hide();
             $('#ph-password-@Model.Id #password-@Model.Id').select().focus();
         });

--- a/src/Presentation/Nop.Web/Views/Shared/_CheckoutAttributes.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/_CheckoutAttributes.cshtml
@@ -161,7 +161,7 @@
                                     </div>
                                 </script>
                                 <script asp-location="Footer">
-                                    $(document).ready(function() {
+                                    $(function() {
                                         $("#@(controlId)uploader").fineUploader({
                                             request: {
                                                 endpoint: '@(Url.RouteUrl("UploadFileCheckoutAttribute", new {attributeId = attribute.Id}))'
@@ -229,7 +229,7 @@
                                     }
                                 </ul>
                                 <script asp-location="Footer">
-                                    $(document).ready(function() {
+                                    $(function() {
                                         $('.checkout-attributes #color-squares-@(attribute.Id)').on('click', 'input', function (event) {
                                             $('.checkout-attributes #color-squares-@(attribute.Id)').find('li').removeClass('selected-value');
                                             $(this).closest('li').addClass('selected-value');
@@ -249,7 +249,7 @@
         </dl>
     </div>
     <script asp-location="Footer">
-        $(document).ready(function() {
+        $(function() {
             checkoutAttributeChange();
             @Html.Raw(attributeChangeScriptsBuilder.ToString())
         });

--- a/src/Presentation/Nop.Web/Views/Shared/_DiscountBox.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/_DiscountBox.cshtml
@@ -29,7 +29,7 @@
         }
     </div>
     <script asp-location="Footer">
-        $(document).ready(function () {
+        $(function() {
             $('#discountcouponcode').on('keydown', function (event) {
                 if (event.keyCode == 13) {
                     $('#applydiscountcouponcode').trigger("click");

--- a/src/Presentation/Nop.Web/Views/Shared/_Notifications.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/_Notifications.cshtml
@@ -37,7 +37,7 @@
     if (messagesSettings.UsePopupNotifications)
     {
         <script asp-location="Footer">
-            $(document).ready(function () {
+            $(function() {
                 var notes = {
                     'success': [
                         @Html.Raw(string.Join(", ", successMessages.Select(x => $" '{JavaScriptEncoder.Default.Encode(x)}' ")))],
@@ -54,7 +54,7 @@
     else
     {
         <script asp-location="Footer">
-            $(document).ready(function () {
+            $(function() {
                 var successMsg = [ @Html.Raw(string.Join(", ", successMessages.Select(x => $" '{JavaScriptEncoder.Default.Encode(x)}' "))) ];
                 displayBarNotification(successMsg, 'success', false);
 

--- a/src/Presentation/Nop.Web/Views/Shared/_Poll.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/_Poll.cshtml
@@ -31,7 +31,7 @@
         <div class="poll-vote-error" id="block-poll-vote-error-@(Model.Id)" style="display:none">
         </div>
         <script asp-location="Footer">
-            $(document).ready(function () {
+            $(function() {
                 $('#vote-poll-@(Model.Id)').on('click', function () {
                     var pollAnswerId = $("input:radio[name=pollanswers-@(Model.Id)]:checked").val();
                     if (typeof (pollAnswerId) == 'undefined') {

--- a/src/Presentation/Nop.Web/Views/ShoppingCart/_GiftCardBox.cshtml
+++ b/src/Presentation/Nop.Web/Views/ShoppingCart/_GiftCardBox.cshtml
@@ -19,7 +19,7 @@
         }
     </div>
     <script asp-location="Footer">
-        $(document).ready(function () {
+        $(function() {
             $('#giftcardcouponcode').on('keydown', function (event) {
                 if (event.keyCode == 13) {
                     $('#applygiftcardcouponcode').trigger("click");

--- a/src/Presentation/Nop.Web/Views/Topic/TopicDetails.cshtml
+++ b/src/Presentation/Nop.Web/Views/Topic/TopicDetails.cshtml
@@ -36,7 +36,7 @@
 @if (Model.IsPasswordProtected)
 {
     <script asp-location="Footer">
-        $(document).ready(function () {
+        $(function() {
             $('#button-password').on('click', function () {
                 var postData = {
                     id: $("#topic-@Model.Id").val(),
@@ -72,7 +72,7 @@
             });
         });
 
-        $(document).ready(function () {
+        $(function() {
             $('#ph-topic').hide();
             $('#ph-password #password').select().focus();
         });

--- a/src/Presentation/Nop.Web/Views/Vendor/ApplyVendor.cshtml
+++ b/src/Presentation/Nop.Web/Views/Vendor/ApplyVendor.cshtml
@@ -55,7 +55,7 @@
                         @if (Model.TermsOfServiceEnabled)
                         {
                             <script asp-location="Footer">
-                                $(document).ready(function() {
+                                $(function() {
                                     $('#apply-vendor').on('click', function() {
                                         if ($('#termsofservice').is(':checked')) {
                                             //do some stuff
@@ -75,7 +75,7 @@
                                 {
                                     <span class="read" id="read-acceptterms">@T("Vendors.ApplyAccount.AcceptTermsOfService.Read")</span>
                                     <script asp-location="Footer">
-                                        $(document).ready(function() {
+                                        $(function() {
                                             $('#read-acceptterms').on('click',
                                                 function (e) {
                                                     displayPopupContentFromUrl(

--- a/src/Presentation/Nop.Web/wwwroot/js/admin.common.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/admin.common.js
@@ -30,7 +30,7 @@ function showThrobber(message) {
     }, 1000);
 }
 
-$(document).ready(function () {
+$(function() {
     $('.multi-store-override-option').each(function (k, v) {
         checkOverriddenStoreValue(v, $(v).attr('data-for-input-selector'));
     });
@@ -237,7 +237,7 @@ $(document).ajaxStart(function () {
     });
 
 //no-tabs solution
-$(document).ready(function () {
+$(function() {
   $(".card.card-secondary >.card-header").click(CardToggle);
 
   //expanded
@@ -268,7 +268,7 @@ function WrapAndSaveBlockData(card, collapsed) {
 }
 
 //collapse search block
-$(document).ready(function () {
+$(function() {
   $(".row.search-row").click(ToggleSearchBlockAndSavePreferences);
 });
 
@@ -317,7 +317,7 @@ function showAlert(alertId, text)
 
 //scrolling and hidden DataTables issue workaround
 //More info - https://datatables.net/examples/api/tabs_and_scrolling.html
-$(document).ready(function () {
+$(function() {
   $('button[data-card-widget="collapse"]').on('click', function (e) {
     //hack with waiting animation. 
     //when page is loaded, a box that should be collapsed have style 'display: none;'.that's why a table is not updated

--- a/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.common.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.common.js
@@ -69,7 +69,7 @@ var AdminTourNextButton = {}
 var AdminTourNextPageButton = {}
 var AdminTourDoneButton = {}
 
-$(document).ready(function () {
+$(function() {
   AdminTourBackButton = {
     classes: 'button-back',
     text: '<i class="fas fa-chevron-left"></i>' + '<div class="button-text">' + AdminTourDataProvider.localized_data.Back + '</div>',

--- a/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.emailaccount.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.emailaccount.js
@@ -1,4 +1,4 @@
-﻿$(document).ready(function () {
+﻿$(function() {
   const tour = new Shepherd.Tour(AdminTourCommonTourOptions);
 
   AdminTourNextPageButton.action = function () { window.location = '/Admin/Topic/List?showtour=True' };

--- a/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.emailaccountlist.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.emailaccountlist.js
@@ -1,4 +1,4 @@
-﻿$(document).ready(function () {
+﻿$(function() {
   $('#email-accounts-grid').on('draw.dt', function () {
     const tour = new Shepherd.Tour(AdminTourCommonTourOptions);
 

--- a/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.generalsettings.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.generalsettings.js
@@ -1,4 +1,4 @@
-﻿$(document).ready(function () {
+﻿$(function() {
   const tour = new Shepherd.Tour(AdminTourCommonTourOptions);
 
   AdminTourNextPageButton.action = function () { window.location = '/Admin/Store/Edit/' + AdminTourDataProvider.next_button_entity_id + '?showtour=True' };

--- a/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.paymentmethods.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.paymentmethods.js
@@ -1,4 +1,4 @@
-﻿$(document).ready(function () {
+﻿$(function() {
   $('#paymentmethods-grid').on('draw.dt', function () {
     const tour = new Shepherd.Tour(AdminTourCommonTourOptions);
 

--- a/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.paymentpaypal.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.paymentpaypal.js
@@ -1,4 +1,4 @@
-﻿$(document).ready(function () {
+﻿$(function() {
   if ($('body').hasClass('basic-settings-mode')) {
     //$('.onoffswitch-checkbox').trigger('click');
   }

--- a/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.product.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.product.js
@@ -1,4 +1,4 @@
-﻿$(document).ready(function () {
+﻿$(function() {
   const tour = new Shepherd.Tour(AdminTourCommonTourOptions);
 
   AdminTourNextPageButton.action = function () { window.location = '/Admin/EmailAccount/List?showtour=True' };

--- a/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.shippingmanual.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.shippingmanual.js
@@ -1,4 +1,4 @@
-﻿$(document).ready(function () {
+﻿$(function() {
   $('#shipping-rate-grid').on('draw.dt', function () {
     if ($('body').hasClass('advanced-settings-mode')) {
       $('.onoffswitch-checkbox').trigger('click');

--- a/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.shippingproviders.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.shippingproviders.js
@@ -1,4 +1,4 @@
-﻿$(document).ready(function () {
+﻿$(function() {
   $('#shippingproviders-grid').on('draw.dt', function () {
     const tour = new Shepherd.Tour(AdminTourCommonTourOptions);
 

--- a/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.store.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.store.js
@@ -1,4 +1,4 @@
-﻿$(document).ready(function () {
+﻿$(function() {
   const tour = new Shepherd.Tour(AdminTourCommonTourOptions);
 
   AdminTourNextPageButton.action = function () { window.location = '/Admin/Shipping/Providers?showtour=True' };

--- a/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.taxmanual.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.taxmanual.js
@@ -1,4 +1,4 @@
-﻿$(document).ready(function () {
+﻿$(function() {
   $('#tax-categories-grid').on('draw.dt', function () {
     if ($('body').hasClass('advanced-settings-mode')) {
       $('.onoffswitch-checkbox').trigger('click');

--- a/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.taxproviders.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.taxproviders.js
@@ -1,4 +1,4 @@
-﻿$(document).ready(function () {
+﻿$(function() {
   $('#tax-providers-grid').on('draw.dt', function () {
     const tour = new Shepherd.Tour(AdminTourCommonTourOptions);
 

--- a/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.topic.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.topic.js
@@ -1,4 +1,4 @@
-﻿$(document).ready(function () {
+﻿$(function() {
   const tour = new Shepherd.Tour(AdminTourCommonTourOptions);
 
   //'Title and content' step

--- a/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.topiclist.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/admintour/admin.tour.topiclist.js
@@ -1,4 +1,4 @@
-﻿$(document).ready(function () {
+﻿$(function() {
   $('#topics-grid').on('draw.dt', function () {
     const tour = new Shepherd.Tour(AdminTourCommonTourOptions);
 


### PR DESCRIPTION
-per https://api.jquery.com/ready/ only one ready signature is not deprecated in jQuery 3+

> jQuery offers several ways to attach a function that will run when the DOM is ready. All of the following syntaxes are equivalent:
> 
> $( handler )
> $( document ).ready( handler )
> $( "document" ).ready( handler )
> $( "img" ).ready( handler )
> $().ready( handler )
> As of jQuery 3.0, **only the first syntax is recommended; the other syntaxes still work but are deprecated**.