### PR TITLE
Refactor to use ToDictionaryAsync for async execution

### DIFF
--- a/src/Libraries/Nop.Services/Localization/LocalizationService.cs
+++ b/src/Libraries/Nop.Services/Localization/LocalizationService.cs
@@ -503,11 +503,8 @@ public partial class LocalizationService : ILocalizationService
         if (xmlStreamReader.EndOfStream)
             return;
 
-        var lsNamesList = new Dictionary<string, LocaleStringResource>();
-
-        foreach (var localeStringResource in _lsrRepository.Table.Where(lsr => lsr.LanguageId == language.Id)
-                     .OrderBy(lsr => lsr.Id))
-            lsNamesList[localeStringResource.ResourceName.ToLowerInvariant()] = localeStringResource;
+        var lsNamesList = await _lsrRepository.Table.Where(lsr => lsr.LanguageId == language.Id)
+                     .ToDictionaryAsync(lsr => lsr.ResourceName.ToLowerInvariant(), lsr => lsr);
 
         var lrsToUpdateList = new List<LocaleStringResource>();
         var lrsToInsertList = new Dictionary<string, LocaleStringResource>();

--- a/src/Libraries/Nop.Services/Localization/LocalizationService.cs
+++ b/src/Libraries/Nop.Services/Localization/LocalizationService.cs
@@ -503,8 +503,16 @@ public partial class LocalizationService : ILocalizationService
         if (xmlStreamReader.EndOfStream)
             return;
 
-        var lsNamesList = await _lsrRepository.Table.Where(lsr => lsr.LanguageId == language.Id)
-                     .ToDictionaryAsync(lsr => lsr.ResourceName.ToLowerInvariant(), lsr => lsr);
+        var lsNamesList = new Dictionary<string, LocaleStringResource>();
+        var locales = await _lsrRepository.Table
+            .Where(lsr => lsr.LanguageId == language.Id)
+            .OrderBy(lsr => lsr.Id)
+            .ToListAsync();
+
+        foreach (var localeStringResource in locales)
+        {
+            lsNamesList[localeStringResource.ResourceName.ToLowerInvariant()] = localeStringResource;
+        }
 
         var lrsToUpdateList = new List<LocaleStringResource>();
         var lrsToInsertList = new Dictionary<string, LocaleStringResource>();


### PR DESCRIPTION
Refactored the `ImportResourcesFromXmlAsync` method in `LocalizationService` to use `ToDictionaryAsync` for efficient async query execution and dictionary creation. Removed unnecessary sorting