### PR TITLE
Sendinblue/Brevo Marketing Automation error

### DIFF
--- a/src/Plugins/Nop.Plugin.Misc.Brevo/Services/MarketingAutomationManager.cs
+++ b/src/Plugins/Nop.Plugin.Misc.Brevo/Services/MarketingAutomationManager.cs
@@ -355,7 +355,7 @@ public class MarketingAutomationManager
             //create track event object
             var trackEvent = new TrackEventRequest
             {
-                Email = customer.Email,
+                Email = customer.Email ?? billingAddress.Email,
                 EventName = BrevoDefaults.OrderCompletedEventName,
                 EventData = new { id = $"cart:{shoppingCartGuid}", data = cartData }
             };

--- a/src/Plugins/Nop.Plugin.Misc.Brevo/Services/MarketingAutomationManager.cs
+++ b/src/Plugins/Nop.Plugin.Misc.Brevo/Services/MarketingAutomationManager.cs
@@ -252,11 +252,13 @@ public class MarketingAutomationManager
         ArgumentNullException.ThrowIfNull(order);
 
         var customer = await _customerService.GetCustomerByIdAsync(order.CustomerId);
+        var shippingAddress = await _addressService.GetAddressByIdAsync(order.ShippingAddressId ?? 0);
+        var billingAddress = await _addressService.GetAddressByIdAsync(order.BillingAddressId);
 
         try
         {
             //first, try to identify current customer
-            await _marketingAutomationHttpClient.RequestAsync(new IdentifyRequest { Email = customer.Email });
+            await _marketingAutomationHttpClient.RequestAsync(new IdentifyRequest { Email = customer.Email ?? billingAddress.Email });
 
             //get URL helper
             var urlHelper = _urlHelperFactory.GetUrlHelper(_actionContextAccessor.ActionContext);
@@ -295,9 +297,6 @@ public class MarketingAutomationManager
                     price = item.PriceInclTax,
                 };
             }).ToArrayAsync();
-
-            var shippingAddress = await _addressService.GetAddressByIdAsync(order.ShippingAddressId ?? 0);
-            var billingAddress = await _addressService.GetAddressByIdAsync(order.BillingAddressId);
 
             var shippingAddressData = new
             {


### PR DESCRIPTION
Hello,

When we enabled guest checkout and start using sendinblue or brevo then we start getting exception in logs with error message "Marketing Automation error". This exception raised because email is empty in customer table when user have role "guest" & not email registered in system.
To handle guest customers exception we can take email from billing address in OrderCompleted event when customer's email is empty.
Please apply solution in next version if you approve PR