### PR TITLE
Possibility to do not select 'ShippingMethod' to filter in 'ShippingByWeightByTotal' plugin

### DIFF
--- a/src/Plugins/Nop.Plugin.Shipping.FixedByWeightByTotal/Controllers/FixedByWeightByTotalController.cs
+++ b/src/Plugins/Nop.Plugin.Shipping.FixedByWeightByTotal/Controllers/FixedByWeightByTotalController.cs
@@ -109,6 +109,7 @@ public class FixedByWeightByTotalController : BasePluginController
         foreach (var sm in await _shippingService.GetAllShippingMethodsAsync())
             model.AvailableShippingMethods.Add(new SelectListItem { Text = sm.Name, Value = sm.Id.ToString() });
         //countries
+        model.AvailableShippingMethods.Add(new SelectListItem { Text = "*", Value = "0" });
         model.AvailableCountries.Add(new SelectListItem { Text = "*", Value = "0" });
         var countries = await _countryService.GetAllCountriesAsync();
         foreach (var c in countries)

--- a/src/Plugins/Nop.Plugin.Shipping.FixedByWeightByTotal/Controllers/FixedByWeightByTotalController.cs
+++ b/src/Plugins/Nop.Plugin.Shipping.FixedByWeightByTotal/Controllers/FixedByWeightByTotalController.cs
@@ -106,10 +106,10 @@ public class FixedByWeightByTotalController : BasePluginController
         foreach (var warehouses in await _shippingService.GetAllWarehousesAsync())
             model.AvailableWarehouses.Add(new SelectListItem { Text = warehouses.Name, Value = warehouses.Id.ToString() });
         //shipping methods
+        model.AvailableShippingMethods.Add(new SelectListItem { Text = "*", Value = "0" });
         foreach (var sm in await _shippingService.GetAllShippingMethodsAsync())
             model.AvailableShippingMethods.Add(new SelectListItem { Text = sm.Name, Value = sm.Id.ToString() });
         //countries
-        model.AvailableShippingMethods.Add(new SelectListItem { Text = "*", Value = "0" });
         model.AvailableCountries.Add(new SelectListItem { Text = "*", Value = "0" });
         var countries = await _countryService.GetAllCountriesAsync();
         foreach (var c in countries)

--- a/src/Plugins/Nop.Plugin.Shipping.FixedByWeightByTotal/Services/ShippingByWeightByTotalService.cs
+++ b/src/Plugins/Nop.Plugin.Shipping.FixedByWeightByTotal/Services/ShippingByWeightByTotalService.cs
@@ -63,7 +63,9 @@ public class ShippingByWeightByTotalService : IShippingByWeightByTotalService
                 : query;
 
             //filter by shipping method
-            data = data.Where(sbw => sbw.ShippingMethodId == shippingMethodId);
+            data = shippingMethodId <= 0
+                ? data
+                : data = data.Where(sbw => sbw.ShippingMethodId == shippingMethodId);
 
             //filter by store
             data = storeId == 0


### PR DESCRIPTION
Some times, it's need to filter shipping rates with all shipping methods, not only one.