### PR TITLE
refactor (jQuery): Replaced deprecated click() with trigger('click')

### DIFF
--- a/src/Plugins/Nop.Plugin.DiscountRules.CustomerRoles/Views/Configure.cshtml
+++ b/src/Plugins/Nop.Plugin.DiscountRules.CustomerRoles/Views/Configure.cshtml
@@ -34,7 +34,7 @@
                                 errorMessages += '</br>';
                         });
                         $alertInfoEl.html(errorMessages);
-                        $("#savecustomerrolesrequirementAlert").click();
+                        $("#savecustomerrolesrequirementAlert").trigger("click");
 
                         return;
                     } 
@@ -52,7 +52,7 @@
                     // display default error
                     $alertInfoEl.html('@T("Admin.Promotions.Discounts.Requirements.FailedToSave")');
 
-                    $("#savecustomerrolesrequirementAlert").click();
+                    $("#savecustomerrolesrequirementAlert").trigger("click");
                 }
             });
         });

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Views/Buttons.cshtml
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Views/Buttons.cshtml
@@ -30,10 +30,10 @@ else
             fundingSource: paypal.FUNDING.PAYPAL,
             onClick: function (e, n) {
                 if ($('#checkout').length > 0) {
-                    $('#checkout').click();
+                    $('#checkout').trigger("click");
                 }
                 if ($('#add-to-cart-button-@Model.ProductId').length > 0) {
-                    $('#add-to-cart-button-@Model.ProductId').click();
+                    $('#add-to-cart-button-@Model.ProductId').trigger('click');
                 }
                 return false;
             },

--- a/src/Plugins/Nop.Plugin.Pickup.PickupInStore/Views/_CreateOrUpdate.cshtml
+++ b/src/Plugins/Nop.Plugin.Pickup.PickupInStore/Views/_CreateOrUpdate.cshtml
@@ -34,7 +34,7 @@
                             });
                         },
                         error: function (jqXHR, textStatus, errorThrown) {
-                            $("#getStatesByCountryIdAlert").click();
+                            $("#getStatesByCountryIdAlert").trigger("click");
                         }
                     });
                 });

--- a/src/Plugins/Nop.Plugin.Shipping.FixedByWeightByTotal/Views/Configure.cshtml
+++ b/src/Plugins/Nop.Plugin.Shipping.FixedByWeightByTotal/Views/Configure.cshtml
@@ -65,7 +65,7 @@
                     data: postData,
                     dataType: "json",
                     error: function (jqXHR, textStatus, errorThrown) {
-                        $("#saveModeAlert").click();
+                            $("#saveModeAlert").trigger("click");
                     }
                 });
                 ensureDataTablesRendered();

--- a/src/Plugins/Nop.Plugin.Shipping.FixedByWeightByTotal/Views/_ByWeightByTotal.cshtml
+++ b/src/Plugins/Nop.Plugin.Shipping.FixedByWeightByTotal/Views/_ByWeightByTotal.cshtml
@@ -35,7 +35,7 @@
                     });
                 },
                 error: function (jqXHR, textStatus, errorThrown) {
-                    $("#getStatesByCountryIdAlert").click();
+                    $("#getStatesByCountryIdAlert").trigger("click");
                 }
             });
         });
@@ -242,10 +242,10 @@
                                             data: postData,
                                             dataType: "json",
                                             success: function (data, textStatus, jqXHR) {
-                                                $("#savegeneralsettingsOk").click();
+                                            	$("#savegeneralsettingsOk").trigger("click");
                                             },
                                             error: function (jqXHR, textStatus, errorThrown) {
-                                                $("#savegeneralsettingsError").click();
+                                                $("#savegeneralsettingsError").trigger("click");
                                             }
                                         });
                                         return false;

--- a/src/Plugins/Nop.Plugin.Shipping.FixedByWeightByTotal/Views/_CreateOrUpdateRateByWeightByTotal.cshtml
+++ b/src/Plugins/Nop.Plugin.Shipping.FixedByWeightByTotal/Views/_CreateOrUpdateRateByWeightByTotal.cshtml
@@ -32,7 +32,7 @@
                     });
                 },
                 error: function (jqXHR, textStatus, errorThrown) {
-                    $("#getStatesByCountryIdAlert").click();
+                    $("#getStatesByCountryIdAlert").trigger("click");
                 }
             });
         });

