### PR TITLE
Add support for vendor reviews

### DIFF
--- a/src/Libraries/Nop.Core/Domain/Vendors/Vendor.cs
+++ b/src/Libraries/Nop.Core/Domain/Vendors/Vendor.cs
@@ -1,6 +1,8 @@
 ﻿using Nop.Core.Domain.Common;
 using Nop.Core.Domain.Localization;
 using Nop.Core.Domain.Seo;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Nop.Core.Domain.Vendors;
 
@@ -103,4 +105,21 @@ public partial class Vendor : BaseEntity, ILocalizedEntity, ISlugSupported, ISof
     /// Gets or sets a value indicating whether the price range should be entered manually
     /// </summary>
     public bool ManuallyPriceRange { get; set; }
+
+    /// <summary>
+    /// Gets or sets the list of vendor reviews
+    /// </summary>
+    public virtual ICollection<VendorReview> VendorReviews { get; set; } = new List<VendorReview>();
+
+    /// <summary>
+    /// Calculates the average rating from the vendor reviews
+    /// </summary>
+    /// <returns>The average rating</returns>
+    public double CalculateAverageRating()
+    {
+        if (VendorReviews == null || !VendorReviews.Any())
+            return 0;
+
+        return VendorReviews.Average(r => r.Rating);
+    }
 }

--- a/src/Libraries/Nop.Core/Domain/Vendors/VendorReview.cs
+++ b/src/Libraries/Nop.Core/Domain/Vendors/VendorReview.cs
@@ -1,0 +1,37 @@
+namespace Nop.Core.Domain.Vendors;
+
+/// <summary>
+/// Represents a vendor review
+/// </summary>
+public partial class VendorReview : BaseEntity
+{
+    /// <summary>
+    /// Gets or sets the vendor identifier
+    /// </summary>
+    public int VendorId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the customer identifier
+    /// </summary>
+    public int CustomerId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the rating
+    /// </summary>
+    public int Rating { get; set; }
+
+    /// <summary>
+    /// Gets or sets the review text
+    /// </summary>
+    public string ReviewText { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the content is approved
+    /// </summary>
+    public bool IsApproved { get; set; }
+
+    /// <summary>
+    /// Gets or sets the date and time of instance creation
+    /// </summary>
+    public DateTime CreatedOnUtc { get; set; }
+}

--- a/src/Libraries/Nop.Services/Catalog/Caching/VendorReviewCacheEventConsumer.cs
+++ b/src/Libraries/Nop.Services/Catalog/Caching/VendorReviewCacheEventConsumer.cs
@@ -1,0 +1,11 @@
+using Nop.Core.Domain.Vendors;
+using Nop.Services.Caching;
+
+namespace Nop.Services.Catalog.Caching;
+
+/// <summary>
+/// Represents a vendor review cache event consumer
+/// </summary>
+public partial class VendorReviewCacheEventConsumer : CacheEventConsumer<VendorReview>
+{
+}


### PR DESCRIPTION
Fixes #7244

Add support for vendor reviews, both written about a vendor and aggregated from product reviews.

* **VendorReview Class**: Add `VendorReview` class in `src/Libraries/Nop.Core/Domain/Vendors/VendorReview.cs` to handle vendor reviews with properties for `VendorId`, `CustomerId`, `Rating`, `ReviewText`, `IsApproved`, and `CreatedOnUtc`.
* **Vendor Class**: Update `Vendor` class in `src/Libraries/Nop.Core/Domain/Vendors/Vendor.cs` to include a list of `VendorReview` and a method to calculate the average rating from the reviews.
* **VendorController**: Update `VendorController` in `src/Presentation/Nop.Web/Areas/Admin/Controllers/VendorController.cs` to handle vendor reviews.
  - Add actions to handle vendor reviews, such as `VendorReviewsSelect`, `VendorReviewAdd`, and `VendorReviewDelete`.
  - Update the `Edit` action to include vendor reviews in the model.
* **Caching**: Add `VendorReviewCacheEventConsumer` class in `src/Libraries/Nop.Services/Catalog/Caching/VendorReviewCacheEventConsumer.cs` to handle caching for vendor reviews.

