### PR TITLE
Update GoogleAnalyticsHttpClient to be ThreadSafe

### DIFF
--- a/src/Plugins/Nop.Plugin.Widgets.GoogleAnalytics/Infrastructure/NopStartup.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.GoogleAnalytics/Infrastructure/NopStartup.cs
@@ -22,6 +22,7 @@ public class NopStartup : INopStartup
         services.AddHttpClient<GoogleAnalyticsHttpClient>(
                 client => client.Timeout = TimeSpan.FromSeconds(10))
             .WithProxy();
+        services.AddScoped<GoogleAnalyticsHttpClient>();
     }
 
     /// <summary>

--- a/src/Plugins/Nop.Plugin.Widgets.GoogleAnalytics/Infrastructure/NopStartup.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.GoogleAnalytics/Infrastructure/NopStartup.cs
@@ -19,7 +19,9 @@ public class NopStartup : INopStartup
     /// <param name="configuration">Configuration of the application</param>
     public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
     {
-        services.AddHttpClient<GoogleAnalyticsHttpClient>().WithProxy();
+        services.AddHttpClient<GoogleAnalyticsHttpClient>(
+                client => client.Timeout = TimeSpan.FromSeconds(10))
+            .WithProxy();
     }
 
     /// <summary>


### PR DESCRIPTION
Because HttpClient is a shared object it produces the following exception:
System.InvalidOperationException: This instance has already started one or more requests. Properties can only be modified before sending the first request.
   at System.Net.Http.HttpClient.set_BaseAddress(Uri value)
   at Nop.Plugin.Widgets.GoogleAnalytics.Api.GoogleAnalyticsHttpClient.RequestAsync(EventRequest request, GoogleAnalyticsSettings googleAnalyticsSettings)
   at Nop.Plugin.Widgets.GoogleAnalytics.EventConsumer.ProcessOrderEventAsync(Order order, GoogleAnalyticsSettings googleAnalyticsSettings, String eventName)

The PR removes the Set BaseAddress and Timeout from the HttpClient inside the RequestAsync method.

Instead of HttpClient now GoogleAnalyticsHttpClient has dependency on IHttpClientFactory and httpClient instance is created using  _clientFactory.CreateClient(nameof(GoogleAnalyticsHttpClient));

BaseAddres is remove, and it is set on HttpRequestMessage instance