### PR TITLE
Optimize Message Template Query by Applying Store Mapping at Database Level

### DIFF
--- a/src/Libraries/Nop.Services/Messages/MessageTemplateService.cs
+++ b/src/Libraries/Nop.Services/Messages/MessageTemplateService.cs
@@ -106,16 +106,16 @@ public partial class MessageTemplateService : IMessageTemplateService
         return await _staticCacheManager.GetAsync(key, async () =>
         {
             //get message templates with the passed name
-            var templates = await _messageTemplateRepository.Table
-                .Where(messageTemplate => messageTemplate.Name.Equals(messageTemplateName))
-                .OrderBy(messageTemplate => messageTemplate.Id)
-                .ToListAsync();
+            var templatesQuery = _messageTemplateRepository.Table
+                .Where(messageTemplate => messageTemplate.Name.Equals(messageTemplateName));
 
-            //filter by the store
             if (storeId.HasValue && storeId.Value > 0)
-                templates = await templates.WhereAwait(async messageTemplate => await _storeMappingService.AuthorizeAsync(messageTemplate, storeId.Value)).ToListAsync();
+            {
+                templatesQuery = await _storeMappingService.ApplyStoreMapping(templatesQuery, storeId.Value);
+            }
 
-            return templates;
+            return await templatesQuery.OrderBy(messageTemplate => messageTemplate.Id)
+            .ToListAsync();
         });
     }
 


### PR DESCRIPTION
Moved store mapping filtering to the query level to improve performance and reduce in-memory filtering when retrieving message templates