### PR TITLE
Allowing search by 'Specification attribute name' in specification attributes page (Admin area)

### DIFF
--- a/src/Libraries/Nop.Services/Catalog/ISpecificationAttributeService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ISpecificationAttributeService.cs
@@ -25,13 +25,12 @@ public partial interface ISpecificationAttributeService
     /// </summary>
     /// <param name="pageIndex">Page index</param>
     /// <param name="pageSize">Page size</param>
-    /// <param name="gName">group name</param>
-    /// <param name="sName">specification attribute name name</param>
+    /// <param name="specificationName">specification attribute name name</param>
     /// <returns>
     /// A task that represents the asynchronous operation
     /// The task result contains the specification attribute groups
     /// </returns>
-    Task<IPagedList<SpecificationAttributeGroup>> GetSpecificationAttributeGroupsAsync(int pageIndex = 0, int pageSize = int.MaxValue, string gName = "", string sName = "");
+    Task<IPagedList<SpecificationAttributeGroup>> GetSpecificationAttributeGroupsAsync(int pageIndex = 0, int pageSize = int.MaxValue, string specificationName = "");
 
     /// <summary>
     /// Gets product specification attribute groups

--- a/src/Libraries/Nop.Services/Catalog/ISpecificationAttributeService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ISpecificationAttributeService.cs
@@ -25,11 +25,13 @@ public partial interface ISpecificationAttributeService
     /// </summary>
     /// <param name="pageIndex">Page index</param>
     /// <param name="pageSize">Page size</param>
+    /// <param name="gName">group name</param>
+    /// <param name="sName">specification attribute name name</param>
     /// <returns>
     /// A task that represents the asynchronous operation
     /// The task result contains the specification attribute groups
     /// </returns>
-    Task<IPagedList<SpecificationAttributeGroup>> GetSpecificationAttributeGroupsAsync(int pageIndex = 0, int pageSize = int.MaxValue);
+    Task<IPagedList<SpecificationAttributeGroup>> GetSpecificationAttributeGroupsAsync(int pageIndex = 0, int pageSize = int.MaxValue, string gName = "", string sName = "");
 
     /// <summary>
     /// Gets product specification attribute groups
@@ -107,14 +109,15 @@ public partial interface ISpecificationAttributeService
     Task<IList<SpecificationAttribute>> GetSpecificationAttributesWithOptionsAsync();
 
     /// <summary>
-    /// Gets specification attributes by group identifier
+    /// Gets specification attributes by group identifier and also by name 
     /// </summary>
     /// <param name="specificationAttributeGroupId">The specification attribute group identifier</param>
+    /// <param name="name">The specification attribute name and it's optional</param>
     /// <returns>
     /// A task that represents the asynchronous operation
     /// The task result contains the specification attributes
     /// </returns>
-    Task<IList<SpecificationAttribute>> GetSpecificationAttributesByGroupIdAsync(int? specificationAttributeGroupId = null);
+    Task<IList<SpecificationAttribute>> GetSpecificationAttributesByGroupIdAsync(int? specificationAttributeGroupId = null, string name = "");
 
     /// <summary>
     /// Deletes a specification attribute

--- a/src/Libraries/Nop.Services/Catalog/SpecificationAttributeService.cs
+++ b/src/Libraries/Nop.Services/Catalog/SpecificationAttributeService.cs
@@ -1,5 +1,4 @@
-﻿using LinqToDB;
-using Nop.Core;
+﻿using Nop.Core;
 using Nop.Core.Caching;
 using Nop.Core.Domain.Catalog;
 using Nop.Data;

--- a/src/Libraries/Nop.Services/Catalog/SpecificationAttributeService.cs
+++ b/src/Libraries/Nop.Services/Catalog/SpecificationAttributeService.cs
@@ -122,25 +122,20 @@ public partial class SpecificationAttributeService : ISpecificationAttributeServ
     /// </summary>
     /// <param name="pageIndex">Page index</param>
     /// <param name="pageSize">Page size</param>
-    /// <param name="gName">group name</param>
-    /// <param name="sName">specification attribute name name</param>
+    /// <param name="specificationName">specification attribute name name</param>
     /// <returns>
     /// A task that represents the asynchronous operation
     /// The task result contains the specification attribute groups
     /// </returns>
