### PR TITLE
Refactor ConvertTo method in GenericListTypeConverter

### DIFF
--- a/src/Libraries/Nop.Core/ComponentModel/GenericListTypeConverter.cs
+++ b/src/Libraries/Nop.Core/ComponentModel/GenericListTypeConverter.cs
@@ -91,16 +91,11 @@ public partial class GenericListTypeConverter<T> : TypeConverter
         if (value == null)
             return result;
 
-        //we don't use string.Join() because it doesn't support invariant culture
-        for (var i = 0; i < ((IList<T>)value).Count; i++)
-        {
-            var str1 = Convert.ToString(((IList<T>)value)[i], CultureInfo.InvariantCulture);
-            result += str1;
-            //don't add comma after the last element
-            if (i != ((IList<T>)value).Count - 1)
-                result += ",";
-        }
-
+        var cultureInvariantStrings = ((IList<T>)value)
+            .Select(o => Convert.ToString(o, CultureInfo.InvariantCulture));
+        
+        result = string.Join(',', cultureInvariantStrings);
+        
         return result;
     }
 }

--- a/src/Tests/Nop.Tests/Nop.Core.Tests/ComponentModel/GenericListTypeConverterTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Core.Tests/ComponentModel/GenericListTypeConverterTests.cs
@@ -71,4 +71,13 @@ public class GenericListTypeConverter
         result.Should().NotBeNull();
         result.Should().Be("foo,bar,day");
     }
+    
+    [Test]
+    public void CanConvertNullToString()
+    {
+        var converter = TypeDescriptor.GetConverter(typeof(List<string>));
+        var result = converter.ConvertTo(null, typeof(string)) as string;
+        result.Should().NotBeNull();
+        result.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
This pull request introduces a refactoring to the GenericListTypeConverter.ConvertTo method (#7198). The primary changes involve:

Replacing the manual loop with a more concise approach using Select and string.Join. This optimizes performance and reduces the risk of errors related to manual concatenation.
Utilizing CultureInfo.InvariantCulture consistently to ensure culture-independent string conversion.
Implementing a unit test (CanConvertNullToString) to verify the converter's behavior when handling null input.
These improvements enhance the overall maintainability and readability of the code while ensuring expected behavior.