### PR TITLE
Add new event of 'ShipmentTrackingNumberSetEvent'

### DIFF
--- a/src/Libraries/Nop.Core/Domain/Shipping/ShipmentTrackingNumberSetEvent.cs
+++ b/src/Libraries/Nop.Core/Domain/Shipping/ShipmentTrackingNumberSetEvent.cs
@@ -1,0 +1,21 @@
+﻿namespace Nop.Core.Domain.Shipping;
+
+/// <summary>
+/// Shipment tracking number set event
+/// </summary>
+public partial class ShipmentTrackingNumberSetEvent
+{
+    /// <summary>
+    /// Ctor
+    /// </summary>
+    /// <param name="shipment">Shipment</param>
+    public ShipmentTrackingNumberSetEvent(Shipment shipment)
+    {
+        Shipment = shipment;
+    }
+
+    /// <summary>
+    /// Shipment
+    /// </summary>
+    public Shipment Shipment { get; }
+}

--- a/src/Presentation/Nop.Web/Areas/Admin/Controllers/OrderController.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Controllers/OrderController.cs
@@ -2078,11 +2078,8 @@ public partial class OrderController : BaseAdminController
 
             await _eventPublisher.PublishAsync(new ShipmentCreatedEvent(shipment));
 
-            //publish an event to inform related consumers
             if (!string.IsNullOrWhiteSpace(shipment.TrackingNumber))
-            {
                 await _eventPublisher.PublishAsync(new ShipmentTrackingNumberSetEvent(shipment));
-            }
 
             var canShip = !order.PickupInStore && model.CanShip;
             if (canShip)
@@ -2190,15 +2187,12 @@ public partial class OrderController : BaseAdminController
         if (await _workContext.GetCurrentVendorAsync() != null && !await HasAccessToShipmentAsync(shipment))
             return RedirectToAction("List");
 
-        //if tracking number has not been changed,
-        //then redirect details page without calling and updating DB!
         if (shipment.TrackingNumber == model.TrackingNumber)
             return RedirectToAction("ShipmentDetails", new { id = shipment.Id });
 
         shipment.TrackingNumber = model.TrackingNumber;
         await _shipmentService.UpdateShipmentAsync(shipment);
 
-        //publish an event to inform related consumers
         await _eventPublisher.PublishAsync(new ShipmentTrackingNumberSetEvent(shipment));
 
         return RedirectToAction("ShipmentDetails", new { id = shipment.Id });

--- a/src/Presentation/Nop.Web/Areas/Admin/Controllers/OrderController.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Controllers/OrderController.cs
@@ -2078,6 +2078,12 @@ public partial class OrderController : BaseAdminController
 
             await _eventPublisher.PublishAsync(new ShipmentCreatedEvent(shipment));
 
+            //publish an event to inform related consumers
+            if (!string.IsNullOrWhiteSpace(shipment.TrackingNumber))
+            {
+                await _eventPublisher.PublishAsync(new ShipmentTrackingNumberSetEvent(shipment));
+            }
+
             var canShip = !order.PickupInStore && model.CanShip;
             if (canShip)
                 await _orderProcessingService.ShipAsync(shipment, true);
@@ -2184,8 +2190,16 @@ public partial class OrderController : BaseAdminController
         if (await _workContext.GetCurrentVendorAsync() != null && !await HasAccessToShipmentAsync(shipment))
             return RedirectToAction("List");
 
+        //if tracking number has not been changed,
+        //then redirect details page without calling and updating DB!
+        if (shipment.TrackingNumber == model.TrackingNumber)
+            return RedirectToAction("ShipmentDetails", new { id = shipment.Id });
+
         shipment.TrackingNumber = model.TrackingNumber;
         await _shipmentService.UpdateShipmentAsync(shipment);
+
+        //publish an event to inform related consumers
+        await _eventPublisher.PublishAsync(new ShipmentTrackingNumberSetEvent(shipment));
 
         return RedirectToAction("ShipmentDetails", new { id = shipment.Id });
     }


### PR DESCRIPTION
Many times, we need to know that any tracking number has been set for a shipment; For example notify customer about that or give him/her this tracking number.
So I have added this event ad called it when creating new shipment (if has any) or when set tracking number (if new one added).
Many number of my customers need it and I decided to add it to the nopCommerce source code except in my custom projects.