### PR TITLE
refactor: renamed PriceWithDiscount to PriceWithoutDiscount

### DIFF
--- a/src/Presentation/Nop.Web/Factories/ProductModelFactory.cs
+++ b/src/Presentation/Nop.Web/Factories/ProductModelFactory.cs
@@ -488,7 +488,7 @@ public partial class ProductModelFactory : IProductModelFactory
 
         if (finalPriceWithoutDiscountBase != finalPriceWithDiscountBase)
         {
-            model.PriceWithDiscount = await _priceFormatter.FormatPriceAsync(finalPriceWithDiscount);
+            model.PriceWithoutDiscount = await _priceFormatter.FormatPriceAsync(finalPriceWithDiscount);
             model.PriceWithDiscountValue = finalPriceWithDiscount;
         }
 

--- a/src/Presentation/Nop.Web/Models/Catalog/ProductPriceModel.cs
+++ b/src/Presentation/Nop.Web/Models/Catalog/ProductPriceModel.cs
@@ -35,7 +35,7 @@ public record ProductPriceModel : BaseNopModel
     /// </summary>
     public string CurrencyCode { get; set; }
     
-    public string PriceWithDiscount { get; set; }
+    public string PriceWithoutDiscount { get; set; }
     public decimal? PriceWithDiscountValue { get; set; }
 
     public bool CustomerEntersPrice { get; set; }

--- a/src/Presentation/Nop.Web/Views/Product/_ProductPrice.cshtml
+++ b/src/Presentation/Nop.Web/Views/Product/_ProductPrice.cshtml
@@ -32,7 +32,7 @@
                     <span>@Model.OldPrice</span>
                 </div>
             }
-            <div class="@if (string.IsNullOrWhiteSpace(Model.PriceWithDiscount))
+            <div class="@if (string.IsNullOrWhiteSpace(Model.PriceWithoutDiscount))
                         {
                             <text>product-price</text>
                         }
@@ -40,23 +40,23 @@
                         {
                             <text>non-discounted-price</text>
                         }">
-                @if (!string.IsNullOrWhiteSpace(Model.OldPrice) || !string.IsNullOrWhiteSpace(Model.PriceWithDiscount))
+                @if (!string.IsNullOrWhiteSpace(Model.OldPrice) || !string.IsNullOrWhiteSpace(Model.PriceWithoutDiscount))
                 {
                     @*display "Price:" label if we have old price or discounted one*@
                     <label for="price-value-@(Model.ProductId)">@T("Products.Price"):</label>
                 }
                 @*render price*@
-                <span @if (string.IsNullOrWhiteSpace(Model.PriceWithDiscount)) { <text> id="price-value-@(Model.ProductId)" class="price-value-@(Model.ProductId)" </text> }>
+                <span @if (string.IsNullOrWhiteSpace(Model.PriceWithoutDiscount)) { <text> id="price-value-@(Model.ProductId)" class="price-value-@(Model.ProductId)" </text> }>
                     @Html.Raw(Model.Price)
                 </span>
             </div>
-            if (!string.IsNullOrWhiteSpace(Model.PriceWithDiscount))
+            if (!string.IsNullOrWhiteSpace(Model.PriceWithoutDiscount))
             {
                 @*discounted price*@
                 <div class="product-price discounted-price">
                     <span>@T("Products.Price.WithDiscount"):</span>
                     <span class="price-value-@(Model.ProductId)">
-                        @Html.Raw(Model.PriceWithDiscount)
+                        @Html.Raw(Model.PriceWithoutDiscount)
                     </span>
                 </div>
             }

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Factories/ProductModelFactoryTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Factories/ProductModelFactoryTests.cs
@@ -548,7 +548,7 @@ public class ProductModelFactoryTests : WebTest
 
                         if (finalPriceWithoutDiscountBase != finalPriceWithDiscountBase)
                         {
-                            model.PriceWithDiscount = await _priceFormatter.FormatPriceAsync(finalPriceWithDiscount);
+                            model.PriceWithoutDiscount = await _priceFormatter.FormatPriceAsync(finalPriceWithDiscount);
                             model.PriceWithDiscountValue = finalPriceWithDiscount;
                         }
 


### PR DESCRIPTION
### Description

This PR contains the following points:
- Renamed the `PriceWithDiscount` to `PriceWithoutDiscount` in the `ProductPriceModel.cs` class.
-  Updated the property name in `_ProductPrice.cshtml` view.
- Updated the model property in `ProductModelFactoryTests.cs`.

Issue Link: https://github.com/nopSolutions/nopCommerce/issues/7654