### PR TITLE
refactor: removed the unused language parameter #7653

### DIFF
--- a/src/Libraries/Nop.Services/Localization/LocalizationService.cs
+++ b/src/Libraries/Nop.Services/Localization/LocalizationService.cs
@@ -79,7 +79,7 @@ public partial class LocalizationService : ILocalizationService
         return locales;
     }
 
-    protected virtual HashSet<(string name, string value)> LoadLocaleResourcesFromStream(StreamReader xmlStreamReader, string language)
+    protected virtual HashSet<(string name, string value)> LoadLocaleResourcesFromStream(StreamReader xmlStreamReader)
     {
         var result = new HashSet<(string name, string value)>();
 
@@ -517,7 +517,7 @@ public partial class LocalizationService : ILocalizationService
         var lrsToUpdateList = new List<LocaleStringResource>();
         var lrsToInsertList = new Dictionary<string, LocaleStringResource>();
 
-        foreach (var (name, value) in LoadLocaleResourcesFromStream(xmlStreamReader, language.Name))
+        foreach (var (name, value) in LoadLocaleResourcesFromStream(xmlStreamReader))
         {
             if (lsNamesList.TryGetValue(name, out var localString))
             {


### PR DESCRIPTION
### Description

This PR contains the following points
- Removed the `unused` language parameter from `LoadLocaleResourcesFromStream` method in `LocalizationService` class

Issue link: https://github.com/nopSolutions/nopCommerce/issues/7653