-    public virtual async Task<IPagedList<SpecificationAttributeGroup>> GetSpecificationAttributeGroupsAsync(int pageIndex = 0, int pageSize = int.MaxValue, string gName = "", string sName = "")
+    public virtual async Task<IPagedList<SpecificationAttributeGroup>> GetSpecificationAttributeGroupsAsync(int pageIndex = 0, int pageSize = int.MaxValue, string specificationName = "")
     {
         var query = _specificationAttributeGroupRepository.Table;
 
-        // Filter by group name
-        if (!string.IsNullOrEmpty(gName))
-            query = query.Where(sag => sag.Name.Contains(gName));
-
         // Filter by specification attribute name
-        if (!string.IsNullOrEmpty(sName))
+        if (!string.IsNullOrEmpty(specificationName))
             query = from sag in query
                     from sa in _specificationAttributeRepository.Table
-                    where sa.Name.Contains(sName) && sa.SpecificationAttributeGroupId == sag.Id
+                    where sa.Name.Contains(specificationName) && sa.SpecificationAttributeGroupId == sag.Id
                     select sag;
 
         // Order the results
@@ -152,10 +147,10 @@ public partial class SpecificationAttributeService : ISpecificationAttributeServ
         var result = await query.ToPagedListAsync(pageIndex, pageSize);
 
         // Add default group if necessary
-        if (pageIndex == 0 && string.IsNullOrEmpty(gName))
+        if (pageIndex == 0)
         {
             var hasNoGroup = _specificationAttributeRepository.Table
-                    .Any(sa => sa.SpecificationAttributeGroupId == null && (string.IsNullOrEmpty(sName) || sa.Name.Contains(sName)));
+                    .Any(sa => sa.SpecificationAttributeGroupId == null && (string.IsNullOrEmpty(specificationName) || sa.Name.Contains(specificationName)));
             if (hasNoGroup)
                 result.Insert(0, new SpecificationAttributeGroup());
         }

--- a/src/Presentation/Nop.Web.Framework/Migrations/UpgradeTo490/LocalizationMigration.cs
+++ b/src/Presentation/Nop.Web.Framework/Migrations/UpgradeTo490/LocalizationMigration.cs
@@ -68,6 +68,12 @@ public class LocalizationMigration : MigrationBase
             //#6407
             ["ActivityLog.PublicStore.PasswordChanged"] = "Public store. Customer has changed the password",
 
+            ["Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.SearchName"] = "Name",
+            ["Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.SearchName.Hint"] = "a specification name",
+            ["Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.SearchGroupName"] = "Group Name",
+            ["Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.SearchGroupName.Hint"] = "a group name"
+
+
         }, languageId);
 
         #endregion

--- a/src/Presentation/Nop.Web.Framework/Migrations/UpgradeTo490/LocalizationMigration.cs
+++ b/src/Presentation/Nop.Web.Framework/Migrations/UpgradeTo490/LocalizationMigration.cs
@@ -68,6 +68,7 @@ public class LocalizationMigration : MigrationBase
             //#6407
             ["ActivityLog.PublicStore.PasswordChanged"] = "Public store. Customer has changed the password",
 
+            //#7545
             ["Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.SearchName"] = "Name",
             ["Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.SearchName.Hint"] = "a specification name",
             ["Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.SearchGroupName"] = "Group Name",

--- a/src/Presentation/Nop.Web.Framework/Migrations/UpgradeTo490/LocalizationMigration.cs
+++ b/src/Presentation/Nop.Web.Framework/Migrations/UpgradeTo490/LocalizationMigration.cs
@@ -70,9 +70,7 @@ public class LocalizationMigration : MigrationBase
 
             //#7545
             ["Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.SearchName"] = "Name",
-            ["Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.SearchName.Hint"] = "a specification name",
-            ["Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.SearchGroupName"] = "Group Name",
-            ["Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.SearchGroupName.Hint"] = "a group name"
+            ["Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.SearchName.Hint"] = "a specification name"
 
 
         }, languageId);

--- a/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
+++ b/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
@@ -1959,6 +1959,18 @@
   <LocaleResource Name="Admin.Catalog.Attributes.ProductAttributes.UsedByProducts.Published">
     <Value>Published</Value>
   </LocaleResource>
