### PR TITLE
Changed the CreateDataConnection signature to allow Transactions with Rollback and Commit options

### DIFF
--- a/src/Libraries/Nop.Data/DataProviders/BaseDataProvider.cs
+++ b/src/Libraries/Nop.Data/DataProviders/BaseDataProvider.cs
@@ -27,7 +27,7 @@ public abstract partial class BaseDataProvider
     /// <summary>
     /// Creates the database connection
     /// </summary>
-    protected virtual DataConnection CreateDataConnection()
+    public virtual DataConnection CreateDataConnection()
     {
         return CreateDataConnection(LinqToDbDataProvider);
     }
@@ -37,7 +37,7 @@ public abstract partial class BaseDataProvider
     /// </summary>
     /// <param name="dataProvider">Data provider</param>
     /// <returns>Database connection</returns>
-    protected virtual DataConnection CreateDataConnection(IDataProvider dataProvider)
+    public virtual DataConnection CreateDataConnection(IDataProvider dataProvider)
     {
         ArgumentNullException.ThrowIfNull(dataProvider);
 

--- a/src/Libraries/Nop.Data/DataProviders/MySqlDataProvider.cs
+++ b/src/Libraries/Nop.Data/DataProviders/MySqlDataProvider.cs
@@ -26,7 +26,7 @@ public partial class MySqlNopDataProvider : BaseDataProvider, INopDataProvider
     /// <summary>
     /// Creates the database connection
     /// </summary>
-    protected override DataConnection CreateDataConnection()
+    public override DataConnection CreateDataConnection()
     {
         var dataContext = CreateDataConnection(LinqToDbDataProvider);
 

--- a/src/Libraries/Nop.Data/DataProviders/PostgreSqlDataProvider.cs
+++ b/src/Libraries/Nop.Data/DataProviders/PostgreSqlDataProvider.cs
@@ -25,7 +25,7 @@ public partial class PostgreSqlDataProvider : BaseDataProvider, INopDataProvider
     /// <summary>
     /// Creates the database connection by the current data configuration
     /// </summary>
-    protected override DataConnection CreateDataConnection()
+    public override DataConnection CreateDataConnection()
     {
         var dataContext = CreateDataConnection(LinqToDbDataProvider);
         dataContext.MappingSchema.SetDataType(

--- a/src/Libraries/Nop.Data/INopDataProvider.cs
+++ b/src/Libraries/Nop.Data/INopDataProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq.Expressions;
 using LinqToDB.Data;
 using Nop.Core;
+using static LinqToDB.Common.Configuration;
 
 namespace Nop.Data;
 
@@ -10,6 +11,11 @@ namespace Nop.Data;
 public partial interface INopDataProvider
 {
     #region Methods
+
+    /// <summary>
+    //// Returns a DataConnection object that supports transactions that include commit and rollback operations.
+    /// </summary>
+    DataConnection CreateDataConnection();
 
     /// <summary>
     /// Create the database


### PR DESCRIPTION
Hello,

In this PR, I have changed the CreateDataConnection signature on the BaseDataProvider class and added the function signature to the INopDataProvider interface to make it accessible from the project.


### Why?

Because while adding the orders and order items relevant to them, I needed to have a transaction block to rollback the changes when any exception occurred. I couldn't find any solution to that, so I have exposed the protected method as public to create a DataConnection object through the DataProvider and used it explicitly to create transactions and allow multiple operations to share the same DataConnection object.

Here, you can an example to my case:

```cs
 public class MyService : IMyService
 {
     private readonly INopDataProvider _nopDataProvider;
     private readonly IShoppingCartItemApiService _shoppingCartItemApiService;
     private readonly IDTOHelper _dtoHelper;

     public MyService(INopDataProvider nopDataProvider,
         IShoppingCartItemApiService shoppingCartItemApiService,
         IDTOHelper dtoHelper)
     {
         _nopDataProvider = nopDataProvider;
         _shoppingCartItemApiService = shoppingCartItemApiService;
         _dtoHelper = dtoHelper;
     }

     public async Task CreateOrder(int customerId)
     {
         // If you want to read data from the database, you can use the following code via using the _nopDataProvider object.
         var user = await _nopDataProvider.GetTable<Customer>().SingleOrDefaultAsync(_ => _.Id == customerId) ?? throw new ArgumentException("User not found");

         //Prepare data START
         var shoppingCartItemsToBePurchased = await _shoppingCartItemApiService.GetShoppingCartItemsV2(customerId);

         var shoppingCartItemsDtos = await shoppingCartItemsToBePurchased
                                     .SelectAwait(async shoppingCartItem => await _dtoHelper.PrepareShoppingCartItemDTOAsyncV2(shoppingCartItem))
                                     .ToListAsync();

         var order = new Order
         {
             CustomerId = customerId,
             BillingAddressId = 1,
             ShippingAddressId = 1,
             OrderGuid = Guid.NewGuid(),
             ShippingStatus = "not_shipped",
             PaymentStatus = "pending",
             OrderTotal = 10000
         };

         var orderItems = shoppingCartItemsDtos.Select(sci => new OrderItem
         {
             OrderItemGuid = Guid.NewGuid(),
             ProductId = sci.ProductId.Value,
             Quantity = sci.Quantity.Value,
             PriceInclTax = sci.Price,
             UnitPriceInclTax = sci.ProductDto.Price
         }).ToList();
         //Prepare data END

         // Create the DataConnection object via using same data provider
         var dataConnectionObject = _nopDataProvider.CreateDataConnection();

         // Create transaction from the data connection object. You may choose any isolation level as per your requirement
         using var transaction = await dataConnectionObject.BeginTransactionAsync(IsolationLevel.ReadCommitted);

         try
         {
             // Perform the insert operations
             var orderId = await dataConnectionObject.InsertWithInt32IdentityAsync(order);
             orderItems.ForEach(each => each.OrderId = orderId);
             await dataConnectionObject.BulkCopyAsync(orderItems);

             // Commit the transaction
             await transaction.CommitAsync();
         }
         catch (Exception)
         {
             // Rollback the transaction if any exception occurs
             await transaction.RollbackAsync();
             throw;
         }
     }
 }
```

With this way, developers may be able to create DataConnection objects and make them shareable through the domain entities to allow transactions. The code is tested and works as expected.