### PR TITLE
#7520 fixed problem of 'Search paging doesn't work'

### DIFF
--- a/src/Presentation/Nop.Web/Factories/CatalogModelFactory.cs
+++ b/src/Presentation/Nop.Web/Factories/CatalogModelFactory.cs
@@ -1813,7 +1813,16 @@ public partial class CatalogModelFactory : ICatalogModelFactory
         IPagedList<Product> products = new PagedList<Product>(new List<Product>(), 0, 1);
         //only search if query string search keyword is set (used to avoid searching or displaying search term min length error message on /search page load)
         //we don't use "!string.IsNullOrEmpty(searchTerms)" in cases of "ProductSearchTermMinimumLength" set to 0 but searching by other parameters (e.g. category or price filter)
-        var isSearchTermSpecified = _httpContextAccessor.HttpContext.Request.Query.ContainsKey("q");
+        var request = _httpContextAccessor.HttpContext.Request;
+
+        bool isSearchTermSpecified = false;
+        if (request.Method == HttpMethod.Post.Method)
+
+            isSearchTermSpecified = request.Form.ContainsKey("q");
+
+        else if (request.Method == HttpMethod.Get.Method)
+            isSearchTermSpecified = request.Query.ContainsKey("q");
+
         if (isSearchTermSpecified)
         {
             var currentStore = await _storeContext.GetCurrentStoreAsync();


### PR DESCRIPTION
fixing #7520 problem , where any change in the page size results no products appear , and this is because we were sending post request and the data in the post request be in the body so here 
`        var isSearchTermSpecified = _httpContextAccessor.HttpContext.Request.Query.ContainsKey("q");
`
we try to get the search key from the query and this is not valid with post request so we must check first whether request method was post or get 
and if it was post then we must search from the `q` in the form not query like this 
`var request = _httpContextAccessor.HttpContext.Request;

        bool isSearchTermSpecified = false;
        if (request.Method == HttpMethod.Post.Method)

            isSearchTermSpecified = request.Form.ContainsKey("q");

        else if (request.Method == HttpMethod.Get.Method)
            isSearchTermSpecified = request.Query.ContainsKey("q");
`