+  <LocaleResource Name="Admin.Catalog.Attributes.SpecificationAttribute.Fields.SearchGroupName">
+    <Value>Group Name</Value>
+  </LocaleResource>
+  <LocaleResource Name="Admin.Catalog.Attributes.SpecificationAttribute.Fields.SearchGroupName.Hint">
+     <Value>a group name</Value>
+  </LocaleResource>
+  <LocaleResource Name="Admin.Catalog.Attributes.SpecificationAttributes.Fields.SearchName">
+     <Value>Name</Value>
+  </LocaleResource>
+  <LocaleResource Name="Admin.Catalog.Attributes.SpecificationAttributes.Fields.SearchName.Hint">
+    <Value>a specification name</Value>
+  </LocaleResource>
   <LocaleResource Name="Admin.Catalog.Attributes.SpecificationAttributes">
     <Value>Specification attributes</Value>
   </LocaleResource>

--- a/src/Presentation/Nop.Web/Areas/Admin/Factories/SpecificationAttributeModelFactory.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Factories/SpecificationAttributeModelFactory.cs
@@ -118,7 +118,7 @@ public partial class SpecificationAttributeModelFactory : ISpecificationAttribut
         var one = new List<SpecificationAttributeGroupModel>();
         //get specification attribute groups
         var specificationAttributeGroups = await _specificationAttributeService
