### PR TITLE
Render usage history on the gift card edit page based on the associated permission

### DIFF
--- a/src/Presentation/Nop.Web/Areas/Admin/Views/GiftCard/_CreateOrUpdate.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/GiftCard/_CreateOrUpdate.cshtml
@@ -1,7 +1,5 @@
 ﻿@model GiftCardModel
 
-@inject Nop.Services.Common.IGenericAttributeService genericAttributeService
-@inject IWorkContext workContext
 @{
     const string hideInfoBlockAttributeName = "GiftCardPage.HideInfoBlock";
     var customer = await workContext.GetCurrentCustomerAsync();
@@ -20,7 +18,7 @@
             <nop-cards id="gift-card-cards">
                 <nop-card asp-name="gift-card-info" asp-icon="fas fa-info" asp-title="@T("Admin.GiftCards.Info")" asp-hide-block-attribute-name="@hideInfoBlockAttributeName" asp-hide="@hideInfoBlock" asp-advanced="false">@await Html.PartialAsync("_CreateOrUpdate.Info", Model)</nop-card>
 
-                @if (Model.Id > 0)
+                @if (Model.Id > 0 && await permissionService.AuthorizeAsync(StandardPermission.Orders.GIFT_CARDS_CREATE_EDIT_DELETE))
                 {
                     <nop-card asp-name="gift-card-usage-history" asp-icon="fas fa-clock-rotate-left" asp-title="@T("Admin.GiftCards.History")" asp-hide-block-attribute-name="@hideUsageHistoryBlockAttributeName" asp-hide="@HideUsageHistoryBlock" asp-advanced="false">@await Html.PartialAsync("_CreateOrUpdate.History", Model)</nop-card>
                 }

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/GiftCard/_CreateOrUpdate.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/GiftCard/_CreateOrUpdate.cshtml
@@ -6,7 +6,9 @@
     var hideInfoBlock = await genericAttributeService.GetAttributeAsync<bool>(customer, hideInfoBlockAttributeName);
 
     const string hideUsageHistoryBlockAttributeName = "GiftCardPage.HideUsageHistoryBlock";
-    var HideUsageHistoryBlock = await genericAttributeService.GetAttributeAsync<bool>(customer, hideUsageHistoryBlockAttributeName, defaultValue: true);
+    var hideUsageHistoryBlock = await genericAttributeService.GetAttributeAsync<bool>(customer, hideUsageHistoryBlockAttributeName, defaultValue: true);
+    
+    var hasGiftCardUsageHistoryWritePermission = await permissionService.AuthorizeAsync(StandardPermission.Orders.GIFT_CARDS_CREATE_EDIT_DELETE);
 }
 
 <div asp-validation-summary="All"></div>
@@ -18,9 +20,9 @@
             <nop-cards id="gift-card-cards">
                 <nop-card asp-name="gift-card-info" asp-icon="fas fa-info" asp-title="@T("Admin.GiftCards.Info")" asp-hide-block-attribute-name="@hideInfoBlockAttributeName" asp-hide="@hideInfoBlock" asp-advanced="false">@await Html.PartialAsync("_CreateOrUpdate.Info", Model)</nop-card>
 
-                @if (Model.Id > 0 && await permissionService.AuthorizeAsync(StandardPermission.Orders.GIFT_CARDS_CREATE_EDIT_DELETE))
+                @if (Model.Id > 0 && hasGiftCardUsageHistoryWritePermission)
                 {
-                    <nop-card asp-name="gift-card-usage-history" asp-icon="fas fa-clock-rotate-left" asp-title="@T("Admin.GiftCards.History")" asp-hide-block-attribute-name="@hideUsageHistoryBlockAttributeName" asp-hide="@HideUsageHistoryBlock" asp-advanced="false">@await Html.PartialAsync("_CreateOrUpdate.History", Model)</nop-card>
+                    <nop-card asp-name="gift-card-usage-history" asp-icon="fas fa-clock-rotate-left" asp-title="@T("Admin.GiftCards.History")" asp-hide-block-attribute-name="@hideUsageHistoryBlockAttributeName" asp-hide="@hideUsageHistoryBlock" asp-advanced="false">@await Html.PartialAsync("_CreateOrUpdate.History", Model)</nop-card>
                 }
 
                 @await Component.InvokeAsync(typeof(AdminWidgetViewComponent), new { widgetZone = AdminWidgetZones.GiftCardDetailsBlock, additionalData = Model })

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/_ViewImports.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/_ViewImports.cshtml
@@ -2,6 +2,7 @@
 
 @inject IGenericAttributeService genericAttributeService
 @inject INopHtmlHelper NopHtml
+@inject IPermissionService permissionService
 @inject IWorkContext workContext
 
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
@@ -19,6 +20,7 @@
 @using Nop.Core.Events
 @using Nop.Core.Infrastructure
 @using Nop.Services.Common
+@using Nop.Services.Security
 @using static Nop.Services.Common.NopLinksDefaults
 @using Nop.Web.Areas.Admin.Components
 @using Nop.Web.Areas.Admin.Models.Affiliates


### PR DESCRIPTION
Checking StandardPermission.Orders.GIFT_CARDS_CREATE_EDIT_DELETE before rendering the usage history block