### PR TITLE
Refactor ClearDiscountProductMappingAsync to remove unnecessary join and optimize query

### DIFF
--- a/src/Libraries/Nop.Services/Catalog/ProductService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ProductService.cs
@@ -2784,18 +2784,11 @@ public partial class ProductService : IProductService
     {
         ArgumentNullException.ThrowIfNull(discount);
 
-        var mappingsWithProducts =
-            from dcm in _discountProductMappingRepository.Table
-            join p in _productRepository.Table on dcm.EntityId equals p.Id
-            where dcm.DiscountId == discount.Id
-            select new { product = p, dcm };
+        var mappingsWithProducts = await _discountProductMappingRepository.Table
+            .Where(dpm => dpm.DiscountId == discount.Id)
+            .ToListAsync();
 
-        var mappingsToDelete = new List<DiscountProductMapping>();
-        await foreach (var pdcm in mappingsWithProducts.ToAsyncEnumerable())
-        {
-            mappingsToDelete.Add(pdcm.dcm);
-        }
-        await _discountProductMappingRepository.DeleteAsync(mappingsToDelete);
+        await _discountProductMappingRepository.DeleteAsync(mappingsWithProducts);
     }
 
     /// <summary>


### PR DESCRIPTION
This PR removes an unnecessary join in `ClearDiscountProductMappingAsync` and optimizes query execution by using `ToListAsync()`