### PR TITLE
Removed unnecessary repository call in settings service | null checks added in zettle plugin settings migration

### DIFF
--- a/src/Libraries/Nop.Services/Configuration/SettingService.cs
+++ b/src/Libraries/Nop.Services/Configuration/SettingService.cs
@@ -344,7 +344,7 @@ public partial class SettingService : ISettingService
         if (setting == null && storeId > 0 && loadSharedValueIfNotFound)
             setting = settingsByKey.FirstOrDefault(x => x.StoreId == 0);
 
-        return setting != null ? await GetSettingByIdAsync(setting.Id) : null;
+        return setting;
     }
 
     /// <summary>

--- a/src/Libraries/Nop.Services/Configuration/SettingService.cs
+++ b/src/Libraries/Nop.Services/Configuration/SettingService.cs
@@ -373,7 +373,7 @@ public partial class SettingService : ISettingService
         if (setting == null && storeId > 0 && loadSharedValueIfNotFound)
             setting = settingsByKey.FirstOrDefault(x => x.StoreId == 0);
 
-        return setting != null ? GetSettingById(setting.Id) : null;
+        return setting;
     }
 
     /// <summary>

--- a/src/Plugins/Nop.Plugin.Misc.Zettle/Data/InventoryBalanceMigration.cs
+++ b/src/Plugins/Nop.Plugin.Misc.Zettle/Data/InventoryBalanceMigration.cs
@@ -40,7 +40,8 @@ public class InventoryBalanceMigration : MigrationBase
 
         //delete settings
         var setting = await _settingService.GetSettingAsync($"{nameof(ZettleSettings)}.InventoryTrackingIds");
-        await _settingService.DeleteSettingAsync(setting);
+        if(setting is not null)
+            await _settingService.DeleteSettingAsync(setting);
     }
 
     /// <summary>


### PR DESCRIPTION
Optimized the SettingsService by removing a redundant repository call. Added null checks in the Zettle plugin settings migration to prevent potential issues during deletion.