--- a/src/Plugins/Nop.Plugin.Tax.Avalara/Views/Configuration/_Configuration.cshtml
+++ b/src/Plugins/Nop.Plugin.Tax.Avalara/Views/Configuration/_Configuration.cshtml
@@ -285,7 +285,7 @@
                                     });
                                 },
                                 error: function (jqXHR, textStatus, errorThrown) {
-                                    $('#states-alert').click();
+                                    $('#states-alert').trigger('click');
                                 }
                             });
                         });

--- a/src/Plugins/Nop.Plugin.Tax.Avalara/Views/Product/_ExportItemsForm.cshtml
+++ b/src/Plugins/Nop.Plugin.Tax.Avalara/Views/Product/_ExportItemsForm.cshtml
@@ -6,7 +6,7 @@
                 var ids = selectedIds.join(',');
                 if (!ids) {
                     $('#export-avalara-selected-alert-info').text('@T("Admin.Products.NoProducts")');
-                    $('#export-avalara-selected-alert').click();
+                    $('#export-avalara-selected-alert').trigger('click');
                 }
                 else {
                     $('#export-avalara-selected-form #selectedIds').val(ids);

--- a/src/Plugins/Nop.Plugin.Tax.FixedOrByCountryStateZip/Views/Configure.cshtml
+++ b/src/Plugins/Nop.Plugin.Tax.FixedOrByCountryStateZip/Views/Configure.cshtml
@@ -59,7 +59,7 @@
                 data: postData,
                 dataType: "json",
                 error: function (jqXHR, textStatus, errorThrown) {
-                    $("#saveModeAlert").click();
+                    $("#saveModeAlert").trigger("click");
                 }
             });
             ensureDataTablesRendered();

--- a/src/Plugins/Nop.Plugin.Tax.FixedOrByCountryStateZip/Views/_CountryStateZip.cshtml
+++ b/src/Plugins/Nop.Plugin.Tax.FixedOrByCountryStateZip/Views/_CountryStateZip.cshtml
@@ -106,7 +106,7 @@
                                             });
                                     },
                                     error: function (jqXHR, textStatus, errorThrown) {
-                                        $("#getStatesByCountryIdAlert").click();
+                                            $("#getStatesByCountryIdAlert").trigger("click");
                                     }
                                 });
                             });
@@ -191,7 +191,7 @@
                                                 updateTable('#tax-countrystatezip-grid');
                                             },
                                             error: function (jqXHR, textStatus, errorThrown) {
-                                                $("#addRateByCountryStateZipAlert").click();
+                                                    $("#addRateByCountryStateZipAlert").trigger("click");
                                             }
                                         });
                                         return false;

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Currency/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Currency/List.cshtml
@@ -160,7 +160,7 @@
                                         updateTable('#currencies-grid');
                                     },
                                     error: function (jqXHR, textStatus, errorThrown) {
-                                        $("#currencyAlert").click();
+                                        $("#currencyAlert").trigger("click");
                                     }
                                 });
                                 $('#btnMarkPSC-action-confirmation').modal('toggle');
@@ -180,7 +180,7 @@
                                         updateTable('#currencies-grid');
                                     },
                                     error: function (jqXHR, textStatus, errorThrown) {
-                                        $("#currencyAlert").click();
+                                        $("#currencyAlert").trigger("click");
                                     }
                                 });
                                 $('#btnMarkPERC-action-confirmation').modal('toggle');
@@ -190,12 +190,12 @@
 
                         function markAsPrimaryExchangeRateCurrency(id) {
                             selectedId = id;
-                            $("#btnMarkPERC").click();
+                            $("#btnMarkPERC").trigger("click");
                         };
 
                         function markAsPrimaryStoreCurrency(id) {
                             selectedId = id;
-                            $("#btnMarkPSC").click();
+                            $("#btnMarkPSC").trigger("click");
                         };
                                 </script>
                             </div>
