### PR TITLE
Improved ViewLocationExpander in OmniSend plugin to prevent conflicts…

### DIFF
--- a/src/Plugins/Nop.Plugin.Misc.Omnisend/Infrastructure/ViewLocationExpander.cs
+++ b/src/Plugins/Nop.Plugin.Misc.Omnisend/Infrastructure/ViewLocationExpander.cs
@@ -28,8 +28,11 @@ public class ViewLocationExpander : IViewLocationExpander
     public IEnumerable<string> ExpandViewLocations(ViewLocationExpanderContext context,
         IEnumerable<string> viewLocations)
     {
-        viewLocations = new[] { $"/Plugins/Misc.Omnisend/Views/{context.ViewName}.cshtml" }
-            .Concat(viewLocations);
+        viewLocations = new[]
+        {
+            $"/Plugins/Misc.Omnisend/Views/{{1}}/{{0}}.cshtml",
+            $"/Plugins/Misc.Omnisend/Views/Shared/{{0}}.cshtml",
+        }.Concat(viewLocations);
 
         return viewLocations;
     }


### PR DESCRIPTION
Title: Resolve conflicts in ViewLocationExpander by improving view location structure

Description: This change addresses a critical issue in the OmniSend plugin's ViewLocationExpander, where its fixed view path caused conflicts with other plugins that define their own ViewLocationExpander.

Key Updates:
Expanded view locations to support:
Controller-based views: /Plugins/Misc.Omnisend/Views/{Controller}/{View}.cshtml
Shared views: /Plugins/Misc.Omnisend/Views/Shared/{View}.cshtml
Improved compatibility with other plugins by avoiding hardcoded view paths.
Introduced flexibility to support more organized and scalable view structures.
This enhancement ensures that OmniSend's view expander works harmoniously with other plugins, reduces potential conflicts, and adheres to common patterns in the NopCommerce ecosystem.