### PR TITLE
Use ToListAsync for async query execution

### DIFF
--- a/src/Libraries/Nop.Services/Catalog/ManufacturerService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ManufacturerService.cs
@@ -418,7 +418,7 @@ public partial class ManufacturerService : IManufacturerService
             query = query.Where(pm => manufacturersQuery.Any(m => m.Id == pm.ManufacturerId));
         }
 
-        return await _staticCacheManager.GetAsync(key, query.ToList);
+        return await _staticCacheManager.GetAsync(key, query.ToListAsync);
     }
 
     /// <summary>

--- a/src/Libraries/Nop.Services/Catalog/ManufacturerService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ManufacturerService.cs
@@ -418,7 +418,7 @@ public partial class ManufacturerService : IManufacturerService
             query = query.Where(pm => manufacturersQuery.Any(m => m.Id == pm.ManufacturerId));
         }
 
-        return await _staticCacheManager.GetAsync(key, query.ToListAsync);
+        return await _staticCacheManager.GetAsync(key, async () => await query.ToListAsync());
     }
 
     /// <summary>


### PR DESCRIPTION
Replaced the synchronous `ToList()` method with `ToListAsync()` in the GetProductManufacturersByProductIdAsync method within ManufacturerService