### PR TITLE
Isssue#7339- (SOLVED) FooterModel.IsHomePage always returns false if SeoFriendlyUrlsForLanguagesEnabled

### DIFF
--- a/src/Presentation/Nop.Web/Factories/CommonModelFactory.cs
+++ b/src/Presentation/Nop.Web/Factories/CommonModelFactory.cs
@@ -466,7 +466,7 @@ public partial class CommonModelFactory : ICommonModelFactory
             NewProductsEnabled = _catalogSettings.NewProductsEnabled,
             DisplayTaxShippingInfoFooter = _catalogSettings.DisplayTaxShippingInfoFooter,
             HidePoweredByNopCommerce = _storeInformationSettings.HidePoweredByNopCommerce,
-            IsHomePage = _webHelper.GetStoreLocation().Equals(_webHelper.GetThisPageUrl(false), StringComparison.InvariantCultureIgnoreCase),
+            IsHomePage = _webHelper.GetThisPageUrl(false).StartsWith(_webHelper.GetStoreLocation(), StringComparison.InvariantCultureIgnoreCase),
             AllowCustomersToApplyForVendorAccount = _vendorSettings.AllowCustomersToApplyForVendorAccount,
             AllowCustomersToCheckGiftCardBalance = _customerSettings.AllowCustomersToCheckGiftCardBalance && _captchaSettings.Enabled,
             Topics = topicModels,


### PR DESCRIPTION
Issue#7339
Earlier Equals method was used which definitely cannot return true if the urls are different. Instead of Equals I have used StartsWith method and swap the place of _webHelper.GetThisPageUrl(false) and _webHelper.GetStoreLocation()