@@ -261,7 +261,7 @@
                                             updateTable('#currencies-grid');
                                         },
                                         error: function (jqXHR, textStatus, errorThrown) {
-                                            $("#currencyAlert").click();
+                                            $("#currencyAlert").trigger("click");
                                         }
                                     });
                                 }

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Customer/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Customer/List.cshtml
@@ -385,7 +385,7 @@
             var ids = selectedIds.join(",");
             if (!ids) {
                 $('#exportXmlSelected-info').text("@T("Admin.Customers.NoCustomers")");
-                $("#exportXmlSelected").click();
+                $("#exportXmlSelected").trigger("click");
             }
             else {
                 $('#export-xml-selected-form #selectedIds').val(ids);
@@ -452,7 +452,7 @@
             var ids = selectedIds.join(",");
             if (!ids) {
                 $('#exportExcelSelected-info').text("@T("Admin.Customers.NoCustomers")");
-                $("#exportExcelSelected").click();
+                $("#exportExcelSelected").trigger("click");
             }
             else {
                 $('#export-excel-selected-form #selectedIds').val(ids);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Customer/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Customer/_CreateOrUpdate.Info.cshtml
@@ -26,7 +26,7 @@
                         });
                     },
                     error: function (jqXHR, textStatus, errorThrown) {
-                        $("#statesAlert").click();
+                        $("#statesAlert").trigger("click");
                     }
                 });
             });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/CustomerRole/AssociateProductToCustomerRolePopup.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/CustomerRole/AssociateProductToCustomerRolePopup.cshtml
@@ -152,7 +152,7 @@
                                         }
                                         function selectAssociatedProduct(productid) {
                                             $("#@Html.IdFor(model => model.AddProductToCustomerRoleModel.AssociatedToProductId)").val(productid);
-                                            $('#save').click();
+                                            $('#save').trigger('click');
                                         }
                                     </script>
                                 </div>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Discount/_CreateOrUpdate.Requirements.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Discount/_CreateOrUpdate.Requirements.cshtml
@@ -118,7 +118,7 @@
                         }
                     },
                     error: function (jqXHR, textStatus, errorThrown) {
-                        $("#getDiscountRequirementsAlert").click();
+                        $("#getDiscountRequirementsAlert").trigger("click");
                     }
                 });
             };
@@ -163,7 +163,7 @@
                         $("#discountRequirementContainer").trigger('nopnewdiscountruleadded', [data.NewRequirementId]);
                     },
                     error: function (jqXHR, textStatus, errorThrown) {
-                        $("#failedToSave").click();
+                        $("#failedToSave").trigger("click");
                     }
                 });
             };

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/GiftCard/_CreateOrUpdate.Info.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/GiftCard/_CreateOrUpdate.Info.cshtml
@@ -79,7 +79,7 @@
                                     },
                                     error: function (jqXHR, textStatus, errorThrown) {
                                         $('#generateCouponCodeFailed-info').text(errorThrown);
-                                        $("#generateCouponCodeFailed").click();                                                
+                                        $("#generateCouponCodeFailed").trigger("click");                                                
                                     }
                                 });
                             });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_CustomerStatistics.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_CustomerStatistics.cshtml
@@ -151,7 +151,7 @@
                     }
                 },
                 error: function (jqXHR, textStatus, errorThrown) {
-                    $("#loadCustomerStatisticsAlert").click();
+                    $("#loadCustomerStatisticsAlert").trigger("click");
                 }
             });
         }

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_OrderStatistics.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Home/_OrderStatistics.cshtml
@@ -150,7 +150,7 @@
                     }
                 },
                 error: function (jqXHR, textStatus, errorThrown) {
-                    $("#loadOrderStatisticsAlert").click();
+                    $("#loadOrderStatisticsAlert").trigger("click");
                 }
             });
         }

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Measure/Dimensions.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Measure/Dimensions.cshtml
@@ -77,7 +77,7 @@
 
             function markAsPrimaryDimension(id) {
                 selectedId = id;
-                $("#btnMarkAsPrimaryDimension").click();
+                $("#btnMarkAsPrimaryDimension").trigger("click");
             };
 
             $(function() {
@@ -95,7 +95,7 @@
                             updateTable('#measuredimension-grid');
                         },
                         error: function (jqXHR, textStatus, errorThrown) {
-                            $("#markAsPrimaryDimensionAlert").click();
+                            $("#markAsPrimaryDimensionAlert").trigger("click");
                         }
                     });
                     $('#btnMarkAsPrimaryDimension-action-confirmation').modal('toggle');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Measure/Weights.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Measure/Weights.cshtml
