### PR TITLE
Preserve inline edit field values on backend validation errors

### DIFF
--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/Table.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/Table.cshtml
@@ -270,6 +270,11 @@
             }
 
             function updateRowData_@(tableName)(currentCells, data, nameData) {
+                var origData = data;
+                var modData = data;
+                if (typeof data == 'string') {
+                    modData = data.replace(/[.*+?^${}()|[\]\\]/g, "_");
+                }
                 var updateRowData = [];
                 updateRowData.push({ 'pname': nameData, 'pvalue': data });
                 $.each(columnData_@(tableName), function (index, element) {
@@ -301,9 +306,15 @@
                         //display error if returned
                         if (data) {
                             display_nop_error(data);
+
+                            //show the buttons
+                             $('#buttonEdit_@(tableName)' + modData).hide();
+                             $('#buttonConfirm_@(tableName)' + modData).show();
+                             $('#buttonCancel_@(tableName)' + modData).show();
+                        } else {
+                             //refresh grid
+                             $('#@Model.Name').DataTable().draw(false);
                         }
-                        //refresh grid
-                         $('#@Model.Name').DataTable().draw(false);
                     },
                     error: function (jqXHR, textStatus, errorThrown) {
                         alert(errorThrown);


### PR DESCRIPTION
In the Admin area, added functionality to retain inline edit field values in the grid when backend validation errors occur during the update process. Previously, upon encountering validation errors, the grid would refresh, causing users to lose all entered field values. This enhancement ensures a smoother editing experience for administrators by maintaining their input even in error scenarios.

Changes Made:
=> Table.cshtml : - Added logic to show update and cancel buttons without grid refresh upon AJAX response in `updateRowData_` function

[12.05.2024 02_44.webm](https://github.com/nopSolutions/nopCommerce/assets/104594350/0c55bcba-a60e-44df-a5a0-d6691eca7f10)
