### PR TITLE
Fix CI tests due to concurrency problems

### DIFF
--- a/src/Tests/Nop.Tests/AssemblyInfo.cs
+++ b/src/Tests/Nop.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using NUnit.Framework;
+
+[assembly: LevelOfParallelism(1)]


### PR DESCRIPTION
When running tests within a GitHub Action runner, tests intermittently fail with `ObjectDisposedException` within the database provider.  This appears to be a concurrency-related problem.  Configuring NUnit to only run a single test at a time fixes the problem.