@@ -76,7 +76,7 @@
 
             function markAsPrimaryWeight(id) {
                 selectedId = id;
-                $("#btnMarkAsPrimaryWeight").click();
+                $("#btnMarkAsPrimaryWeight").trigger("click");
             };
 
             $(function() {
@@ -94,7 +94,7 @@
                             updateTable('#measureweight-grid');
                         },
                         error: function (jqXHR, textStatus, errorThrown) {
-                            $("#markAsPrimaryWeightAlert").click();
+                            $("#markAsPrimaryWeightAlert").trigger("click");
                         }
                     });
                     $('#btnMarkAsPrimaryWeight-action-confirmation').modal('toggle');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/List.cshtml
@@ -422,7 +422,7 @@
                                     $("#@Html.IdFor(model => model.GoDirectlyToCustomOrderNumber)").keydown(
                                         function(event) {
                                             if (event.keyCode === 13) {
-                                                $("#go-to-order-by-number").click();
+                                                $("#go-to-order-by-number").trigger("click");
                                                 return false;
                                             }
                                         });
@@ -530,7 +530,7 @@
             var ids = selectedIds.join(",");
             if (!ids) {
                 $('#exportXmlSelected-info').text("@T("Admin.Orders.NoOrders")");
-                $("#exportXmlSelected").click();
+                $("#exportXmlSelected").trigger("click");
             }
             else {
                 $('#export-xml-selected-form #selectedIds').val(ids);
@@ -555,7 +555,7 @@
             var ids = selectedIds.join(",");
              if (!ids) {
                 $('#exportExcelSelected-info').text("@T("Admin.Orders.NoOrders")");
-                $("#exportExcelSelected").click();
+                $("#exportExcelSelected").trigger("click");
             }
             else {
                 $('#export-excel-selected-form #selectedIds').val(ids);
@@ -580,7 +580,7 @@
             var ids = selectedIds.join(",");
            if (!ids) {
                 $('#pdfInvoiceSelected-info').text("@T("Admin.Orders.NoOrders")");
-                $("#pdfInvoiceSelected").click();
+                $("#pdfInvoiceSelected").trigger("click");
             }
             else {
                 $('#pdf-invoice-selected-form #selectedIds').val(ids);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/ShipmentList.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/ShipmentList.cshtml
@@ -333,7 +333,7 @@
                                             });
                                         },
                                         error: function (jqXHR, textStatus, errorThrown) {
-                                            $("#statesAlert").click();
+                                            $("#statesAlert").trigger("click");
                                         }
                                     });
                                 });
@@ -384,7 +384,7 @@
             var ids = selectedIds.join(",");
             if (!ids) {
                 $('#exportPackagingSlipsSelected-info').text("@T("Admin.Orders.Shipments.NoShipmentsSelected")");
-                $("#exportPackagingSlipsSelected").click();
+                $("#exportPackagingSlipsSelected").trigger("click");
             }
             else {
                 $('#pdf-packaging-slip-selected-form #selectedIds').val(ids);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_ProductAddAttributes.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_ProductAddAttributes.cshtml
@@ -213,7 +213,7 @@
 
                                                     if (responseJSON.message) {
                                                         $('#uploadFileProductAttributeFailed-info').text((responseJSON.message).Text.replace(/<[^>]+>/g, ''));
-                                                        $("#uploadFileProductAttributeFailed").click();
+                                                        $("#uploadFileProductAttributeFailed").trigger("click");
                                                     }
                                                 });
 
@@ -305,7 +305,7 @@
                             }
                             if (data.message) {
                                 $('#productdetails_attributechangeMessage-info').text(data.message);
-                                $("#productdetails_attributechangeMessage").click();
+                                $("#productdetails_attributechangeMessage").trigger("click");
                             }
                         }
                     });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/AssociateProductToAttributeValuePopup.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/AssociateProductToAttributeValuePopup.cshtml
