### PR TITLE
Refactor SplitCamelCaseWord method

### DIFF
--- a/src/Libraries/Nop.Core/CommonHelper.cs
+++ b/src/Libraries/Nop.Core/CommonHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Globalization;
 using System.Net;
+using System.Text;
 using System.Text.RegularExpressions;
 using Nop.Core.Infrastructure;
 
@@ -262,14 +263,21 @@ public partial class CommonHelper
         if (string.IsNullOrEmpty(str))
             return string.Empty;
 
-        var result = str.ToCharArray()
-            .Select(p => p.ToString())
-            .Aggregate(string.Empty, (current, c) => current + (c == c.ToUpperInvariant() ? $" {c}" : c));
+        var sb = new StringBuilder(str.Length);
+        var space = ' ';
 
-        //ensure no spaces (e.g. when the first letter is upper case)
-        result = result.TrimStart();
+        for (var i = 0; i < str.Length; i++)
+        {
+            if (char.IsWhiteSpace(str[i]))
+                continue;
 
-        return result;
+            if (char.IsUpper(str[i]) && sb.Length != 0)
+                sb.Append(space);
+
+            sb.Append(str[i]);
+        }
+
+        return sb.ToString();
     }
 
     /// <summary>


### PR DESCRIPTION
```

BenchmarkDotNet v0.14.0, Windows 11 (10.0.22631.3007/23H2/2023Update/SunValley3)
Unknown processor
.NET SDK 8.0.303
  [Host]     : .NET 8.0.7 (8.0.724.31311), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.7 (8.0.724.31311), X64 RyuJIT AVX2


```
| Method | StringToSplit        | Mean       | Error     | StdDev    | Gen0     | Gen1   | Allocated  |
|------- |--------------------- |-----------:|----------:|----------:|---------:|-------:|-----------:|
| New    | This(...)Case [1785] |   4.076 μs | 0.0279 μs | 0.0261 μs |   0.7095 | 0.0153 |   11.66 KB |
| Old    | This(...)Case [1785] | 154.659 μs | 1.4227 μs | 1.3973 μs | 255.1270 | 5.8594 | 4170.13 KB |
