### PR TITLE
Hide "Purchased with orders" block for users without "View orders" permission

### DIFF
--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.cshtml
@@ -51,6 +51,8 @@
 
     const string hideStockQuantityHistoryBlockAttributeName = "ProductPage.HideStockQuantityHistoryBlock";
     var hideStockQuantityHistoryBlock = await genericAttributeService.GetAttributeAsync<bool>(customer, hideStockQuantityHistoryBlockAttributeName, defaultValue: true);
+
+    var hasViewOrderPermission = await permissionService.AuthorizeAsync(StandardPermission.Orders.ORDERS_VIEW);
 }
 
 <div asp-validation-summary="All"></div>
@@ -92,7 +94,7 @@
 
                 @if (Model.Id > 0)
                 {
-                    if (await permissionService.AuthorizeAsync(StandardPermission.Orders.ORDERS_VIEW))
+                    if (hasViewOrderPermission)
                     {
                         <nop-card asp-name="product-purchased-with-orders" asp-icon="fas fa-cart-arrow-down" asp-title="@T("Admin.Catalog.Products.PurchasedWithOrders")" asp-hide-block-attribute-name="@hidePurchasedWithOrdersBlockAttributeName" asp-hide="@hidePurchasedWithOrdersBlock" asp-advanced="@(!Model.ProductEditorSettingsModel.PurchasedWithOrders)">@await Html.PartialAsync("_CreateOrUpdate.PurchasedWithOrders", Model)</nop-card>
                     }

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Product/_CreateOrUpdate.cshtml
@@ -92,7 +92,10 @@
 
                 @if (Model.Id > 0)
                 {
-                    <nop-card asp-name="product-purchased-with-orders" asp-icon="fas fa-cart-arrow-down" asp-title="@T("Admin.Catalog.Products.PurchasedWithOrders")" asp-hide-block-attribute-name="@hidePurchasedWithOrdersBlockAttributeName" asp-hide="@hidePurchasedWithOrdersBlock" asp-advanced="@(!Model.ProductEditorSettingsModel.PurchasedWithOrders)">@await Html.PartialAsync("_CreateOrUpdate.PurchasedWithOrders", Model)</nop-card>
+                    if (await permissionService.AuthorizeAsync(StandardPermission.Orders.ORDERS_VIEW))
+                    {
+                        <nop-card asp-name="product-purchased-with-orders" asp-icon="fas fa-cart-arrow-down" asp-title="@T("Admin.Catalog.Products.PurchasedWithOrders")" asp-hide-block-attribute-name="@hidePurchasedWithOrdersBlockAttributeName" asp-hide="@hidePurchasedWithOrdersBlock" asp-advanced="@(!Model.ProductEditorSettingsModel.PurchasedWithOrders)">@await Html.PartialAsync("_CreateOrUpdate.PurchasedWithOrders", Model)</nop-card>
+                    }
                     <nop-card asp-name="product-stock-quantity-history" asp-icon="fas fa-clock-rotate-left" asp-title="@T("Admin.Catalog.Products.StockQuantityHistory")" asp-hide-block-attribute-name="@hideStockQuantityHistoryBlockAttributeName" asp-hide="@hideStockQuantityHistoryBlock" asp-advanced="@(!Model.ProductEditorSettingsModel.StockQuantityHistory)">@await Html.PartialAsync("_CreateOrUpdate.StockQuantityHistory", Model)</nop-card>
                 }
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/_ViewImports.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/_ViewImports.cshtml
@@ -3,6 +3,7 @@
 @inject IGenericAttributeService genericAttributeService
 @inject INopHtmlHelper NopHtml
 @inject IWorkContext workContext
+@inject IPermissionService permissionService
 
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, Nop.Web.Framework
@@ -19,6 +20,7 @@
 @using Nop.Core.Events
 @using Nop.Core.Infrastructure
 @using Nop.Services.Common
+@using Nop.Services.Security
 @using static Nop.Services.Common.NopLinksDefaults
 @using Nop.Web.Areas.Admin.Components
 @using Nop.Web.Areas.Admin.Models.Affiliates

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/_ViewImports.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/_ViewImports.cshtml
@@ -2,8 +2,8 @@
 
 @inject IGenericAttributeService genericAttributeService
 @inject INopHtmlHelper NopHtml
-@inject IWorkContext workContext
 @inject IPermissionService permissionService
+@inject IWorkContext workContext
 
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, Nop.Web.Framework


### PR DESCRIPTION
The "Purchased with orders" block on the product edit page is hidden when the current user does not have the "View orders" permission.