@@ -156,7 +156,7 @@
                                 <script>
                                     function selectAssociatedProduct(productid) {
                                         $("#@Html.IdFor(model => model.AssociateProductToAttributeValueModel.AssociatedToProductId)").val(productid);
-                                        $('#save').click();
+                                        $('#save').trigger('click');
                                     }
                                 </script>
                             </div>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/List.cshtml
@@ -323,7 +323,7 @@
         $(function() {
             $("#@Html.IdFor(model => model.GoDirectlyToSku)").keydown(function (event) {
                 if (event.keyCode === 13) {
-                    $("#go-to-product-by-sku").click();
+                    $("#go-to-product-by-sku").trigger("click");
                     return false;
                 }
             });
@@ -427,7 +427,7 @@
             var ids = selectedIds.join(",");
             if (!ids) {
                 $('#exportXmlSelected-info').text("@T("Admin.Products.NoProducts")");
-                $("#exportXmlSelected").click();
+                $("#exportXmlSelected").trigger("click");
             }
             else {
                 $('#export-xml-selected-form #selectedIds').val(ids);
@@ -452,7 +452,7 @@
                 var ids = selectedIds.join(",");
                 if (!ids) {
                     $('#exportExcelSelected-info').text("@T("Admin.Products.NoProducts")");
-                    $("#exportExcelSelected").click();
+                    $("#exportExcelSelected").trigger("click");
                 }
                 else {
                     $('#export-excel-selected-form #selectedIds').val(ids);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/ProductSpecAttributeAddOrEdit.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/ProductSpecAttributeAddOrEdit.cshtml
@@ -170,7 +170,7 @@
                                                         });
                                                 },
                                                 error: function (jqXHR, textStatus, errorThrown) {
-                                                    $("#getOptionsByAttributeIdAlert").click();
+                                                    $("#getOptionsByAttributeIdAlert").trigger("click");
                                                 }
                                             });
                                         });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.ProductAttributes.Combinations.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.ProductAttributes.Combinations.cshtml
