### PR TITLE
Use async KeyDeleteAsync in RedisCacheManager.RemoveByPrefixAsync

### DIFF
--- a/src/Libraries/Nop.Services/Caching/RedisCacheManager.cs
+++ b/src/Libraries/Nop.Services/Caching/RedisCacheManager.cs
@@ -67,7 +67,7 @@ public partial class RedisCacheManager : DistributedCacheManager
         foreach (var endPoint in await _connectionWrapper.GetEndPointsAsync())
         {
             var keys = await GetKeysAsync(endPoint, instanceName + prefix);
-            db.KeyDelete(keys.ToArray());
+            await db.KeyDeleteAsync(keys.ToArray());
         }
 
         RemoveByPrefixInstanceData(prefix);


### PR DESCRIPTION
Refactored the `RemoveByPrefixAsync` method in `RedisCacheManager` to use `await db.KeyDeleteAsync(keys.ToArray());`, leveraging _StackExchange.Redis_'s async API for non-blocking execution.