### PR TITLE
In ValidatePictureAsync I added condition to check if image is not nu…

### DIFF
--- a/src/Libraries/Nop.Services/Media/PictureService.cs
+++ b/src/Libraries/Nop.Services/Media/PictureService.cs
@@ -1065,7 +1065,16 @@ public partial class PictureService : IPictureService
     {
         try
         {
-            using var image = SKBitmap.Decode(pictureBinary);
+            
+
+            if (image == null)
+                throw new ArgumentNullException(nameof(image), "Decoded image is null");
+            if (fileName.EndsWith(".jpeg", StringComparison.OrdinalIgnoreCase))
+        {
+            fileName = fileName.Substring(0, fileName.Length - 5) + ".jpg";
+        }
+        
+        using var image = SKBitmap.Decode(pictureBinary);
 
             //resize the image in accordance with the maximum size
             if (Math.Max(image.Height, image.Width) > _mediaSettings.MaximumImageSize)


### PR DESCRIPTION
…ll if it is not null then it convert the jpeg file to jpg file SKBitmap.Decode method might not recognize the file format due to incorrect MIME type or corrupted image data.
fixes : #7471 
![image](https://github.com/user-attachments/assets/752f0b45-01c3-47b5-b0d4-e0bf69f2e511)