@@ -139,7 +139,7 @@
                                 updateTable('#attributecombinations-grid');
                             },
                             error: function (jqXHR, textStatus, errorThrown) {
-                                $("#generateAllAttributeCombinationsAlert").click();
+                                $("#generateAllAttributeCombinationsAlert").trigger("click");
                             }
                         });
                         $('#btnGenerateAllCombinations-action-confirmation').modal('toggle');

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/QueuedEmail/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/QueuedEmail/List.cshtml
@@ -213,7 +213,7 @@
                             $(function() {
                                 $("#@Html.IdFor(model => model.GoDirectlyToNumber)").keydown(function (event) {
                                     if (event.keyCode === 13) {
-                                        $("#go-to-email-by-number").click();
+                                        $("#go-to-email-by-number").trigger("click");
                                         return false;
                                     }
                                 });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/Address.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/Address.cshtml
@@ -21,7 +21,7 @@
                         });
                 },
                 error: function (jqXHR, textStatus, errorThrown) {
-                    $("#statesAlert").click();
+                    $("#statesAlert").trigger("click");
                 }
             });
         });

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/Download.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/Download.cshtml
@@ -17,9 +17,9 @@
 
 <script>
     $(function() {
-        $('#cbUseDownloadURL@(randomNumber)').click(toggleDownloadRecordType@(randomNumber));
+        $('#cbUseDownloadURL@(randomNumber)').on('click', toggleDownloadRecordType@(randomNumber));
 
-        $('#saveDownloadUrl@(randomNumber)').click(function () {
+        $('#saveDownloadUrl@(randomNumber)').on('click', function () {
             var downloadUrl = $("#downloadurl@(randomNumber)").val();
             $('#saveDownloadUrl@(randomNumber)').attr('disabled', true);
 
@@ -40,11 +40,11 @@
                     }
                     else {
                         $('#saveDownloadUrlFailed-info').text(data.message);
-                        $("#saveDownloadUrlFailed").click();
+                        $("#saveDownloadUrlFailed").trigger("click");
                     }
                 },
                 error: function (jqXHR, textStatus, errorThrown) {
-                    $("#saveDownloadUrlAlert").click();
+                    $("#saveDownloadUrlAlert").trigger("click");
                 },
                 complete: function (jqXHR, textStatus) {
                     $('#saveDownloadUrl@(randomNumber)').attr('disabled', false);

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/RichEditor.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/RichEditor.cshtml
@@ -74,7 +74,7 @@
                 },
                 error: function (jqXHR, textStatus, errorThrown) {
                     $('#createConfigurationFailed-info').text(errorThrown);
-                    $("#createConfigurationFailed").click();
+                    $("#createConfigurationFailed").trigger("click");
                 }
             });
         }

--- a/src/Presentation/Nop.Web/Views/Customer/CheckGiftCardBalance.cshtml
+++ b/src/Presentation/Nop.Web/Views/Customer/CheckGiftCardBalance.cshtml
@@ -67,7 +67,7 @@
                     $(function() {
                         $('#giftcardcouponcode').keydown(function (event) {
                             if (event.keyCode == 13) {
-                                $('#checkbalancegiftcard').click();
+                                $('#checkbalancegiftcard').trigger('click');
                                 return false;
                             }
                         });

--- a/src/Presentation/Nop.Web/Views/Shared/Components/OrderSummary/Default.cshtml
+++ b/src/Presentation/Nop.Web/Views/Shared/Components/OrderSummary/Default.cshtml
@@ -180,7 +180,7 @@
                                         {
                                             <div class="product-quantity">
                                                 <div class="quantity up" id="quantity-up-@(item.Id)"></div>
-                                                <input name="itemquantity@(item.Id)" id="itemquantity@(item.Id)" type="text" value="@(item.Quantity)" class="qty-input" aria-label="@T("ShoppingCart.Quantity")" onchange="$('#updatecart').click();" />
+                                                <input name="itemquantity@(item.Id)" id="itemquantity@(item.Id)" type="text" value="@(item.Quantity)" class="qty-input" aria-label="@T("ShoppingCart.Quantity")" onchange="$('#updatecart').trigger('click');" />
                                                 <div class="quantity down" id="quantity-down-@(item.Id)"></div>
                                             </div>
                                             <script asp-location="Footer">
@@ -237,7 +237,7 @@
                                         else
                                         {
                                             <input type="checkbox" name="removefromcart" id="removefromcart@(item.Id)" value="@(item.Id)" aria-label="@T("ShoppingCart.Remove")" />
-                                            <button type="button" name="updatecart" class="remove-btn" onclick="$('#removefromcart@(item.Id)').attr('checked', true); $('#updatecart').click();"></button>
+                                            <button type="button" name="updatecart" class="remove-btn" onclick="$('#removefromcart@(item.Id)').attr('checked', true); $('#updatecart').trigger('click');"></button>
                                         }
                                     </td>
                                 }

--- a/src/Presentation/Nop.Web/Views/ShoppingCart/Wishlist.cshtml
+++ b/src/Presentation/Nop.Web/Views/ShoppingCart/Wishlist.cshtml
@@ -224,7 +224,7 @@
                                         {
                                             <td class="remove-from-cart">
                                                 <input type="checkbox" name="removefromcart" id="removefromcart@(item.Id)" value="@(item.Id)" aria-label="@T("ShoppingCart.Remove")" />
-                                                <button type="button" name="updatecart" class="remove-btn" onclick="$('#removefromcart@(item.Id)').attr('checked', true); $('#updatecart').click();"></button>
+                                                <button type="button" name="updatecart" class="remove-btn" onclick="$('#removefromcart@(item.Id)').attr('checked', true); $('#updatecart').trigger('click');"></button>
                                             </td>
                                         }
                                     </tr>


### PR DESCRIPTION
replace deprecated jQuery `click()` with `trigger('click')`
-per https://api.jquery.com/click-shorthand/#click-handler

> This API is deprecated.
> 
> Instead of .click( handler ) or .click( eventData, handler ), use .on( "click", handler ) or .on( "click", eventData, handler ), respectively.
> 
> Instead of .click(), use .trigger( "click" ).