### PR TITLE
Fix missing custom address attributes for billing address in admin order edit page. (Issue #7618 )

### DIFF
--- a/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
+++ b/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
@@ -13073,6 +13073,9 @@
   </LocaleResource>
   <LocaleResource Name="Admin.Orders.Address.County">
     <Value>County / region</Value>
+  </LocaleResource>  
+  <LocaleResource Name="Admin.Orders.Address.CustomAttributes">
+    <Value>Custom Attributes</Value>
   </LocaleResource>
   <LocaleResource Name="Admin.Orders.Address.EditAddress">
     <Value>Edit address</Value>

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.BillingShipping.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.BillingShipping.cshtml
@@ -180,16 +180,26 @@
                             </div>
                         </div>
                     </div>
-                </div>
 
-                @if (!string.IsNullOrEmpty(Model.BillingAddress.FormattedCustomAddressAttributes))
-                {
-                    <div class="form-group row">
-                        <div class="offset-md-3 col-md-8 custom-attributes-view">
-                            @Html.Raw(Model.BillingAddress.FormattedCustomAddressAttributes)
+                    @if (!string.IsNullOrEmpty(Model.BillingAddress.FormattedCustomAddressAttributes))
+                    {
+                        var customAttributes = Model.BillingAddress.FormattedCustomAddressAttributes;
+
+                        <div class="form-group row">
+                            <div class="col-md-4">
+                                <div class="label-wrapper">
+                                    <label class="col-form-label">@T("Admin.Orders.Address.CustomAttributes")</label>
+                                </div>
+                            </div>
+                            <div class="col-md-8">
+                                <div class="form-text-row">
+                                    @Html.Raw(customAttributes)
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                }
+                    }
+
+                </div>
 
                 @if (!Model.IsLoggedInAsVendor)
                 {
@@ -388,13 +398,21 @@
 
                             @if (!string.IsNullOrEmpty(Model.ShippingAddress.FormattedCustomAddressAttributes))
                             {
+                                var customAttributes = Model.ShippingAddress.FormattedCustomAddressAttributes;
+
                                 <div class="form-group row">
-                                    <div class="offset-md-3 col-md-8 custom-attributes-view">
-                                        @Html.Raw(Model.ShippingAddress.FormattedCustomAddressAttributes)
+                                    <div class="col-md-4">
+                                        <div class="label-wrapper">
+                                            <label class="col-form-label">@T("Admin.Orders.Address.CustomAttributes")</label>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-8">
+                                        <div class="form-text-row">
+                                            @Html.Raw(customAttributes)
+                                        </div>
                                     </div>
                                 </div>
                             }
-
 
                         </div>
 

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.BillingShipping.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.BillingShipping.cshtml
@@ -182,6 +182,15 @@
                     </div>
                 </div>
 
+                @if (!string.IsNullOrEmpty(Model.BillingAddress.FormattedCustomAddressAttributes))
+                {
+                    <div class="form-group row">
+                        <div class="offset-md-3 col-md-8 custom-attributes-view">
+                            @Html.Raw(Model.BillingAddress.FormattedCustomAddressAttributes)
+                        </div>
+                    </div>
+                }
+
                 @if (!Model.IsLoggedInAsVendor)
                 {
                     <div class="card-footer">

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.BillingShipping.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Order/_OrderDetails.BillingShipping.cshtml
@@ -183,8 +183,6 @@
 
                     @if (!string.IsNullOrEmpty(Model.BillingAddress.FormattedCustomAddressAttributes))
                     {
-                        var customAttributes = Model.BillingAddress.FormattedCustomAddressAttributes;
-
                         <div class="form-group row">
                             <div class="col-md-4">
                                 <div class="label-wrapper">
@@ -193,7 +191,7 @@
                             </div>
                             <div class="col-md-8">
                                 <div class="form-text-row">
-                                    @Html.Raw(customAttributes)
+                                    @Html.Raw(Model.BillingAddress.FormattedCustomAddressAttributes)
                                 </div>
                             </div>
                         </div>
@@ -398,8 +396,6 @@
 
                             @if (!string.IsNullOrEmpty(Model.ShippingAddress.FormattedCustomAddressAttributes))
                             {
-                                var customAttributes = Model.ShippingAddress.FormattedCustomAddressAttributes;
-
                                 <div class="form-group row">
                                     <div class="col-md-4">
                                         <div class="label-wrapper">
@@ -408,7 +404,7 @@
                                     </div>
                                     <div class="col-md-8">
                                         <div class="form-text-row">
-                                            @Html.Raw(customAttributes)
+                                            @Html.Raw(Model.ShippingAddress.FormattedCustomAddressAttributes)
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
Currently order edit page does not show custom attribute for billing address.
Updated `_OrderDetails.BillingShipping.cshtml` to ensure billing address attributes are also rendered.