### PR TITLE
Fix: correct index existence check for database migration in v4.9.0

### DIFF
--- a/src/Libraries/Nop.Data/Migrations/UpgradeTo490/AddIndexesMigration.cs
+++ b/src/Libraries/Nop.Data/Migrations/UpgradeTo490/AddIndexesMigration.cs
@@ -24,7 +24,7 @@ public class AddIndexesMigration : ForwardOnlyMigration
         var topicEndDateColumnName = nameof(Topic.AvailableEndDateTimeUtc);
         var topicStartDateColumnName = nameof(Topic.AvailableStartDateTimeUtc);
         var topicAvailableDatesIndexName = "IX_Topic_Availability";
-        if (!Schema.Table(topicAvailableDatesIndexName).Exists())
+        if (!Schema.Table(topicTableName).Index(topicAvailableDatesIndexName).Exists())
             Create.Index(topicAvailableDatesIndexName)
                 .OnTable(topicTableName)
                 .OnColumn(topicEndDateColumnName).Descending()


### PR DESCRIPTION
This bug caused a database exception because the code attempted to create an index that already existed.