-            .GetSpecificationAttributeGroupsAsync(searchModel.Page - 1, searchModel.PageSize, searchModel.SpecificationAttributeSearchGroupName, searchModel.SpecificationAttributeName);
+            .GetSpecificationAttributeGroupsAsync(searchModel.Page - 1, searchModel.PageSize, searchModel.SpecificationAttributeName);
         // check wether to set the default group
         if (specificationAttributeGroups.Any(s => s.Id == 0))
         {

--- a/src/Presentation/Nop.Web/Areas/Admin/Factories/SpecificationAttributeModelFactory.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Factories/SpecificationAttributeModelFactory.cs
@@ -115,19 +115,15 @@ public partial class SpecificationAttributeModelFactory : ISpecificationAttribut
     {
         ArgumentNullException.ThrowIfNull(searchModel);
 
+        var one = new List<SpecificationAttributeGroupModel>();
         //get specification attribute groups
         var specificationAttributeGroups = await _specificationAttributeService
-            .GetSpecificationAttributeGroupsAsync(searchModel.Page - 1, searchModel.PageSize);
-
-        if (searchModel.Page == 1)
+            .GetSpecificationAttributeGroupsAsync(searchModel.Page - 1, searchModel.PageSize, searchModel.SpecificationAttributeSearchGroupName, searchModel.SpecificationAttributeName);
+        // check wether to set the default group
+        if (specificationAttributeGroups.Any(s => s.Id == 0))
         {
-            //dislpay default group with non-grouped specification attributes on first page
-            specificationAttributeGroups.Insert(0, new SpecificationAttributeGroup
-            {
-                Name = await _localizationService.GetResourceAsync("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttributeGroup.DefaultGroupName")
-            });
+            specificationAttributeGroups.FirstOrDefault(sag => sag.Id == 0).Name = await _localizationService.GetResourceAsync("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttributeGroup.DefaultGroupName");
         }
-
         //prepare list model
         var model = new SpecificationAttributeGroupListModel().PrepareToGrid(searchModel, specificationAttributeGroups, () =>
         {
@@ -186,7 +182,7 @@ public partial class SpecificationAttributeModelFactory : ISpecificationAttribut
         ArgumentNullException.ThrowIfNull(searchModel);
 
         //get specification attributes
-        var specificationAttributes = (await _specificationAttributeService.GetSpecificationAttributesByGroupIdAsync(group?.Id)).ToPagedList(searchModel);
+        var specificationAttributes = (await _specificationAttributeService.GetSpecificationAttributesByGroupIdAsync(group?.Id, searchModel.SpecificationAttributeSearchName)).ToPagedList(searchModel);
 
         //prepare list model
         var model = new SpecificationAttributeListModel().PrepareToGrid(searchModel, specificationAttributes, () =>

--- a/src/Presentation/Nop.Web/Areas/Admin/Models/Catalog/SpecificationAttributeGroupSearchModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Models/Catalog/SpecificationAttributeGroupSearchModel.cs
@@ -8,10 +8,6 @@ namespace Nop.Web.Areas.Admin.Models.Catalog;
 /// </summary>
 public partial record SpecificationAttributeGroupSearchModel : BaseSearchModel
 {
-    // this is was empty 
-    [NopResourceDisplayName("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.SearchGroupName")]
-    public string SpecificationAttributeSearchGroupName { get; set; }
-
     [NopResourceDisplayName("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.SearchName")]
     public string SpecificationAttributeName { get; set; }
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Models/Catalog/SpecificationAttributeGroupSearchModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Models/Catalog/SpecificationAttributeGroupSearchModel.cs
@@ -1,4 +1,5 @@
 ﻿using Nop.Web.Framework.Models;
+using Nop.Web.Framework.Mvc.ModelBinding;
 
 namespace Nop.Web.Areas.Admin.Models.Catalog;
 
@@ -7,4 +8,11 @@ namespace Nop.Web.Areas.Admin.Models.Catalog;
 /// </summary>
 public partial record SpecificationAttributeGroupSearchModel : BaseSearchModel
 {
+    // this is was empty 
+    [NopResourceDisplayName("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.SearchGroupName")]
+    public string SpecificationAttributeSearchGroupName { get; set; }
+
+    [NopResourceDisplayName("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.SearchName")]
+    public string SpecificationAttributeName { get; set; }
+
 }

--- a/src/Presentation/Nop.Web/Areas/Admin/Models/Catalog/SpecificationAttributeSearchModel.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Models/Catalog/SpecificationAttributeSearchModel.cs
@@ -1,4 +1,5 @@
 ﻿using Nop.Web.Framework.Models;
+using Nop.Web.Framework.Mvc.ModelBinding;
 
 namespace Nop.Web.Areas.Admin.Models.Catalog;
 
@@ -10,6 +11,7 @@ public partial record SpecificationAttributeSearchModel : BaseSearchModel
     #region Properties
 
     public int SpecificationAttributeGroupId { get; set; }
-
+    [NopResourceDisplayName("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.SearchName")]
+    public string SpecificationAttributeSearchName { get; set; }
     #endregion
 }

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/SpecificationAttribute/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/SpecificationAttribute/List.cshtml
@@ -55,7 +55,7 @@
 						<div class="search-body @(hideSearchBlock ? "closed" : "")">
 
 							<div class="row">
-								<div class="col-md-6">
+								<div class="col-md-5">
 
 									<div class="form-group row">
 										<div class="col-md-4">

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/SpecificationAttribute/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/SpecificationAttribute/List.cshtml
@@ -59,15 +59,6 @@
 
 									<div class="form-group row">
 										<div class="col-md-4">
-											<nop-label asp-for="SpecificationAttributeSearchGroupName" />
-										</div>
-										<div class="col-md-8">
-											<nop-editor asp-for="SpecificationAttributeSearchGroupName" />
-										</div>
-									</div>
-
-									<div class="form-group row">
-										<div class="col-md-4">
 											<nop-label asp-for="SpecificationAttributeName" />
 										</div>
 										<div class="col-md-8">
@@ -103,7 +94,6 @@
 							 Length = Model.PageSize,
 							 LengthMenu = Model.AvailablePageSizes,
 							 Filters = new List<FilterParameter> {
-								new FilterParameter(nameof(Model.SpecificationAttributeSearchGroupName)),
 								new FilterParameter(nameof(Model.SpecificationAttributeName)),
 							 },
 							 ColumnCollection = new List<ColumnProperty>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/SpecificationAttribute/List.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/SpecificationAttribute/List.cshtml
@@ -1,150 +1,238 @@
 @model SpecificationAttributeGroupSearchModel
 
 @{
-    //page title
-    ViewBag.PageTitle = T("Admin.Catalog.Attributes.SpecificationAttributes").Text;
-    //active menu item (system name)
-    NopHtml.SetActiveMenuItemSystemName("Specification attributes");
+	//page title
+	ViewBag.PageTitle = T("Admin.Catalog.Attributes.SpecificationAttributes").Text;
+	//active menu item (system name)
+	NopHtml.SetActiveMenuItemSystemName("SpecificationAttributeList");
+}
+
+@{
+	const string hideSearchBlockAttributeName = "SpecificationAttributeListPage.HideSearchBlock";
+	var hideSearchBlock = await genericAttributeService.GetAttributeAsync<bool>(await workContext.GetCurrentCustomerAsync(), hideSearchBlockAttributeName);
 }
 
 <div class="content-header clearfix">
-    <h1 class="float-left">
-        @T("Admin.Catalog.Attributes.SpecificationAttributes")
-    </h1>
-    <div class="float-right">
-        <a asp-action="CreateSpecificationAttributeGroup" class="btn btn-primary">
-            <i class="fas fa-square-plus"></i>
-            @T("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttributeGroup.Buttons.AddNew")
-        </a>
-        <a asp-action="CreateSpecificationAttribute" class="btn btn-primary">
-            <i class="fas fa-square-plus"></i>
-            @T("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Buttons.AddNew")
-        </a>
-        @await Component.InvokeAsync(typeof(AdminWidgetViewComponent), new { widgetZone = AdminWidgetZones.SpecificationAttributeListButtons, additionalData = Model })
-        <button type="button" id="delete-selected-specification-attributes" class="btn btn-danger">
-            <i class="far fa-trash-can"></i>
-            @T("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Buttons.DeleteSelected")
-        </button>
-        <nop-action-confirmation asp-button-id="delete-selected-specification-attributes" />
-    </div>
+	<h1 class="float-left">
+		@T("Admin.Catalog.Attributes.SpecificationAttributes")
+	</h1>
+	<div class="float-right">
+		<a asp-action="CreateSpecificationAttributeGroup" class="btn btn-primary">
+			<i class="fas fa-square-plus"></i>
+			@T("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttributeGroup.Buttons.AddNew")
+		</a>
+		<a asp-action="CreateSpecificationAttribute" class="btn btn-primary">
+			<i class="fas fa-square-plus"></i>
+			@T("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Buttons.AddNew")
+		</a>
+		@await Component.InvokeAsync(typeof(AdminWidgetViewComponent), new { widgetZone = AdminWidgetZones.SpecificationAttributeListButtons, additionalData = Model })
+		<button type="button" id="delete-selected-specification-attributes" class="btn btn-danger">
+			<i class="far fa-trash-can"></i>
+			@T("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Buttons.DeleteSelected")
+		</button>
+		<nop-action-confirmation asp-button-id="delete-selected-specification-attributes" />
+	</div>
 </div>
 
 <section class="content">
-    <div class="container-fluid">
-    <div class="cards-group">
-        <div class="card card-default">
-            <div class="card-body">
-                <p>
-                    @T("Admin.Catalog.Attributes.SpecificationAttributes.Description")
-                    <nop-doc-reference asp-string-resource="@T("Admin.Documentation.Reference.SpecificationAttributes", Docs.SpecificationAttributes + Utm.OnAdmin)" asp-add-wrapper="false"/>
-                </p>
-                @await Html.PartialAsync("Table", new DataTablesModel
-                {
-                    Name = "specificationattributegroups-grid",
-                    UrlRead = new DataUrl("SpecificationAttributeGroupList", "SpecificationAttribute", null),
-                    PrimaryKeyColumn = nameof(SpecificationAttributeGroupModel.Id),
-                    Length = Model.PageSize,
-                    LengthMenu = Model.AvailablePageSizes,
-                    ColumnCollection = new List<ColumnProperty>
-                    {
-                        new ColumnProperty(null)
-                        {
-                            Render = new RenderChildCaret(),
-                            Width = "5",
-                            Searchable = false,
-                            ClassName =  NopColumnClassDefaults.ChildControl
-                        },
-                        new ColumnProperty(nameof(SpecificationAttributeGroupModel.Name))
-                        {
-                            Title = T("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttributeGroup.Fields.Name").Text,
-                            Render = new RenderCustom("renderColumnNameSpecificationAttributeGroup")
-                        },
-                        new ColumnProperty(nameof(SpecificationAttributeGroupModel.DisplayOrder))
-                        {
-                            Title = T("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttributeGroup.Fields.DisplayOrder").Text,
-                            Width = "100",
-                            ClassName =  NopColumnClassDefaults.CenterAll
-                        }
-                    },
-                    ChildTable = new DataTablesModel
-                    {
-                        Name = "specificationattributes-grid",
-                        UrlRead = new DataUrl("SpecificationAttributeList", "SpecificationAttribute", null),
-                        IsChildTable = true,
-                        Length = Model.PageSize,
-                        LengthMenu = Model.AvailablePageSizes,
-                        Filters = new List<FilterParameter>
-                        {
-                            new FilterParameter(nameof(SpecificationAttributeModel.SpecificationAttributeGroupId), nameof(SpecificationAttributeGroupModel.Id), true)
-                        },
-                        ColumnCollection = new List<ColumnProperty>
-                        {
-                            new ColumnProperty(nameof(SpecificationAttributeModel.Id))
-                            {
-                                IsMasterCheckBox = true,
-                                Render = new RenderCheckBox("checkbox_specificationattributes"),
-                                ClassName =  NopColumnClassDefaults.CenterAll,
-                                Width = "50"
-                            },
-                            new ColumnProperty(nameof(SpecificationAttributeModel.Name))
-                            {
-                                Title = T("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.Name").Text,
-                                    Width = "300"
-                            },
-                            new ColumnProperty(nameof(SpecificationAttributeModel.DisplayOrder))
-                            {
-                                Title = T("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.DisplayOrder").Text,
-                                Width = "150",
-                                ClassName =  NopColumnClassDefaults.CenterAll
-                            },
-                            new ColumnProperty(nameof(SpecificationAttributeModel.Id))
-                            {
-                                Title = T("Admin.Common.Edit").Text,
-                                Width = "50",
-                                ClassName = NopColumnClassDefaults.Button,
-                                Render = new RenderButtonEdit(new DataUrl("~/Admin/SpecificationAttribute/EditSpecificationAttribute"))
-                            }
-                        }
-                    }
-                })
+	<div class="container-fluid">
+		<div class="form-horizontal">
+			<div class="cards-group">
+				<div class="card card-default card-search">
+					<div class="card-body">
+						<p>
+							@T("Admin.Catalog.Attributes.SpecificationAttributes.Description")
+							<nop-doc-reference asp-string-resource="@T("Admin.Documentation.Reference.SpecificationAttributes", Docs.SpecificationAttributes + Utm.OnAdmin)" asp-add-wrapper="false"/>
+						</p>
 
-                <script>
-                function renderColumnNameSpecificationAttributeGroup(name, type, row, meta) {
-                    return row.Id ? '<a href="@Url.Action("EditSpecificationAttributeGroup", "SpecificationAttribute")/' + row.Id +'">' + name + '</a>' : name;
-                }
 
-                $(function() {
-                    $('#delete-selected-specification-attributes-action-confirmation-submit-button').bind('click', function () {
-                        var postData = {
-                            selectedIds: selectedIds
-                        };
-                        addAntiForgeryToken(postData);
-                        $.ajax({
-                            cache: false,
-                            type: "POST",
-                            url: "@(Url.Action("DeleteSelectedSpecificationAttributes", "SpecificationAttribute"))",
-                            data: postData,
-                            error: function (jqXHR, textStatus, errorThrown) {
-                                showAlert('delete-selected-specification-attributes-alert', errorThrown);
-                            },
-                            complete: function (jqXHR, textStatus) {
-                                if (jqXHR.status === 204)
-                                {
-                                    showAlert('nothingSelectedAlert', '@T("Admin.Common.Alert.NothingSelected")');
-                                    return;
-                                }
-                                updateTable('#specificationattributegroups-grid');
-                            }
-                        });
-                        $('#delete-selected-specification-attributes-action-confirmation').modal('toggle');
-                        return false;
-                    });
-                });
-                </script>
-                <nop-alert asp-alert-id="delete-selected-specification-attributes-alert" />
-                <nop-alert asp-alert-id="nothingSelectedAlert" />
-            </div>
-        </div>
-    </div>
-</div>
+						<div class="row search-row @(!hideSearchBlock ? "opened" : "")" data-hideAttribute="@hideSearchBlockAttributeName">
+							<div class="search-text">@T("Admin.Common.Search")</div>
+							<div class="icon-search"><i class="fas fa-magnifying-glass" aria-hidden="true"></i></div>
+							<div class="icon-collapse"><i class="far fa-angle-@(!hideSearchBlock ? "up" : "down")" aria-hidden="true"></i></div>
+						</div>
+
+						<div class="search-body @(hideSearchBlock ? "closed" : "")">
+
+							<div class="row">
+								<div class="col-md-6">
+
+									<div class="form-group row">
+										<div class="col-md-4">
+											<nop-label asp-for="SpecificationAttributeSearchGroupName" />
+										</div>
+										<div class="col-md-8">
+											<nop-editor asp-for="SpecificationAttributeSearchGroupName" />
+										</div>
+									</div>
+
+									<div class="form-group row">
+										<div class="col-md-4">
+											<nop-label asp-for="SpecificationAttributeName" />
+										</div>
+										<div class="col-md-8">
+											<nop-editor asp-for="SpecificationAttributeName" />
+										</div>
+									</div>
+								</div>
+							</div>
+
+
+							<div class="row">
+								<div class="text-center col-12">
+									<button type="button" id="search-groups" class="btn btn-primary btn-search">
+										<i class="fas fa-magnifying-glass"></i>
+										@T("Admin.Common.Search")
+									</button>
+								</div>
+							</div>
+
+						</div>
+
+				</div>
+				</div>
+				<div class="card card-default">
+					
+					<div class="card-body">
+						@await Html.PartialAsync("Table", new DataTablesModel
+						{
+							 Name = "specificationattributegroups-grid",
+							 UrlRead = new DataUrl("SpecificationAttributeGroupList", "SpecificationAttribute", null),
+							 SearchButtonId = "search-groups",
+							 PrimaryKeyColumn = nameof(SpecificationAttributeGroupModel.Id),
+							 Length = Model.PageSize,
+							 LengthMenu = Model.AvailablePageSizes,
+							 Filters = new List<FilterParameter> {
+								new FilterParameter(nameof(Model.SpecificationAttributeSearchGroupName)),
+								new FilterParameter(nameof(Model.SpecificationAttributeName)),
+							 },
+							 ColumnCollection = new List<ColumnProperty>
+							{
+									new ColumnProperty(null)
+									{
+										Render = new RenderChildCaret(),
+										Width = "5",
+										Searchable = false,
+										ClassName =  NopColumnClassDefaults.ChildControl
+									},
+									new ColumnProperty(nameof(SpecificationAttributeGroupModel.Name))
+									{
+										Title = T("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttributeGroup.Fields.Name").Text,
+										Render = new RenderCustom("renderColumnNameSpecificationAttributeGroup")
+									},
+									new ColumnProperty(nameof(SpecificationAttributeGroupModel.DisplayOrder))
+									{
+										Title = T("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttributeGroup.Fields.DisplayOrder").Text,
+										Width = "100",
+										ClassName =  NopColumnClassDefaults.CenterAll
+									}
+							},
+							ChildTable = new DataTablesModel
+							{
+								Name = "specificationattributes-grid",
+								UrlRead = new DataUrl("SpecificationAttributeList", "SpecificationAttribute", null),
+								IsChildTable = true,
+								Length = Model.PageSize,
+								LengthMenu = Model.AvailablePageSizes,
+								Filters = new List<FilterParameter>
+								{
+									new FilterParameter(nameof(SpecificationAttributeModel.SpecificationAttributeGroupId), nameof(SpecificationAttributeGroupModel.Id), true),
+									new FilterParameter(nameof(SpecificationAttributeSearchModel.SpecificationAttributeSearchName)),
+								},
+								ColumnCollection = new List<ColumnProperty>
+								{
+									new ColumnProperty(nameof(SpecificationAttributeModel.Id))
+									{
+										IsMasterCheckBox = true,
+										Render = new RenderCheckBox("checkbox_specificationattributes"),
+										ClassName =  NopColumnClassDefaults.CenterAll,
+										Width = "50"
+									},
+									new ColumnProperty(nameof(SpecificationAttributeModel.Name))
+									{
+										Title = T("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.Name").Text,
+										Width = "300"
+									},
+									new ColumnProperty(nameof(SpecificationAttributeModel.DisplayOrder))
+									{
+										Title = T("Admin.Catalog.Attributes.SpecificationAttributes.SpecificationAttribute.Fields.DisplayOrder").Text,
+										Width = "150",
+										ClassName =  NopColumnClassDefaults.CenterAll
+									},
+									new ColumnProperty(nameof(SpecificationAttributeModel.Id))
+									{
+										Title = T("Admin.Common.Edit").Text,
+										Width = "50",
+										ClassName = NopColumnClassDefaults.Button,
+										Render = new RenderButtonEdit(new DataUrl("~/Admin/SpecificationAttribute/EditSpecificationAttribute"))
+									}
+								}
+							}
+						})
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
 </section>
+<script>
+$(document).ready(function() {
+	$('<input/>', {
+		type: 'hidden',
+		id: 'SpecificationAttributeSearchName',
+		name: 'SpecificationAttributeSearchName',
+		class: 'form-control',
+	}).appendTo('.search-body');
+});
+$("#search-groups").click(function() {
+	var searchName = $('#@nameof(Model.SpecificationAttributeName)').val().trim();
+	console.log(searchName);
+	console.log($("#SpecificationAttributeSearchName"));
+	$("#SpecificationAttributeSearchName").val("");
+	if (searchName) {
+		$("#SpecificationAttributeSearchName").val(searchName);
+		var table = $('#specificationattributegroups-grid').DataTable();
+		table.one('draw.dt', function () {
+            var rows = table.rows().nodes();
+            $(rows).find('td.child-control').each(function () {
+                $(this).trigger('click');
+            });
+        });
+	}
+
+})
+function renderColumnNameSpecificationAttributeGroup(name, type, row, meta) {
+	return row.Id ? '<a href="@Url.Action("EditSpecificationAttributeGroup", "SpecificationAttribute")/' + row.Id +'">' + name + '</a>' : name;
+}
+
+$(function() {
+	$('#delete-selected-specification-attributes-action-confirmation-submit-button').bind('click', function () {
+	var postData = {
+		selectedIds: selectedIds
+	};
+	addAntiForgeryToken(postData);
+	$.ajax({
+		cache: false,
+		type: "POST",
+		url: "@(Url.Action("DeleteSelectedSpecificationAttributes", "SpecificationAttribute"))",
+		data: postData,
+		error: function (jqXHR, textStatus, errorThrown) {
+		showAlert('delete-selected-specification-attributes-alert', errorThrown);
+		},
+		complete: function (jqXHR, textStatus) {
+		if (jqXHR.status === 204)
+		{
+		showAlert('nothingSelectedAlert', '@T("Admin.Common.Alert.NothingSelected")');
+		return;
+		}
+		updateTable('#specificationattributegroups-grid');
+		}
+	});
+	$('#delete-selected-specification-attributes-action-confirmation').modal('toggle');
+		return false;
+	});
+});
+
+</script>
+<nop-alert asp-alert-id="delete-selected-specification-attributes-alert" />
+<nop-alert asp-alert-id="nothingSelectedAlert" />


### PR DESCRIPTION
#7545 i have added this feature by these steps 

- update `GetSpecificationAttributeGroupsAsync` in the `ISpecificationAttributeService.cs` file to have this signature `GetSpecificationAttributeGroupsAsync(int pageIndex = 0, int pageSize = int.MaxValue, string specificationName = "")` and this is to enable search by group name which contains this specification attribute 
- update `GetSpecificationAttributesByGroupIdAsync` to `GetSpecificationAttributesByGroupIdAsync(int? specificationAttributeGroupId = null, string name = "")` to enable searching by attribute name in the group 
- update `PrepareSpecificationAttributeGroupListModelAsync` in the `SpecificationAttributeModelFactory` 
- update `List.cshtml` to include search box 
- update `SpecificationAttributeSearchModel.cs` to include add searchName property 
- update `SpecificationAttributeGroupSearchModel.cs` to include specification attribute search property 


**So this will be the page** 
<img width="749" alt="1" src="https://github.com/user-attachments/assets/ea1de7ba-815e-443d-b14d-ec08af700eef" />

**You can type the attribute name and it will fetch the attribute and the group of it , and if it has no group then it appear in the default group**

**_And you don't have to click on the control icon to display the result attributes , but the child table of specification attributes will open auto, so that you will see the attribute result directly_** 

**See images below**
<img width="725" alt="2" src="https://github.com/user-attachments/assets/969ae69d-a7c8-46d3-8108-9f38d28a0dfa" />
<img width="737" alt="3" src="https://github.com/user-attachments/assets/e1d42392-01f3-4aa1-af80-42f9aee2b0a4" />
<img width="731" alt="4" src="https://github.com/user-attachments/assets/b6a20a6c-0e7a-44aa-864f-4b3071a0b141" />
