### PR TITLE
When NumberOfProductTags is set 0, don't show popular tags widget on …

### DIFF
--- a/src/Presentation/Nop.Web/Components/PopularProductTagsViewComponent.cs
+++ b/src/Presentation/Nop.Web/Components/PopularProductTagsViewComponent.cs
@@ -18,7 +18,7 @@ public partial class PopularProductTagsViewComponent : NopViewComponent
 
     public async Task<IViewComponentResult> InvokeAsync()
     {
-        if (_catalogSettings.NumberOfProductTags < 1)
+        if (_catalogSettings.NumberOfProductTags == 0)
             return Content("");
 
         var model = await _catalogModelFactory.PreparePopularProductTagsModelAsync(_catalogSettings.NumberOfProductTags);

--- a/src/Presentation/Nop.Web/Components/PopularProductTagsViewComponent.cs
+++ b/src/Presentation/Nop.Web/Components/PopularProductTagsViewComponent.cs
@@ -18,8 +18,10 @@ public partial class PopularProductTagsViewComponent : NopViewComponent
 
     public async Task<IViewComponentResult> InvokeAsync()
     {
-        var model = await _catalogModelFactory.PreparePopularProductTagsModelAsync(_catalogSettings.NumberOfProductTags);
+        if (_catalogSettings.NumberOfProductTags < 1)
+            return Content("");
 
+        var model = await _catalogModelFactory.PreparePopularProductTagsModelAsync(_catalogSettings.NumberOfProductTags);
         if (!model.Tags.Any())
             return Content("");
 


### PR DESCRIPTION
…catalog pages.

Used same logic as in ManufacturerNavigationViewComponent. NumberOfProductTags property is only used in PopularProductTagsViewComponent, so no sideeffects elsewhere when set to 0 to hide it.