### PR TITLE
Optimize GetAssociatedProductsAsync to Apply ACL & Store Mapping at Query Level

### DIFF
--- a/src/Libraries/Nop.Services/Catalog/ProductAttributeService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ProductAttributeService.cs
@@ -377,11 +377,7 @@ public partial class ProductAttributeService : IProductAttributeService
     /// <returns>A ProductAttributeValuePicture that has the specified values; otherwise null</returns>
     public virtual ProductAttributeValuePicture FindProductAttributeValuePicture(IList<ProductAttributeValuePicture> source, int valueId, int pictureId)
     {
-        foreach (var valuePicture in source)
-            if (valuePicture.ProductAttributeValueId == valueId && valuePicture.PictureId == pictureId)
-                return valuePicture;
-
-        return null;
+        return source.FirstOrDefault(vp => vp.ProductAttributeValueId == valueId && vp.PictureId == pictureId);
     }
 
     #endregion


### PR DESCRIPTION
This PR optimizes the `GetAssociatedProductsAsync` method in `ProductService` by moving ACL and store mapping constraints to the query level. Previously, these filters were applied after fetching data, causing unnecessary in-memory filtering. The change improves performance by reducing the number of records retrieved from the database.

Additionally I changed `FindProductAttributeValuePicture` method in `ProductAttributeService` just to make it more readable like others similar functionalities. 