### PR TITLE
#7048 Fix incorrect documentation in HtmlFormatter

### DIFF
--- a/src/Libraries/Nop.Services/Html/HtmlFormatter.cs
+++ b/src/Libraries/Nop.Services/Html/HtmlFormatter.cs
@@ -28,8 +28,8 @@ public partial class HtmlFormatter : IHtmlFormatter
     /// <summary>
     /// Ensure only allowed HTML tags
     /// </summary>
-    /// <param name="text">Text to check</param>
-    /// <returns>True - if the text contains only valid tags, false otherwise</returns>
+    /// <param name="text">Text</param>
+    /// <returns>Validated text with all invalid tags removed</returns>
     protected static string EnsureOnlyAllowedHtml(string text)
     {
         if (string.IsNullOrEmpty(text))
@@ -53,7 +53,7 @@ public partial class HtmlFormatter : IHtmlFormatter
     /// <summary>
     /// Indicates whether the HTML tag is valid
     /// </summary>
-    /// <param name="tag">HTMl tag to check</param>
+    /// <param name="tag">HTML tag to check</param>
     /// <param name="tags">List of valid tags</param>
     /// <returns>True - if the tag if valid, false otherwise</returns>
     protected static bool IsValidTag(string tag, string tags)

--- a/src/Libraries/Nop.Services/Html/HtmlFormatter.cs
+++ b/src/Libraries/Nop.Services/Html/HtmlFormatter.cs
@@ -29,7 +29,7 @@ public partial class HtmlFormatter : IHtmlFormatter
     /// Ensure only allowed HTML tags
     /// </summary>
     /// <param name="text">Text</param>
-    /// <returns>Validated text with all invalid tags removed</returns>
+    /// <returns>Sanitized text with all invalid tags removed</returns>
     protected static string EnsureOnlyAllowedHtml(string text)
     {
         if (string.IsNullOrEmpty(text))


### PR DESCRIPTION
### Issue #7048

In `Nop.Services.HtmlFormatter`, the documentation comment for the utility method `EnsureOnlyAllowedHtml` includes an incorrect description for the return value.

The method signature is `protected static string EnsureOnlyAllowedHtml(string text)`, and the method implementation returns the validated text with all invalid tags removed. However, the documentation indicates that the method returns a `bool` value to indicate the validity of the original text.

Actual documentation: `<returns>True - if the text contains only valid tags, false otherwise</returns>`.

Expected documentation: `<returns>Validated text with all invalid tags removed</returns>`.

### Modifications

- Modify `EnsureOnlyAllowedHtml` `text` parameter description for consistency with same parameter in other methods.
- Modify `EnsureOnlyAllowedHtml` return description for correctness.
- Ensure that "HTML" is written in all capitals.