### PR TITLE
Fix topic index issue

### DIFF
--- a/src/Libraries/Nop.Data/Mapping/Builders/Topics/TopicTemplateBuilder.cs
+++ b/src/Libraries/Nop.Data/Mapping/Builders/Topics/TopicTemplateBuilder.cs
@@ -18,7 +18,8 @@ public partial class TopicTemplateBuilder : NopEntityBuilder<TopicTemplate>
     {
         table
             .WithColumn(nameof(TopicTemplate.Name)).AsString(400).NotNullable()
-            .WithColumn(nameof(TopicTemplate.ViewPath)).AsString(400).NotNullable();
+            .WithColumn(nameof(TopicTemplate.ViewPath)).AsString(400).NotNullable()
+            .WithColumn(nameof(TopicTemplate.SystemName)).AsString(400).NotNullable();
     }
 
     #endregion

--- a/src/Libraries/Nop.Data/Migrations/Installation/Indexes.cs
+++ b/src/Libraries/Nop.Data/Migrations/Installation/Indexes.cs
@@ -12,6 +12,7 @@ using Nop.Core.Domain.Orders;
 using Nop.Core.Domain.Security;
 using Nop.Core.Domain.Seo;
 using Nop.Core.Domain.Stores;
+using Nop.Core.Domain.Topics;
 using Nop.Data.Mapping;
 
 namespace Nop.Data.Migrations.Installation;
@@ -305,6 +306,11 @@ public class Indexes : ForwardOnlyMigration
         Create.Index("IX_Customer_Deleted")
             .OnTable(nameof(Customer))
             .OnColumn(nameof(Customer.Deleted)).Ascending()
+            .WithOptions().NonClustered();
+
+        Create.Index("IX_Topic_SystemName")
+            .OnTable(nameof(Topic))
+            .OnColumn(nameof(Topic.SystemName)).Ascending()
             .WithOptions().NonClustered();
     }
 

--- a/src/Libraries/Nop.Data/Migrations/Installation/SchemaMigration.cs
+++ b/src/Libraries/Nop.Data/Migrations/Installation/SchemaMigration.cs
@@ -165,5 +165,9 @@ public class SchemaMigration : ForwardOnlyMigration
         Create.TableFor<VendorAttribute>();
         Create.TableFor<VendorAttributeValue>();
         Create.TableFor<VendorNote>();
+
+        // Alter Topic.SystemName column to nvarchar(400)
+        Alter.Table(nameof(Topic))
+            .AlterColumn(nameof(Topic.SystemName)).AsString(400).NotNullable();
     }
 }


### PR DESCRIPTION
Fixes #7294

Update `TopicTemplateBuilder.cs`, `Indexes.cs`, and `SchemaMigration.cs` to add an index on `Topic.SystemName` by changing its type to `nvarchar(400)`.

* **TopicTemplateBuilder.cs**
  - Add `SystemName` column definition with `nvarchar(400)` in `MapEntity` method.

* **Indexes.cs**
  - Add index creation for `Topic.SystemName` in `Up` method.

* **SchemaMigration.cs**
  - Alter `SystemName` column to `nvarchar(400)` in `Up` method.

