### PR TITLE
Update PictureService.cs - NullReferenceException remedy

### DIFF
--- a/src/Libraries/Nop.Services/Media/PictureService.cs
+++ b/src/Libraries/Nop.Services/Media/PictureService.cs
@@ -173,7 +173,7 @@ public partial class PictureService : IPictureService
     /// </returns>
     protected virtual Task<string> GetImagesPathUrlAsync(string storeLocation = null)
     {
-        var pathBase = _httpContextAccessor.HttpContext.Request?.PathBase.Value ?? string.Empty;
+        var pathBase = _httpContextAccessor.HttpContext?.Request?.PathBase.Value ?? string.Empty;
         var imagesPathUrl = _mediaSettings.UseAbsoluteImagePath ? storeLocation : $"{pathBase}/";
         imagesPathUrl = string.IsNullOrEmpty(imagesPathUrl) ? _webHelper.GetStoreLocation() : imagesPathUrl;
         imagesPathUrl += "images/";


### PR DESCRIPTION
This is an edge case - my plugin generates invoices in a background task, in which the HttpContext is null, which produces `System.NullReferenceException: Object reference not set to an instance of an object.` 
`HttpContext` should have a null check just like `Request` does and this should not have any negative side effects, since null is just converted to `string.Empty` anyway.