### PR TITLE
Refactor constructors for improved dependency injection

### DIFF
--- a/src/Libraries/Nop.Core/Caching/SynchronizedMemoryCacheManager.cs
+++ b/src/Libraries/Nop.Core/Caching/SynchronizedMemoryCacheManager.cs
@@ -8,11 +8,9 @@ namespace Nop.Core.Caching;
 /// <remarks>
 /// This class should be registered on IoC as singleton instance
 /// </remarks>
-public partial class SynchronizedMemoryCacheManager : MemoryCacheManager
-{
-    public SynchronizedMemoryCacheManager(AppSettings appSettings,
+public partial class SynchronizedMemoryCacheManager(AppSettings appSettings,
         ISynchronizedMemoryCache memoryCache,
-        ICacheKeyManager cacheKeyManager) : base(appSettings, memoryCache, cacheKeyManager)
-    {
-    }
+        ICacheKeyManager cacheKeyManager) 
+    : MemoryCacheManager(appSettings, memoryCache, cacheKeyManager)
+{
 }

--- a/src/Libraries/Nop.Data/Migrations/UpgradeTo480/AddIndexesMigration.cs
+++ b/src/Libraries/Nop.Data/Migrations/UpgradeTo480/AddIndexesMigration.cs
@@ -6,15 +6,8 @@ using Nop.Core.Domain.Topics;
 namespace Nop.Data.Migrations.UpgradeTo480;
 
 [NopSchemaMigration("2024-11-25 00:00:00", "AddIndexesMigration for 4.80.0")]
-public class AddIndexesMigration : ForwardOnlyMigration
+public class AddIndexesMigration(INopDataProvider dataProvider) : ForwardOnlyMigration
 {
-    private readonly INopDataProvider _dataProvider;
-
-    public AddIndexesMigration(INopDataProvider dataProvider)
-    {
-        _dataProvider = dataProvider;
-    }
-
     /// <summary>
     /// Collect the UP migration expressions
     /// </summary>
@@ -30,7 +23,7 @@ public class AddIndexesMigration : ForwardOnlyMigration
         if (!Schema.Table(nameof(Order)).Index("AK_Order_OrderGuid").Exists() &&
             !Schema.Table(nameof(Order)).Constraint("AK_Order_OrderGuid").Exists())
         {
-            var orders = _dataProvider.GetTable<Order>().GroupBy(p => p.OrderGuid, p => p)
+            var orders = dataProvider.GetTable<Order>().GroupBy(p => p.OrderGuid, p => p)
                 .Where(p => p.Count() > 1)
                 .SelectMany(p => p)
                 .ToList();
@@ -40,7 +33,7 @@ public class AddIndexesMigration : ForwardOnlyMigration
                 foreach (var order in orders)
                     order.OrderGuid = Guid.NewGuid();
 
-                _dataProvider.UpdateEntities(orders);
+                dataProvider.UpdateEntities(orders);
             }
 
             Create.UniqueConstraint("AK_Order_OrderGuid")

--- a/src/Libraries/Nop.Data/Migrations/UpgradeTo480/DataMigration.cs
+++ b/src/Libraries/Nop.Data/Migrations/UpgradeTo480/DataMigration.cs
@@ -4,25 +4,18 @@ using Nop.Core.Domain.Messages;
 namespace Nop.Data.Migrations.UpgradeTo480;
 
 [NopUpdateMigration("2023-10-30 12:00:00", "4.80", UpdateMigrationType.Data)]
-public class DataMigration : Migration
+public class DataMigration(INopDataProvider dataProvider) : Migration
 {
-    private readonly INopDataProvider _dataProvider;
-
-    public DataMigration(INopDataProvider dataProvider)
-    {
-        _dataProvider = dataProvider;
-    }
-
     /// <summary>
     /// Collect the UP migration expressions
     /// </summary>
     public override void Up()
     {
         //#7108 New message template
-        if (!_dataProvider.GetTable<MessageTemplate>().Any(st => string.Compare(st.Name, MessageTemplateSystemNames.ORDER_CANCELLED_VENDOR_NOTIFICATION, StringComparison.InvariantCultureIgnoreCase) == 0))
+        if (!dataProvider.GetTable<MessageTemplate>().Any(st => string.Compare(st.Name, MessageTemplateSystemNames.ORDER_CANCELLED_VENDOR_NOTIFICATION, StringComparison.InvariantCultureIgnoreCase) == 0))
         {
-            var eaGeneral = _dataProvider.GetTable<EmailAccount>().FirstOrDefault() ?? throw new Exception("Default email account cannot be loaded");
-            _dataProvider.InsertEntity(new MessageTemplate()
+            var eaGeneral = dataProvider.GetTable<EmailAccount>().FirstOrDefault() ?? throw new Exception("Default email account cannot be loaded");
+            dataProvider.InsertEntity(new MessageTemplate()
             {
                 Name = MessageTemplateSystemNames.ORDER_CANCELLED_VENDOR_NOTIFICATION,
                 Subject = "%Store.Name%. Order #%Order.OrderNumber% cancelled",
@@ -33,10 +26,10 @@ public class DataMigration : Migration
         }
 
         //#5898
-        if (!_dataProvider.GetTable<MessageTemplate>().Any(st => string.Compare(st.Name, MessageTemplateSystemNames.QUANTITY_BELOW_VENDOR_NOTIFICATION, StringComparison.InvariantCultureIgnoreCase) == 0))
+        if (!dataProvider.GetTable<MessageTemplate>().Any(st => string.Compare(st.Name, MessageTemplateSystemNames.QUANTITY_BELOW_VENDOR_NOTIFICATION, StringComparison.InvariantCultureIgnoreCase) == 0))
         {
-            var eaGeneral = _dataProvider.GetTable<EmailAccount>().FirstOrDefault() ?? throw new Exception("Default email account cannot be loaded");
-            _dataProvider.InsertEntity(new MessageTemplate()
+            var eaGeneral = dataProvider.GetTable<EmailAccount>().FirstOrDefault() ?? throw new Exception("Default email account cannot be loaded");
+            dataProvider.InsertEntity(new MessageTemplate()
             {
                 Name = MessageTemplateSystemNames.QUANTITY_BELOW_VENDOR_NOTIFICATION,
                 Subject = "%Store.Name%. Quantity below notification. %Product.Name%\"",
@@ -46,10 +39,10 @@ public class DataMigration : Migration
             });
         }
 
-        if (!_dataProvider.GetTable<MessageTemplate>().Any(st => string.Compare(st.Name, MessageTemplateSystemNames.QUANTITY_BELOW_ATTRIBUTE_COMBINATION_VENDOR_NOTIFICATION, StringComparison.InvariantCultureIgnoreCase) == 0))
+        if (!dataProvider.GetTable<MessageTemplate>().Any(st => string.Compare(st.Name, MessageTemplateSystemNames.QUANTITY_BELOW_ATTRIBUTE_COMBINATION_VENDOR_NOTIFICATION, StringComparison.InvariantCultureIgnoreCase) == 0))
         {
-            var eaGeneral = _dataProvider.GetTable<EmailAccount>().FirstOrDefault() ?? throw new Exception("Default email account cannot be loaded");
-            _dataProvider.InsertEntity(new MessageTemplate()
+            var eaGeneral = dataProvider.GetTable<EmailAccount>().FirstOrDefault() ?? throw new Exception("Default email account cannot be loaded");
+            dataProvider.InsertEntity(new MessageTemplate()
             {
                 Name = MessageTemplateSystemNames.QUANTITY_BELOW_ATTRIBUTE_COMBINATION_VENDOR_NOTIFICATION,
                 Subject = "%Store.Name%. Quantity below notification. %Product.Name%\"",

--- a/src/Libraries/Nop.Data/Migrations/UpgradeTo490/AddIndexesMigration.cs
+++ b/src/Libraries/Nop.Data/Migrations/UpgradeTo490/AddIndexesMigration.cs
@@ -4,15 +4,8 @@ using Nop.Core.Domain.Topics;
 namespace Nop.Data.Migrations.UpgradeTo490;
 
 [NopSchemaMigration("2025-01-28 00:00:00", "AddIndexesMigration for 4.90.0")]
-public class AddIndexesMigration : ForwardOnlyMigration
+public class AddIndexesMigration(INopDataProvider dataProvider) : ForwardOnlyMigration
 {
-    private readonly INopDataProvider _dataProvider;
-
-    public AddIndexesMigration(INopDataProvider dataProvider)
-    {
-        _dataProvider = dataProvider;
-    }
-
     /// <summary>
     /// Collect the UP migration expressions
     /// </summary>

--- a/src/Libraries/Nop.Data/Migrations/UpgradeTo490/DataMigration.cs
+++ b/src/Libraries/Nop.Data/Migrations/UpgradeTo490/DataMigration.cs
@@ -5,25 +5,18 @@ using Nop.Core.Domain.Messages;
 namespace Nop.Data.Migrations.UpgradeTo490;
 
 [NopUpdateMigration("2024-12-25 00:00:00", "4.90", UpdateMigrationType.Data)]
-public class DataMigration : Migration
+public class DataMigration(INopDataProvider dataProvider) : Migration
 {
-    private readonly INopDataProvider _dataProvider;
-
-    public DataMigration(INopDataProvider dataProvider)
-    {
-        _dataProvider = dataProvider;
-    }
-
     /// <summary>
     /// Collect the UP migration expressions
     /// </summary>
     public override void Up()
     {
         //#3425
-        if (!_dataProvider.GetTable<MessageTemplate>().Any(st => string.Compare(st.Name, MessageTemplateSystemNames.ORDER_COMPLETED_STORE_OWNER_NOTIFICATION, StringComparison.InvariantCultureIgnoreCase) == 0))
+        if (!dataProvider.GetTable<MessageTemplate>().Any(st => string.Compare(st.Name, MessageTemplateSystemNames.ORDER_COMPLETED_STORE_OWNER_NOTIFICATION, StringComparison.InvariantCultureIgnoreCase) == 0))
         {
-            var eaGeneral = _dataProvider.GetTable<EmailAccount>().FirstOrDefault() ?? throw new Exception("Default email account cannot be loaded");
-            _dataProvider.InsertEntity(new MessageTemplate()
+            var eaGeneral = dataProvider.GetTable<EmailAccount>().FirstOrDefault() ?? throw new Exception("Default email account cannot be loaded");
+            dataProvider.InsertEntity(new MessageTemplate()
             {
                 Name = MessageTemplateSystemNames.ORDER_COMPLETED_STORE_OWNER_NOTIFICATION,
                 Subject = "%Store.Name%. Order #%Order.OrderNumber% completed",
@@ -33,12 +26,12 @@ public class DataMigration : Migration
             });
         }
 
-        var activityLogTypeTable = _dataProvider.GetTable<ActivityLogType>();
+        var activityLogTypeTable = dataProvider.GetTable<ActivityLogType>();
 
         //#6407
         if (!activityLogTypeTable.Any(alt => string.Compare(alt.SystemKeyword, "PublicStore.PasswordChanged", StringComparison.InvariantCultureIgnoreCase) == 0))
         {
-            _dataProvider.InsertEntity(
+            dataProvider.InsertEntity(
                 new ActivityLogType
                 {
                     SystemKeyword = "PublicStore.PasswordChanged",
@@ -53,11 +46,11 @@ public class DataMigration : Migration
             is ActivityLogType loginActivity)
         {
             loginActivity.SystemKeyword = "PublicStore.SuccessfulLogin";
-            _dataProvider.UpdateEntity(loginActivity);
+            dataProvider.UpdateEntity(loginActivity);
         }
         else
         {
-            _dataProvider.InsertEntity(
+            dataProvider.InsertEntity(
                 new ActivityLogType
                 {
                     SystemKeyword = "PublicStore.SuccessfulLogin",
@@ -69,7 +62,7 @@ public class DataMigration : Migration
 
         if (!activityLogTypeTable.Any(alt => string.Compare(alt.SystemKeyword, "PublicStore.FailedLogin", StringComparison.InvariantCultureIgnoreCase) == 0))
         {
-            _dataProvider.InsertEntity(
+            dataProvider.InsertEntity(
                 new ActivityLogType
                 {
                     SystemKeyword = "PublicStore.FailedLogin",
@@ -79,10 +72,10 @@ public class DataMigration : Migration
             );
         }
 
-        if (!_dataProvider.GetTable<MessageTemplate>().Any(st => string.Compare(st.Name, MessageTemplateSystemNames.CUSTOMER_FAILED_LOGIN_ATTEMPT_NOTIFICATION, StringComparison.InvariantCultureIgnoreCase) == 0))
+        if (!dataProvider.GetTable<MessageTemplate>().Any(st => string.Compare(st.Name, MessageTemplateSystemNames.CUSTOMER_FAILED_LOGIN_ATTEMPT_NOTIFICATION, StringComparison.InvariantCultureIgnoreCase) == 0))
         {
-            var eaGeneral = _dataProvider.GetTable<EmailAccount>().FirstOrDefault() ?? throw new Exception("Default email account cannot be loaded");
-            _dataProvider.InsertEntity(new MessageTemplate()
+            var eaGeneral = dataProvider.GetTable<EmailAccount>().FirstOrDefault() ?? throw new Exception("Default email account cannot be loaded");
+            dataProvider.InsertEntity(new MessageTemplate()
             {
                 Name = MessageTemplateSystemNames.CUSTOMER_FAILED_LOGIN_ATTEMPT_NOTIFICATION,
                 Subject = "%Store.Name%. Failed Login Attempt",

--- a/src/Plugins/Nop.Plugin.Misc.Brevo/Controllers/BrevoWebhookController.cs
+++ b/src/Plugins/Nop.Plugin.Misc.Brevo/Controllers/BrevoWebhookController.cs
@@ -3,29 +3,14 @@ using Nop.Plugin.Misc.Brevo.Services;
 
 namespace Nop.Plugin.Misc.Brevo.Controllers;
 
-public class BrevoWebhookController : Controller
+public class BrevoWebhookController(BrevoManager brevoEmailManager) : Controller
 {
-    #region Fields
-
-    private readonly BrevoManager _brevoEmailManager;
-
-    #endregion
-
-    #region Ctor
-
-    public BrevoWebhookController(BrevoManager brevoEmailManager)
-    {
-        _brevoEmailManager = brevoEmailManager;
-    }
-
-    #endregion
-
     #region Methods
 
     [HttpPost]
     public async Task<IActionResult> UnsubscribeWebHook()
     {
-        await _brevoEmailManager.HandleWebhookAsync(Request);
+        await brevoEmailManager.HandleWebhookAsync(Request);
         return Ok();
     }
 

--- a/src/Plugins/Nop.Plugin.Misc.Dynamics365/Dynamics365Plugin.cs
+++ b/src/Plugins/Nop.Plugin.Misc.Dynamics365/Dynamics365Plugin.cs
@@ -7,23 +7,8 @@ namespace Nop.Plugin.Misc.Dynamics365;
 /// <summary>
 /// Represents the Dynamics 365 helper plugin
 /// </summary>
-public class Dynamics365Plugin : BasePlugin, IMiscPlugin
+public class Dynamics365Plugin(IWebHelper webHelper) : BasePlugin, IMiscPlugin
 {
-    #region Fields
-
-    private readonly IWebHelper _webHelper;
-
-    #endregion
-
-    #region Ctor
-
-    public Dynamics365Plugin(IWebHelper webHelper)
-    {
-        _webHelper = webHelper;
-    }
-
-    #endregion
-
     #region Methods
 
     /// <summary>
@@ -31,7 +16,7 @@ public class Dynamics365Plugin : BasePlugin, IMiscPlugin
     /// </summary>
     public override string GetConfigurationPageUrl()
     {
-        return $"{_webHelper.GetStoreLocation()}Admin/Dynamics365/Configure";
+        return $"{webHelper.GetStoreLocation()}Admin/Dynamics365/Configure";
     }
 
     /// <summary>

--- a/src/Plugins/Nop.Plugin.Misc.NopMobileApp/Controllers/NopMobileAppController.cs
+++ b/src/Plugins/Nop.Plugin.Misc.NopMobileApp/Controllers/NopMobileAppController.cs
@@ -9,23 +9,8 @@ namespace Nop.Plugin.Misc.NopMobileApp.Controllers;
 [AutoValidateAntiforgeryToken]
 [AuthorizeAdmin]
 [Area(AreaNames.ADMIN)]
-public class NopMobileAppController : BasePluginController
+public class NopMobileAppController(IPermissionService permissionService) : BasePluginController
 {
-    #region Fields
-
-    private readonly IPermissionService _permissionService;
-
-    #endregion
-
-    #region Ctor 
-
-    public NopMobileAppController(IPermissionService permissionService)
-    {
-        _permissionService = permissionService;
-    }
-
-    #endregion
-
     #region Methods
 
     [CheckPermission(StandardPermission.Configuration.MANAGE_PLUGINS)]

--- a/src/Plugins/Nop.Plugin.Misc.NopMobileApp/NopMobilePlugin.cs
+++ b/src/Plugins/Nop.Plugin.Misc.NopMobileApp/NopMobilePlugin.cs
@@ -7,23 +7,8 @@ namespace Nop.Plugin.Misc.NopMobileApp;
 /// <summary>
 /// Represents the nopCommerce mobile application helper plugin
 /// </summary>
-public class NopMobilePlugin : BasePlugin, IMiscPlugin
+public class NopMobilePlugin(IWebHelper webHelper) : BasePlugin, IMiscPlugin
 {
-    #region Fields
-
-    private readonly IWebHelper _webHelper;
-
-    #endregion
-
-    #region Ctor
-
-    public NopMobilePlugin(IWebHelper webHelper)
-    {
-        _webHelper = webHelper;
-    }
-
-    #endregion
-
     #region Methods
 
     /// <summary>
@@ -31,7 +16,7 @@ public class NopMobilePlugin : BasePlugin, IMiscPlugin
     /// </summary>
     public override string GetConfigurationPageUrl()
     {
-        return $"{_webHelper.GetStoreLocation()}Admin/NopMobileApp/Configure";
+        return $"{webHelper.GetStoreLocation()}Admin/NopMobileApp/Configure";
     }
 
     /// <summary>

--- a/src/Plugins/Nop.Plugin.Misc.OmnibusDirective/OmnibusDirectivePlugin.cs
+++ b/src/Plugins/Nop.Plugin.Misc.OmnibusDirective/OmnibusDirectivePlugin.cs
@@ -8,26 +8,10 @@ namespace Nop.Plugin.Misc.OmnibusDirective;
 /// <summary>
 /// Represents EU Omnibus Directive plugin
 /// </summary>
-public class OmnibusDirectivePlugin : BasePlugin, IMiscPlugin
+public class OmnibusDirectivePlugin(IPermissionService permissionService,
+        IWebHelper webHelper) 
+    : BasePlugin, IMiscPlugin
 {
-    #region Fields
-
-    private readonly IPermissionService _permissionService;
-    private readonly IWebHelper _webHelper;
-
-    #endregion
-
-    #region Ctor
-
-    public OmnibusDirectivePlugin(IPermissionService permissionService,
-        IWebHelper webHelper)
-    {
-        _permissionService = permissionService;
-        _webHelper = webHelper;
-    }
-
-    #endregion
-
     #region Methods
 
     /// <summary>
@@ -35,7 +19,7 @@ public class OmnibusDirectivePlugin : BasePlugin, IMiscPlugin
     /// </summary>
     public override string GetConfigurationPageUrl()
     {
-        return $"{_webHelper.GetStoreLocation()}Admin/OmnibusDirective/Configure";
+        return $"{webHelper.GetStoreLocation()}Admin/OmnibusDirective/Configure";
     }
 
     /// <summary>

--- a/src/Plugins/Nop.Plugin.Misc.Omnisend/Components/CustomViewComponent.cs
+++ b/src/Plugins/Nop.Plugin.Misc.Omnisend/Components/CustomViewComponent.cs
@@ -17,51 +17,25 @@ namespace Nop.Plugin.Misc.Omnisend.Components;
 /// <summary>
 /// Represents view component to embed tracking script on pages
 /// </summary>
-public class WidgetsOmnisendViewComponent : NopViewComponent
-{
-    #region Fields
-
-    private readonly ICustomerService _customerService;
-    private readonly IGenericAttributeService _genericAttributeService;
-    private readonly INopUrlHelper _nopUrlHelper;
-    private readonly IWebHelper _webHelper;
-    private readonly IWorkContext _workContext;
-    private readonly OmnisendService _omnisendService;
-    private readonly OmnisendSettings _omnisendSettings;
-
-    #endregion
-
-    #region Ctor
-
-    public WidgetsOmnisendViewComponent(ICustomerService customerService,
+public class WidgetsOmnisendViewComponent(ICustomerService customerService,
         IGenericAttributeService genericAttributeService,
         INopUrlHelper nopUrlHelper,
         IWebHelper webHelper,
         IWorkContext workContext,
         OmnisendService omnisendService,
-        OmnisendSettings omnisendSettings)
-    {
-        _customerService = customerService;
-        _genericAttributeService = genericAttributeService;
-        _nopUrlHelper = nopUrlHelper;
-        _webHelper = webHelper;
-        _workContext = workContext;
-        _omnisendService = omnisendService;
-        _omnisendSettings = omnisendSettings;
-    }
-
-    #endregion
-
+        OmnisendSettings omnisendSettings) 
+    : NopViewComponent
+{
     #region Utilities
 
     private async Task<string> AddIdentifyContactScriptAsync(string script)
     {
-        var customer = await _workContext.GetCurrentCustomerAsync();
+        var customer = await workContext.GetCurrentCustomerAsync();
 
-        if (await _customerService.IsGuestAsync(customer))
+        if (await customerService.IsGuestAsync(customer))
             await GenerateGuestScriptAsync(customer);
 
-        var identifyContactScript = await _genericAttributeService.GetAttributeAsync<string>(customer,
+        var identifyContactScript = await genericAttributeService.GetAttributeAsync<string>(customer,
             OmnisendDefaults.IdentifyContactAttribute);
 
         if (string.IsNullOrEmpty(identifyContactScript))
@@ -69,7 +43,7 @@ public class WidgetsOmnisendViewComponent : NopViewComponent
 
         script += $"{Environment.NewLine}{identifyContactScript}";
 
-        await _genericAttributeService.SaveAttributeAsync<string>(customer,
+        await genericAttributeService.SaveAttributeAsync<string>(customer,
             OmnisendDefaults.IdentifyContactAttribute, null);
 
         return script;
@@ -77,14 +51,14 @@ public class WidgetsOmnisendViewComponent : NopViewComponent
 
     private async Task GenerateGuestScriptAsync(Customer customer)
     {
-        var customerEmail = await _genericAttributeService.GetAttributeAsync<string>(customer,
+        var customerEmail = await genericAttributeService.GetAttributeAsync<string>(customer,
             OmnisendDefaults.CustomerEmailAttribute);
 
         if (!string.IsNullOrEmpty(customerEmail))
             return;
 
         //try to get the ContactId from query parameters
-        var omnisendContactId = _webHelper.QueryString<string>(OmnisendDefaults.ContactIdQueryParamName);
+        var omnisendContactId = webHelper.QueryString<string>(OmnisendDefaults.ContactIdQueryParamName);
         if (string.IsNullOrEmpty(omnisendContactId))
             //try to get the ContactId from cookies
             Request.Cookies.TryGetValue($"{OmnisendDefaults.ContactIdQueryParamName}", out omnisendContactId);
@@ -92,23 +66,23 @@ public class WidgetsOmnisendViewComponent : NopViewComponent
         if (string.IsNullOrEmpty(omnisendContactId))
             return;
 
-        var contact = await _omnisendService.GetContactInfoAsync(omnisendContactId);
+        var contact = await omnisendService.GetContactInfoAsync(omnisendContactId);
 
         var email = contact?.Identifiers.FirstOrDefault(p => !string.IsNullOrEmpty(p.Id))?.Id;
 
         if (string.IsNullOrEmpty(email))
             return;
 
-        await _genericAttributeService.SaveAttributeAsync(customer,
+        await genericAttributeService.SaveAttributeAsync(customer,
             OmnisendDefaults.CustomerEmailAttribute, email);
 
-        if (string.IsNullOrEmpty(_omnisendSettings.IdentifyContactScript))
+        if (string.IsNullOrEmpty(omnisendSettings.IdentifyContactScript))
             return;
 
-        var identifyScript = _omnisendSettings.IdentifyContactScript.Replace(OmnisendDefaults.Email,
+        var identifyScript = omnisendSettings.IdentifyContactScript.Replace(OmnisendDefaults.Email,
             email);
 
-        await _genericAttributeService.SaveAttributeAsync(customer,
+        await genericAttributeService.SaveAttributeAsync(customer,
             OmnisendDefaults.IdentifyContactAttribute, identifyScript);
     }
 
@@ -128,23 +102,23 @@ public class WidgetsOmnisendViewComponent : NopViewComponent
     public async Task<IViewComponentResult> InvokeAsync(string widgetZone, object additionalData)
     {
         //ensure tracking is enabled
-        if (!_omnisendSettings.UseTracking || string.IsNullOrEmpty(_omnisendSettings.BrandId))
+        if (!omnisendSettings.UseTracking || string.IsNullOrEmpty(omnisendSettings.BrandId))
             return Content(string.Empty);
 
         var script = string.Empty;
 
         //prepare tracking script
-        if (!string.IsNullOrEmpty(_omnisendSettings.TrackingScript) &&
+        if (!string.IsNullOrEmpty(omnisendSettings.TrackingScript) &&
             widgetZone.Equals(PublicWidgetZones.BodyStartHtmlTagAfter, StringComparison.InvariantCultureIgnoreCase))
-            script = await AddIdentifyContactScriptAsync(_omnisendSettings.TrackingScript
-                .Replace(OmnisendDefaults.BrandId, _omnisendSettings.BrandId));
+            script = await AddIdentifyContactScriptAsync(omnisendSettings.TrackingScript
+                .Replace(OmnisendDefaults.BrandId, omnisendSettings.BrandId));
 
         //prepare product script
-        if (!string.IsNullOrEmpty(_omnisendSettings.ProductScript) &&
+        if (!string.IsNullOrEmpty(omnisendSettings.ProductScript) &&
             widgetZone.Equals(PublicWidgetZones.ProductDetailsBottom,
                 StringComparison.InvariantCultureIgnoreCase) &&
             additionalData is ProductDetailsModel productDetails)
-            script = _omnisendSettings.ProductScript
+            script = omnisendSettings.ProductScript
                 .Replace(OmnisendDefaults.ProductId, $"{productDetails.Id}")
                 .Replace(OmnisendDefaults.Sku, productDetails.Sku)
                 .Replace(OmnisendDefaults.Currency, productDetails.ProductPrice.CurrencyCode)
@@ -152,7 +126,7 @@ public class WidgetsOmnisendViewComponent : NopViewComponent
                 .Replace(OmnisendDefaults.Title, productDetails.Name)
                 .Replace(OmnisendDefaults.ImageUrl, productDetails.DefaultPictureModel.ImageUrl)
                 .Replace(OmnisendDefaults.ProductUrl,
-                    await _nopUrlHelper.RouteGenericUrlAsync<Product>(new { productDetails.SeName }, _webHelper.GetCurrentRequestProtocol()));
+                    await nopUrlHelper.RouteGenericUrlAsync<Product>(new { productDetails.SeName }, webHelper.GetCurrentRequestProtocol()));
 
         return string.IsNullOrEmpty(script)
             ? Content(string.Empty)

--- a/src/Plugins/Nop.Plugin.Misc.Omnisend/Controllers/OmnisendAdminController.cs
+++ b/src/Plugins/Nop.Plugin.Misc.Omnisend/Controllers/OmnisendAdminController.cs
@@ -14,40 +14,17 @@ namespace Nop.Plugin.Misc.Omnisend.Controllers;
 [Area(AreaNames.ADMIN)]
 [AuthorizeAdmin]
 [AutoValidateAntiforgeryToken]
-public class OmnisendAdminController : BasePluginController
-{
-    #region Fields
-
-    private readonly ILocalizationService _localizationService;
-    private readonly INotificationService _notificationService;
-    private readonly ISettingService _settingService;
-    private readonly OmnisendService _omnisendService;
-    private readonly OmnisendSettings _omnisendSettings;
-
-    #endregion
-
-    #region Ctor
-
-    public OmnisendAdminController(ILocalizationService localizationService,
+public class OmnisendAdminController(ILocalizationService localizationService,
         INotificationService notificationService,
         ISettingService settingService,
         OmnisendService omnisendService,
-        OmnisendSettings omnisendSettings)
-    {
-        _localizationService = localizationService;
-        _notificationService = notificationService;
-        _settingService = settingService;
-        _omnisendService = omnisendService;
-        _omnisendSettings = omnisendSettings;
-    }
-
-    #endregion
-
+        OmnisendSettings omnisendSettings) : BasePluginController
+{
     #region Utilities
 
     private async Task FillBatchesAsync(ConfigurationModel model)
     {
-        if (!_omnisendSettings.BatchesIds.Any())
+        if (!omnisendSettings.BatchesIds.Any())
             return;
 
         bool needBlock(BatchResponse response, string endpoint)
@@ -57,7 +34,7 @@ public class OmnisendAdminController : BasePluginController
                     StringComparison.InvariantCultureIgnoreCase);
         }
 
-        var batches = await _omnisendService.GetStoredBatchesAsync();
+        var batches = await omnisendService.GetStoredBatchesAsync();
         model.Batches = batches;
 
         model.BlockSyncContacts = model.Batches.Any(p => needBlock(p, OmnisendDefaults.ContactsEndpoint));
@@ -74,8 +51,8 @@ public class OmnisendAdminController : BasePluginController
     {
         var model = new ConfigurationModel
         {
-            ApiKey = _omnisendSettings.ApiKey,
-            UseTracking = _omnisendSettings.UseTracking
+            ApiKey = omnisendSettings.ApiKey,
+            UseTracking = omnisendSettings.UseTracking
         };
 
         await FillBatchesAsync(model);
@@ -90,29 +67,29 @@ public class OmnisendAdminController : BasePluginController
         if (!ModelState.IsValid)
             return await Configure();
 
-        if (_omnisendSettings.ApiKey != model.ApiKey || string.IsNullOrEmpty(_omnisendSettings.BrandId))
+        if (omnisendSettings.ApiKey != model.ApiKey || string.IsNullOrEmpty(omnisendSettings.BrandId))
         {
-            var brandId = await _omnisendService.GetBrandIdAsync(model.ApiKey);
+            var brandId = await omnisendService.GetBrandIdAsync(model.ApiKey);
 
             if (brandId != null)
             {
-                _omnisendSettings.ApiKey = model.ApiKey;
-                _omnisendSettings.BrandId = brandId;
+                omnisendSettings.ApiKey = model.ApiKey;
+                omnisendSettings.BrandId = brandId;
 
-                await _omnisendService.SendCustomerDataAsync();
+                await omnisendService.SendCustomerDataAsync();
             }
         }
 
         //_omnisendSettings.UseTracking = model.UseTracking;
         //recommended not to change this setting
-        _omnisendSettings.UseTracking = true;
+        omnisendSettings.UseTracking = true;
 
-        await _settingService.SaveSettingAsync(_omnisendSettings);
+        await settingService.SaveSettingAsync(omnisendSettings);
 
-        if (string.IsNullOrEmpty(_omnisendSettings.BrandId))
-            _notificationService.ErrorNotification(await _localizationService.GetResourceAsync("Plugins.Misc.Omnisend.CantGetBrandId"));
+        if (string.IsNullOrEmpty(omnisendSettings.BrandId))
+            notificationService.ErrorNotification(await localizationService.GetResourceAsync("Plugins.Misc.Omnisend.CantGetBrandId"));
         else
-            _notificationService.SuccessNotification(await _localizationService.GetResourceAsync("Admin.Plugins.Saved"));
+            notificationService.SuccessNotification(await localizationService.GetResourceAsync("Admin.Plugins.Saved"));
 
         return await Configure();
     }
@@ -121,10 +98,10 @@ public class OmnisendAdminController : BasePluginController
     [FormValueRequired("sync-contacts")]
     public async Task<IActionResult> SyncContacts()
     {
-        if (!ModelState.IsValid || string.IsNullOrEmpty(_omnisendSettings.BrandId))
+        if (!ModelState.IsValid || string.IsNullOrEmpty(omnisendSettings.BrandId))
             return await Configure();
 
-        await _omnisendService.SyncContactsAsync();
+        await omnisendService.SyncContactsAsync();
 
         return await Configure();
     }
@@ -133,11 +110,11 @@ public class OmnisendAdminController : BasePluginController
     [FormValueRequired("sync-products")]
     public async Task<IActionResult> SyncProducts()
     {
-        if (!ModelState.IsValid || string.IsNullOrEmpty(_omnisendSettings.BrandId))
+        if (!ModelState.IsValid || string.IsNullOrEmpty(omnisendSettings.BrandId))
             return await Configure();
 
-        await _omnisendService.SyncCategoriesAsync();
-        await _omnisendService.SyncProductsAsync();
+        await omnisendService.SyncCategoriesAsync();
+        await omnisendService.SyncProductsAsync();
 
         return await Configure();
     }
@@ -146,11 +123,11 @@ public class OmnisendAdminController : BasePluginController
     [FormValueRequired("sync-orders")]
     public async Task<IActionResult> SyncOrders()
     {
-        if (!ModelState.IsValid || string.IsNullOrEmpty(_omnisendSettings.BrandId))
+        if (!ModelState.IsValid || string.IsNullOrEmpty(omnisendSettings.BrandId))
             return await Configure();
 
-        await _omnisendService.SyncOrdersAsync();
-        await _omnisendService.SyncCartsAsync();
+        await omnisendService.SyncOrdersAsync();
+        await omnisendService.SyncCartsAsync();
 
         return await Configure();
     }

--- a/src/Plugins/Nop.Plugin.Misc.Omnisend/Controllers/OmnisendController.cs
+++ b/src/Plugins/Nop.Plugin.Misc.Omnisend/Controllers/OmnisendController.cs
@@ -7,48 +7,26 @@ using Nop.Web.Framework.Controllers;
 
 namespace Nop.Plugin.Misc.Omnisend.Controllers;
 
-public class OmnisendController : BasePluginController
-{
-    #region Fields
-
-    private readonly ICustomerService _customerService;
-    private readonly IGenericAttributeService _genericAttributeService;
-    private readonly IWebHelper _webHelper;
-    private readonly IWorkContext _workContext;
-    private readonly OmnisendService _omnisendService;
-
-    #endregion
-
-    #region Ctor
-
-    public OmnisendController(ICustomerService customerService,
+public class OmnisendController(ICustomerService customerService,
         IGenericAttributeService genericAttributeService,
         IWebHelper webHelper,
         IWorkContext workContext,
-        OmnisendService omnisendService)
-    {
-        _customerService = customerService;
-        _genericAttributeService = genericAttributeService;
-        _webHelper = webHelper;
-        _workContext = workContext;
-        _omnisendService = omnisendService;
-    }
-
-    #endregion
-
+        OmnisendService omnisendService) 
+    : BasePluginController
+{
     #region Methods
 
     public async Task<IActionResult> AbandonedCheckout(string cartId)
     {
-        var customer = await _workContext.GetCurrentCustomerAsync();
-        if (await _customerService.IsGuestAsync(customer))
-            return RedirectToRoute("Login", new { ReturnUrl = _webHelper.GetRawUrl(Request) });
+        var customer = await workContext.GetCurrentCustomerAsync();
+        if (await customerService.IsGuestAsync(customer))
+            return RedirectToRoute("Login", new { ReturnUrl = webHelper.GetRawUrl(Request) });
 
-        var customerEmail = await _genericAttributeService.GetAttributeAsync<string>(customer, OmnisendDefaults.CustomerEmailAttribute);
+        var customerEmail = await genericAttributeService.GetAttributeAsync<string>(customer, OmnisendDefaults.CustomerEmailAttribute);
         if (!string.IsNullOrEmpty(customerEmail) && !customerEmail.Equals(customer.Email, StringComparison.InvariantCultureIgnoreCase))
-            return RedirectToRoute("Login", new { ReturnUrl = _webHelper.GetRawUrl(Request) });
+            return RedirectToRoute("Login", new { ReturnUrl = webHelper.GetRawUrl(Request) });
 
-        await _omnisendService.RestoreShoppingCartAsync(cartId);
+        await omnisendService.RestoreShoppingCartAsync(cartId);
 
         return RedirectToRoute("ShoppingCart");
     }

--- a/src/Plugins/Nop.Plugin.Misc.Omnisend/OmnisendPlugin.cs
+++ b/src/Plugins/Nop.Plugin.Misc.Omnisend/OmnisendPlugin.cs
@@ -16,35 +16,12 @@ namespace Nop.Plugin.Misc.Omnisend;
 /// <summary>
 /// Represents Omnisend plugin
 /// </summary>
-public class OmnisendPlugin : BasePlugin, IMiscPlugin, IWidgetPlugin
-{
-    #region Fields
-
-    private readonly IActionContextAccessor _actionContextAccessor;
-    private readonly ILocalizationService _localizationService;
-    private readonly ISettingService _settingService;
-    private readonly IUrlHelperFactory _urlHelperFactory;
-    private readonly WidgetSettings _widgetSettings;
-
-    #endregion
-
-    #region Ctor
-
-    public OmnisendPlugin(IActionContextAccessor actionContextAccessor,
+public class OmnisendPlugin(IActionContextAccessor actionContextAccessor,
         ILocalizationService localizationService,
         ISettingService settingService,
         IUrlHelperFactory urlHelperFactory,
-        WidgetSettings widgetSettings)
-    {
-        _actionContextAccessor = actionContextAccessor;
-        _localizationService = localizationService;
-        _settingService = settingService;
-        _urlHelperFactory = urlHelperFactory;
-        _widgetSettings = widgetSettings;
-    }
-
-    #endregion
-
+        WidgetSettings widgetSettings) : BasePlugin, IMiscPlugin, IWidgetPlugin
+{
     #region Methods
 
     /// <summary>
@@ -52,8 +29,8 @@ public class OmnisendPlugin : BasePlugin, IMiscPlugin, IWidgetPlugin
     /// </summary>
     public override string GetConfigurationPageUrl()
     {
-        if (_actionContextAccessor.ActionContext != null)
-            return _urlHelperFactory.GetUrlHelper(_actionContextAccessor.ActionContext)
+        if (actionContextAccessor.ActionContext != null)
+            return urlHelperFactory.GetUrlHelper(actionContextAccessor.ActionContext)
                 .RouteUrl(OmnisendDefaults.ConfigurationRouteName);
 
         return base.GetConfigurationPageUrl();
@@ -93,7 +70,7 @@ public class OmnisendPlugin : BasePlugin, IMiscPlugin, IWidgetPlugin
     public override async Task InstallAsync()
     {
         //ensure MediaSettings.UseAbsoluteImagePath is enabled (used for images uploading)
-        await _settingService.SetSettingAsync($"{nameof(MediaSettings)}.{nameof(MediaSettings.UseAbsoluteImagePath)}", true, clearCache: false);
+        await settingService.SetSettingAsync($"{nameof(MediaSettings)}.{nameof(MediaSettings.UseAbsoluteImagePath)}", true, clearCache: false);
 
         var omnisendTrackingScript =
             @$"<!-- Omnisend starts -->
@@ -138,15 +115,15 @@ public class OmnisendPlugin : BasePlugin, IMiscPlugin, IWidgetPlugin
             RequestTimeout = OmnisendDefaults.RequestTimeout
         };
 
-        await _settingService.SaveSettingAsync(settings);
+        await settingService.SaveSettingAsync(settings);
 
-        if (!_widgetSettings.ActiveWidgetSystemNames.Contains(OmnisendDefaults.SystemName))
+        if (!widgetSettings.ActiveWidgetSystemNames.Contains(OmnisendDefaults.SystemName))
         {
-            _widgetSettings.ActiveWidgetSystemNames.Add(OmnisendDefaults.SystemName);
-            await _settingService.SaveSettingAsync(_widgetSettings);
+            widgetSettings.ActiveWidgetSystemNames.Add(OmnisendDefaults.SystemName);
+            await settingService.SaveSettingAsync(widgetSettings);
         }
 
-        await _localizationService.AddOrUpdateLocaleResourceAsync(new Dictionary<string, string>
+        await localizationService.AddOrUpdateLocaleResourceAsync(new Dictionary<string, string>
         {
             ["Plugins.Misc.Omnisend.CantGetBrandId"] = "Failed to get the required data from the Omnisend server. Please check if the API key is correct and save the settings again. Error details can be found in the Log page",
             ["Plugins.Misc.Omnisend.Credentials"] = "Credentials",
@@ -179,14 +156,14 @@ public class OmnisendPlugin : BasePlugin, IMiscPlugin, IWidgetPlugin
     /// <returns>A task that represents the asynchronous operation</returns>
     public override async Task UninstallAsync()
     {
-        if (_widgetSettings.ActiveWidgetSystemNames.Contains(OmnisendDefaults.SystemName))
+        if (widgetSettings.ActiveWidgetSystemNames.Contains(OmnisendDefaults.SystemName))
         {
-            _widgetSettings.ActiveWidgetSystemNames.Remove(OmnisendDefaults.SystemName);
-            await _settingService.SaveSettingAsync(_widgetSettings);
+            widgetSettings.ActiveWidgetSystemNames.Remove(OmnisendDefaults.SystemName);
+            await settingService.SaveSettingAsync(widgetSettings);
         }
-        await _settingService.DeleteSettingAsync<OmnisendSettings>();
+        await settingService.DeleteSettingAsync<OmnisendSettings>();
 
-        await _localizationService.DeleteLocaleResourcesAsync("Plugins.Misc.Omnisend");
+        await localizationService.DeleteLocaleResourcesAsync("Plugins.Misc.Omnisend");
 
         await base.UninstallAsync();
     }

--- a/src/Plugins/Nop.Plugin.Misc.Omnisend/Services/OmnisendCustomerService.cs
+++ b/src/Plugins/Nop.Plugin.Misc.Omnisend/Services/OmnisendCustomerService.cs
@@ -13,38 +13,13 @@ namespace Nop.Plugin.Misc.Omnisend.Services;
 /// <summary>
 /// Represents the helper class for customer
 /// </summary>
-public class OmnisendCustomerService
-{
-    #region Fields
-
-    private readonly IActionContextAccessor _actionContextAccessor;
-    private readonly IAddressService _addressService;
-    private readonly IGenericAttributeService _genericAttributeService;
-    private readonly IUrlHelperFactory _urlHelperFactory;
-    private readonly IWebHelper _webHelper;
-    private readonly OmnisendHttpClient _httpClient;
-
-    #endregion
-
-    #region Ctor
-
-    public OmnisendCustomerService(IActionContextAccessor actionContextAccessor,
+public class OmnisendCustomerService(IActionContextAccessor actionContextAccessor,
         IAddressService addressService,
         IGenericAttributeService genericAttributeService,
         IUrlHelperFactory urlHelperFactory,
         IWebHelper webHelper,
         OmnisendHttpClient httpClient)
-    {
-        _actionContextAccessor = actionContextAccessor;
-        _addressService = addressService;
-        _genericAttributeService = genericAttributeService;
-        _urlHelperFactory = urlHelperFactory;
-        _webHelper = webHelper;
-        _httpClient = httpClient;
-    }
-
-    #endregion
-
+{
     #region Methods
 
     /// <summary>
@@ -53,11 +28,11 @@ public class OmnisendCustomerService
     /// <param name="customer">Customer</param>
     public async Task<string> GetCartIdAsync(Customer customer)
     {
-        var cartId = await _genericAttributeService.GetAttributeAsync<string>(customer,
+        var cartId = await genericAttributeService.GetAttributeAsync<string>(customer,
             OmnisendDefaults.StoredCustomerShoppingCartIdAttribute);
 
         cartId = string.IsNullOrEmpty(cartId)
-            ? await _genericAttributeService.GetAttributeAsync<string>(customer,
+            ? await genericAttributeService.GetAttributeAsync<string>(customer,
                 OmnisendDefaults.CurrentCustomerShoppingCartIdAttribute)
             : cartId;
 
@@ -66,7 +41,7 @@ public class OmnisendCustomerService
 
         cartId = Guid.NewGuid().ToString();
 
-        await _genericAttributeService.SaveAttributeAsync(customer,
+        await genericAttributeService.SaveAttributeAsync(customer,
             OmnisendDefaults.CurrentCustomerShoppingCartIdAttribute, cartId);
 
         return cartId;
@@ -81,12 +56,12 @@ public class OmnisendCustomerService
     {
         var email = !string.IsNullOrEmpty(customer.Email)
             ? customer.Email
-            : await _genericAttributeService.GetAttributeAsync<string>(customer,
+            : await genericAttributeService.GetAttributeAsync<string>(customer,
                 OmnisendDefaults.CustomerEmailAttribute);
 
         return !string.IsNullOrEmpty(email)
             ? email
-            : (await _addressService.GetAddressByIdAsync((billingAddressId ?? customer.BillingAddressId) ?? 0))
+            : (await addressService.GetAddressByIdAsync((billingAddressId ?? customer.BillingAddressId) ?? 0))
             ?.Email;
     }
 
@@ -119,7 +94,7 @@ public class OmnisendCustomerService
     {
         var url = $"{OmnisendDefaults.ContactsApiUrl}?email={email}&limit=1";
 
-        var res = await _httpClient.PerformRequestAsync(url, httpMethod: HttpMethod.Get);
+        var res = await httpClient.PerformRequestAsync(url, httpMethod: HttpMethod.Get);
 
         if (string.IsNullOrEmpty(res))
             return null;
@@ -137,11 +112,11 @@ public class OmnisendCustomerService
     /// <param name="customer">Customer</param>
     public async Task StoreCartIdAsync(Customer customer)
     {
-        var cartId = await _genericAttributeService.GetAttributeAsync<string>(customer,
+        var cartId = await genericAttributeService.GetAttributeAsync<string>(customer,
             OmnisendDefaults.StoredCustomerShoppingCartIdAttribute);
 
         if (string.IsNullOrEmpty(cartId))
-            await _genericAttributeService.SaveAttributeAsync(customer,
+            await genericAttributeService.SaveAttributeAsync(customer,
                 OmnisendDefaults.StoredCustomerShoppingCartIdAttribute, await GetCartIdAsync(customer));
     }
 
@@ -151,7 +126,7 @@ public class OmnisendCustomerService
     /// <param name="customer">Customer</param>
     public async Task DeleteCurrentCustomerShoppingCartIdAsync(Customer customer)
     {
-        await _genericAttributeService.SaveAttributeAsync<string>(customer,
+        await genericAttributeService.SaveAttributeAsync<string>(customer,
             OmnisendDefaults.CurrentCustomerShoppingCartIdAttribute, null);
     }
 
@@ -164,7 +139,7 @@ public class OmnisendCustomerService
     /// The task result contains the True if we need to sand delete events</returns>
     public async Task<bool> IsNeedToSendDeleteShoppingCartEventAsync(Customer customer)
     {
-        return string.IsNullOrEmpty(await _genericAttributeService.GetAttributeAsync<string>(customer,
+        return string.IsNullOrEmpty(await genericAttributeService.GetAttributeAsync<string>(customer,
             OmnisendDefaults.StoredCustomerShoppingCartIdAttribute));
     }
 
@@ -174,7 +149,7 @@ public class OmnisendCustomerService
     /// <param name="customer">Customer</param>
     public async Task DeleteStoredCustomerShoppingCartIdAsync(Customer customer)
     {
-        await _genericAttributeService.SaveAttributeAsync<string>(customer,
+        await genericAttributeService.SaveAttributeAsync<string>(customer,
             OmnisendDefaults.StoredCustomerShoppingCartIdAttribute, null);
     }
 
@@ -185,11 +160,11 @@ public class OmnisendCustomerService
     /// <returns>The abandoned checkout url</returns>
     public string GetAbandonedCheckoutUrl(string cartId)
     {
-        if (_actionContextAccessor.ActionContext == null)
+        if (actionContextAccessor.ActionContext == null)
             return null;
 
-        return _urlHelperFactory.GetUrlHelper(_actionContextAccessor.ActionContext)
-            .RouteUrl(OmnisendDefaults.AbandonedCheckoutRouteName, new { cartId }, _webHelper.GetCurrentRequestProtocol());
+        return urlHelperFactory.GetUrlHelper(actionContextAccessor.ActionContext)
+            .RouteUrl(OmnisendDefaults.AbandonedCheckoutRouteName, new { cartId }, webHelper.GetCurrentRequestProtocol());
     }
 
     #endregion

--- a/src/Plugins/Nop.Plugin.Misc.Omnisend/Services/OmnisendEventsService.cs
+++ b/src/Plugins/Nop.Plugin.Misc.Omnisend/Services/OmnisendEventsService.cs
@@ -27,43 +27,7 @@ namespace Nop.Plugin.Misc.Omnisend.Services;
 /// <summary>
 /// Events based Platform integration service
 /// </summary>
-public class OmnisendEventsService
-{
-    #region Fields
-
-    private readonly IActionContextAccessor _actionContextAccessor;
-    private readonly IAddressService _addressService;
-    private readonly ICategoryService _categoryService;
-    private readonly ICountryService _countryService;
-    private readonly ICustomerService _customerService;
-    private readonly IDiscountService _discountService;
-    private readonly IGenericAttributeService _genericAttributeService;
-    private readonly ILocalizationService _localizationService;
-    private readonly IManufacturerService _manufacturerService;
-    private readonly IMeasureService _measureService;
-    private readonly IOrderService _orderService;
-    private readonly IOrderTotalCalculationService _orderTotalCalculationService;
-    private readonly IPaymentPluginManager _paymentPluginManager;
-    private readonly IPictureService _pictureService;
-    private readonly IProductService _productService;
-    private readonly IProductTagService _productTagService;
-    private readonly IShipmentService _shipmentService;
-    private readonly IShoppingCartService _shoppingCartService;
-    private readonly IStateProvinceService _stateProvinceService;
-    private readonly IStoreContext _storeContext;
-    private readonly ITaxService _taxService;
-    private readonly IUrlHelperFactory _urlHelperFactory;
-    private readonly IWebHelper _webHelper;
-    private readonly IWorkContext _workContext;
-    private readonly OmnisendCustomerService _omnisendCustomerService;
-    private readonly OmnisendHelper _omnisendHelper;
-    private readonly OmnisendHttpClient _omnisendHttpClient;
-
-    #endregion
-
-    #region Ctor
-
-    public OmnisendEventsService(IActionContextAccessor actionContextAccessor,
+public class OmnisendEventsService(IActionContextAccessor actionContextAccessor,
         IAddressService addressService,
         ICategoryService categoryService,
         ICountryService countryService,
@@ -90,38 +54,7 @@ public class OmnisendEventsService
         OmnisendCustomerService omnisendCustomerService,
         OmnisendHelper omnisendHelper,
         OmnisendHttpClient omnisendHttpClient)
-    {
-        _actionContextAccessor = actionContextAccessor;
-        _addressService = addressService;
-        _categoryService = categoryService;
-        _countryService = countryService;
-        _customerService = customerService;
-        _discountService = discountService;
-        _genericAttributeService = genericAttributeService;
-        _localizationService = localizationService;
-        _manufacturerService = manufacturerService;
-        _measureService = measureService;
-        _orderService = orderService;
-        _orderTotalCalculationService = orderTotalCalculationService;
-        _paymentPluginManager = paymentPluginManager;
-        _pictureService = pictureService;
-        _productService = productService;
-        _productTagService = productTagService;
-        _shipmentService = shipmentService;
-        _shoppingCartService = shoppingCartService;
-        _stateProvinceService = stateProvinceService;
-        _storeContext = storeContext;
-        _taxService = taxService;
-        _urlHelperFactory = urlHelperFactory;
-        _webHelper = webHelper;
-        _workContext = workContext;
-        _omnisendCustomerService = omnisendCustomerService;
-        _omnisendHelper = omnisendHelper;
-        _omnisendHttpClient = omnisendHttpClient;
-    }
-
-    #endregion
-
+{
     #region Utilities
 
     private async Task SendEventAsync(CustomerEvents customerEvent)
@@ -130,14 +63,14 @@ public class OmnisendEventsService
             return;
 
         var data = JsonConvert.SerializeObject(customerEvent);
-        await _omnisendHttpClient.PerformRequestAsync(OmnisendDefaults.CustomerEventsApiUrl, data, HttpMethod.Post);
+        await omnisendHttpClient.PerformRequestAsync(OmnisendDefaults.CustomerEventsApiUrl, data, HttpMethod.Post);
     }
 
     private async Task<CustomerEvents> CreateAddedProductToCartEventAsync(ShoppingCartItem shoppingCartItem)
     {
-        var customer = await _customerService.GetCustomerByIdAsync(shoppingCartItem.CustomerId);
+        var customer = await customerService.GetCustomerByIdAsync(shoppingCartItem.CustomerId);
 
-        var customerEvent = await _omnisendCustomerService.CreateCustomerEventAsync(customer,
+        var customerEvent = await omnisendCustomerService.CreateCustomerEventAsync(customer,
             await PrepareAddedProductToCartPropertyAsync(shoppingCartItem));
 
         return customerEvent;
@@ -145,9 +78,9 @@ public class OmnisendEventsService
 
     private async Task<CustomerEvents> CreateStartedCheckoutEventAsync()
     {
-        var customer = await _workContext.GetCurrentCustomerAsync();
+        var customer = await workContext.GetCurrentCustomerAsync();
         var customerEvent =
-            await _omnisendCustomerService.CreateCustomerEventAsync(customer,
+            await omnisendCustomerService.CreateCustomerEventAsync(customer,
                 await PrepareStartedCheckoutPropertyAsync(customer));
 
         return customerEvent;
@@ -155,10 +88,10 @@ public class OmnisendEventsService
 
     private async Task<CustomerEvents> CreateOrderPlacedEventAsync(Order order)
     {
-        var customer = await _customerService.GetCustomerByIdAsync(order.CustomerId);
+        var customer = await customerService.GetCustomerByIdAsync(order.CustomerId);
 
         var customerEvent =
-            await _omnisendCustomerService.CreateCustomerEventAsync(customer,
+            await omnisendCustomerService.CreateCustomerEventAsync(customer,
                 await PreparePlacedOrderPropertyAsync(order));
 
         return customerEvent;
@@ -166,10 +99,10 @@ public class OmnisendEventsService
 
     private async Task<CustomerEvents> CreateOrderPaidEventAsync(Order order)
     {
-        var customer = await _customerService.GetCustomerByIdAsync(order.CustomerId);
+        var customer = await customerService.GetCustomerByIdAsync(order.CustomerId);
 
         var customerEvent =
-            await _omnisendCustomerService.CreateCustomerEventAsync(customer,
+            await omnisendCustomerService.CreateCustomerEventAsync(customer,
                 await PreparePlacedPaidPropertyAsync(order));
 
         return customerEvent;
@@ -177,10 +110,10 @@ public class OmnisendEventsService
 
     private async Task<CustomerEvents> CreateOrderCanceledEventAsync(Order order)
     {
-        var customer = await _customerService.GetCustomerByIdAsync(order.CustomerId);
+        var customer = await customerService.GetCustomerByIdAsync(order.CustomerId);
 
         var customerEvent =
-            await _omnisendCustomerService.CreateCustomerEventAsync(customer,
+            await omnisendCustomerService.CreateCustomerEventAsync(customer,
                 await PrepareOrderCanceledPropertyAsync(order));
 
         return customerEvent;
@@ -188,10 +121,10 @@ public class OmnisendEventsService
 
     private async Task<CustomerEvents> CreateOrderFulfilledEventAsync(Order order)
     {
-        var customer = await _customerService.GetCustomerByIdAsync(order.CustomerId);
+        var customer = await customerService.GetCustomerByIdAsync(order.CustomerId);
 
         var customerEvent =
-            await _omnisendCustomerService.CreateCustomerEventAsync(customer,
+            await omnisendCustomerService.CreateCustomerEventAsync(customer,
                 await PrepareOrderFulfilledPropertyAsync(order));
 
         return customerEvent;
@@ -199,10 +132,10 @@ public class OmnisendEventsService
 
     private async Task<CustomerEvents> CreateOrderRefundedEventAsync(Order order)
     {
-        var customer = await _customerService.GetCustomerByIdAsync(order.CustomerId);
+        var customer = await customerService.GetCustomerByIdAsync(order.CustomerId);
 
         var customerEvent =
-            await _omnisendCustomerService.CreateCustomerEventAsync(customer,
+            await omnisendCustomerService.CreateCustomerEventAsync(customer,
                 await PrepareOrderRefundedPropertyAsync(order));
 
         return customerEvent;
@@ -211,17 +144,17 @@ public class OmnisendEventsService
     private async Task<AddedProductToCartProperty> PrepareAddedProductToCartPropertyAsync(
         ShoppingCartItem shoppingCartItem)
     {
-        var customer = await _customerService.GetCustomerByIdAsync(shoppingCartItem.CustomerId);
-        var cart = await _shoppingCartService.GetShoppingCartAsync(customer, ShoppingCartType.ShoppingCart,
+        var customer = await customerService.GetCustomerByIdAsync(shoppingCartItem.CustomerId);
+        var cart = await shoppingCartService.GetShoppingCartAsync(customer, ShoppingCartType.ShoppingCart,
             shoppingCartItem.StoreId);
 
-        var cartId = await _omnisendCustomerService.GetCartIdAsync(customer);
+        var cartId = await omnisendCustomerService.GetCartIdAsync(customer);
 
         var property = new AddedProductToCartProperty
         {
-            AbandonedCheckoutURL = _omnisendCustomerService.GetAbandonedCheckoutUrl(cartId),
+            AbandonedCheckoutURL = omnisendCustomerService.GetAbandonedCheckoutUrl(cartId),
             CartId = cartId,
-            Currency = await _omnisendHelper.GetPrimaryStoreCurrencyCodeAsync(),
+            Currency = await omnisendHelper.GetPrimaryStoreCurrencyCodeAsync(),
             LineItems =
                 await cart.SelectAwait(async sci => await ShoppingCartItemToProductItemAsync(sci))
                     .ToListAsync(),
@@ -234,17 +167,17 @@ public class OmnisendEventsService
 
     private async Task<StartedCheckoutProperty> PrepareStartedCheckoutPropertyAsync(Customer customer)
     {
-        var store = await _storeContext.GetCurrentStoreAsync();
-        var cart = await _shoppingCartService.GetShoppingCartAsync(customer, ShoppingCartType.ShoppingCart, store.Id);
+        var store = await storeContext.GetCurrentStoreAsync();
+        var cart = await shoppingCartService.GetShoppingCartAsync(customer, ShoppingCartType.ShoppingCart, store.Id);
 
-        var cartSum = (await _orderTotalCalculationService.GetShoppingCartTotalAsync(cart)).shoppingCartTotal ?? 0;
-        var cartId = await _omnisendCustomerService.GetCartIdAsync(customer);
+        var cartSum = (await orderTotalCalculationService.GetShoppingCartTotalAsync(cart)).shoppingCartTotal ?? 0;
+        var cartId = await omnisendCustomerService.GetCartIdAsync(customer);
 
         var property = new StartedCheckoutProperty
         {
-            AbandonedCheckoutURL = _omnisendCustomerService.GetAbandonedCheckoutUrl(cartId),
+            AbandonedCheckoutURL = omnisendCustomerService.GetAbandonedCheckoutUrl(cartId),
             CartId = cartId,
-            Currency = await _omnisendHelper.GetPrimaryStoreCurrencyCodeAsync(),
+            Currency = await omnisendHelper.GetPrimaryStoreCurrencyCodeAsync(),
             LineItems = await cart.SelectAwait(async sci => await ShoppingCartItemToProductItemAsync(sci))
                 .ToListAsync(),
             Value = (float)cartSum
@@ -297,13 +230,13 @@ public class OmnisendEventsService
 
     private async Task<ProductItem> ShoppingCartItemToProductItemAsync(ShoppingCartItem shoppingCartItem)
     {
-        var product = await _productService.GetProductByIdAsync(shoppingCartItem.ProductId);
+        var product = await productService.GetProductByIdAsync(shoppingCartItem.ProductId);
 
         var (sku, variantId) =
-            await _omnisendHelper.GetSkuAndVariantIdAsync(product, shoppingCartItem.AttributesXml);
+            await omnisendHelper.GetSkuAndVariantIdAsync(product, shoppingCartItem.AttributesXml);
         var (price, discount) = await GetShoppingCartItemPriceAsync(shoppingCartItem);
-        var picture = await _pictureService.GetProductPictureAsync(product, shoppingCartItem.AttributesXml);
-        var (pictureUrl, _) = await _pictureService.GetPictureUrlAsync(picture);
+        var picture = await pictureService.GetProductPictureAsync(product, shoppingCartItem.AttributesXml);
+        var (pictureUrl, _) = await pictureService.GetPictureUrlAsync(picture);
 
         var productItem = new ProductItem
         {
@@ -317,7 +250,7 @@ public class OmnisendEventsService
             ProductSku = sku,
             ProductStrikeThroughPrice = (float)product.OldPrice,
             ProductTitle = product.Name,
-            ProductURL = await _omnisendHelper.GetProductUrlAsync(product),
+            ProductURL = await omnisendHelper.GetProductUrlAsync(product),
             ProductVariantId = variantId,
             ProductVariantImageURL = pictureUrl
         };
@@ -327,21 +260,21 @@ public class OmnisendEventsService
 
     private async Task FillOrderEventBaseAsync(OrderEventBaseProperty property, Order order)
     {
-        var urlHelper = _urlHelperFactory.GetUrlHelper(_actionContextAccessor.ActionContext);
+        var urlHelper = urlHelperFactory.GetUrlHelper(actionContextAccessor.ActionContext);
 
-        var items = await _orderService.GetOrderItemsAsync(order.Id);
-        var appliedDiscounts = await _discountService.GetAllDiscountUsageHistoryAsync(orderId: order.Id);
+        var items = await orderService.GetOrderItemsAsync(order.Id);
+        var appliedDiscounts = await discountService.GetAllDiscountUsageHistoryAsync(orderId: order.Id);
 
-        var paymentMethodName = await _paymentPluginManager.LoadPluginBySystemNameAsync(order.PaymentMethodSystemName) is { } plugin
-            ? await _localizationService.GetLocalizedFriendlyNameAsync(plugin, order.CustomerLanguageId)
+        var paymentMethodName = await paymentPluginManager.LoadPluginBySystemNameAsync(order.PaymentMethodSystemName) is { } plugin
+            ? await localizationService.GetLocalizedFriendlyNameAsync(plugin, order.CustomerLanguageId)
             : order.PaymentMethodSystemName;
 
         property.BillingAddress = await GetAddressItemDataAsync(order.BillingAddressId);
         property.CreatedAt = order.CreatedOnUtc.ToDtoString();
-        property.Currency = await _omnisendHelper.GetPrimaryStoreCurrencyCodeAsync();
+        property.Currency = await omnisendHelper.GetPrimaryStoreCurrencyCodeAsync();
         property.Discounts = await appliedDiscounts.SelectAwait(async duh =>
         {
-            var discount = await _discountService.GetDiscountByIdAsync(duh.DiscountId);
+            var discount = await discountService.GetDiscountByIdAsync(duh.DiscountId);
 
             return new DiscountItem
             {
@@ -356,7 +289,7 @@ public class OmnisendEventsService
         property.Note = null;
         property.OrderId = order.CustomOrderNumber;
         property.OrderNumber = order.Id;
-        property.OrderStatusURL = urlHelper.RouteUrl("OrderDetails", new { orderId = order.Id }, _webHelper.GetCurrentRequestProtocol());
+        property.OrderStatusURL = urlHelper.RouteUrl("OrderDetails", new { orderId = order.Id }, webHelper.GetCurrentRequestProtocol());
         property.PaymentMethod = paymentMethodName;
         property.PaymentStatus = order.PaymentStatus.ToString();
         property.ShippingAddress = await GetAddressItemDataAsync(order.ShippingAddressId);
@@ -369,8 +302,8 @@ public class OmnisendEventsService
         property.TotalPrice = (float)order.OrderTotal;
         property.TotalTax = (float)order.OrderTax;
 
-        if ((await _shipmentService.GetShipmentsByOrderIdAsync(order.Id)).LastOrDefault() is { } shipment &&
-            await _shipmentService.GetShipmentTrackerAsync(shipment) is { } shipmentTracker)
+        if ((await shipmentService.GetShipmentsByOrderIdAsync(order.Id)).LastOrDefault() is { } shipment &&
+            await shipmentService.GetShipmentTrackerAsync(shipment) is { } shipmentTracker)
             property.Tracking = new TrackingItem
             {
                 Code = shipment.TrackingNumber,
@@ -380,19 +313,19 @@ public class OmnisendEventsService
 
     private async Task<OrderProductItem> OrderItemToProductItemAsync(OrderItem orderItem)
     {
-        var product = await _productService.GetProductByIdAsync(orderItem.ProductId);
+        var product = await productService.GetProductByIdAsync(orderItem.ProductId);
 
-        var (sku, variantId) = await _omnisendHelper.GetSkuAndVariantIdAsync(product, orderItem.AttributesXml);
+        var (sku, variantId) = await omnisendHelper.GetSkuAndVariantIdAsync(product, orderItem.AttributesXml);
 
-        var picture = await _pictureService.GetProductPictureAsync(product, orderItem.AttributesXml);
-        var (pictureUrl, _) = await _pictureService.GetPictureUrlAsync(picture);
+        var picture = await pictureService.GetProductPictureAsync(product, orderItem.AttributesXml);
+        var (pictureUrl, _) = await pictureService.GetPictureUrlAsync(picture);
 
-        var productManufacturer = (await _manufacturerService.GetProductManufacturersByProductIdAsync(orderItem.ProductId)).FirstOrDefault();
-        var manufacturer = await _manufacturerService.GetManufacturerByIdAsync(productManufacturer?.ManufacturerId ?? 0);
-        var productsTags = await _productTagService.GetAllProductTagsByProductIdAsync(product.Id);
+        var productManufacturer = (await manufacturerService.GetProductManufacturersByProductIdAsync(orderItem.ProductId)).FirstOrDefault();
+        var manufacturer = await manufacturerService.GetManufacturerByIdAsync(productManufacturer?.ManufacturerId ?? 0);
+        var productsTags = await productTagService.GetAllProductTagsByProductIdAsync(product.Id);
 
-        var weight = await _measureService.GetMeasureWeightBySystemKeywordAsync("grams") is { } measureWeight
-            ? await _measureService.ConvertFromPrimaryMeasureWeightAsync(orderItem.ItemWeight ?? 0, measureWeight)
+        var weight = await measureService.GetMeasureWeightBySystemKeywordAsync("grams") is { } measureWeight
+            ? await measureService.ConvertFromPrimaryMeasureWeightAsync(orderItem.ItemWeight ?? 0, measureWeight)
             : 0;
 
         float discount = 0;
@@ -413,7 +346,7 @@ public class OmnisendEventsService
             ProductStrikeThroughPrice = (float)product.OldPrice,
             ProductTags = productsTags.Select(tag => tag.Name).ToList(),
             ProductTitle = product.Name,
-            ProductURL = await _omnisendHelper.GetProductUrlAsync(product),
+            ProductURL = await omnisendHelper.GetProductUrlAsync(product),
             ProductVariantId = variantId,
             ProductVariantImageURL = pictureUrl,
             ProductVendor = manufacturer?.Name,
@@ -425,13 +358,13 @@ public class OmnisendEventsService
 
     private async Task<AddressItem> GetAddressItemDataAsync(int? addressId)
     {
-        var address = await _addressService.GetAddressByIdAsync(addressId ?? 0);
+        var address = await addressService.GetAddressByIdAsync(addressId ?? 0);
 
         if (address == null)
             return null;
 
-        var country = await _countryService.GetCountryByIdAsync(address.CountryId ?? 0);
-        var state = await _stateProvinceService.GetStateProvinceByIdAsync(address.StateProvinceId ?? 0);
+        var country = await countryService.GetCountryByIdAsync(address.CountryId ?? 0);
+        var state = await stateProvinceService.GetStateProvinceByIdAsync(address.StateProvinceId ?? 0);
 
         return new AddressItem
         {
@@ -453,24 +386,24 @@ public class OmnisendEventsService
     private async Task<(float price, float discountAmount)> GetShoppingCartItemPriceAsync(
         ShoppingCartItem shoppingCartItem)
     {
-        var customer = await _customerService.GetCustomerByIdAsync(shoppingCartItem.CustomerId);
-        var product = await _productService.GetProductByIdAsync(shoppingCartItem.ProductId);
+        var customer = await customerService.GetCustomerByIdAsync(shoppingCartItem.CustomerId);
+        var product = await productService.GetProductByIdAsync(shoppingCartItem.ProductId);
 
         var (scSubTotal, discountAmount, _, _) =
-            await _shoppingCartService.GetSubTotalAsync(shoppingCartItem, true);
-        var price = (float)(await _taxService.GetProductPriceAsync(product, scSubTotal, true, customer)).price;
+            await shoppingCartService.GetSubTotalAsync(shoppingCartItem, true);
+        var price = (float)(await taxService.GetProductPriceAsync(product, scSubTotal, true, customer)).price;
 
         return (price, (float)discountAmount);
     }
 
     private async Task<List<ProductItem.ProductItemCategories>> GetProductCategoriesAsync(Product product)
     {
-        var productCategories = await _categoryService.GetProductCategoriesByProductIdAsync(product.Id);
+        var productCategories = await categoryService.GetProductCategoriesByProductIdAsync(product.Id);
 
         return await productCategories.SelectAwait(async pc => new ProductItem.ProductItemCategories
         {
             Id = pc.Id,
-            Title = (await _categoryService.GetCategoryByIdAsync(pc.CategoryId)).Name
+            Title = (await categoryService.GetCategoryByIdAsync(pc.CategoryId)).Name
         }).ToListAsync();
     }
 
@@ -530,27 +463,27 @@ public class OmnisendEventsService
         {
             case OrderStatus.Cancelled:
             {
-                var sent = await _genericAttributeService.GetAttributeAsync<bool>(order, OmnisendDefaults.OrderCanceledAttribute);
+                var sent = await genericAttributeService.GetAttributeAsync<bool>(order, OmnisendDefaults.OrderCanceledAttribute);
 
                 if (sent)
                     return;
 
                 await SendEventAsync(await CreateOrderCanceledEventAsync(order));
 
-                await _genericAttributeService.SaveAttributeAsync(order, OmnisendDefaults.OrderCanceledAttribute, true);
+                await genericAttributeService.SaveAttributeAsync(order, OmnisendDefaults.OrderCanceledAttribute, true);
 
                 break;
             }
             case OrderStatus.Complete:
             {
-                var sent = await _genericAttributeService.GetAttributeAsync<bool>(order, OmnisendDefaults.OrderFulfilledAttribute);
+                var sent = await genericAttributeService.GetAttributeAsync<bool>(order, OmnisendDefaults.OrderFulfilledAttribute);
 
                 if (sent)
                     return;
 
                 await SendEventAsync(await CreateOrderFulfilledEventAsync(order));
 
-                await _genericAttributeService.SaveAttributeAsync(order, OmnisendDefaults.OrderFulfilledAttribute, true);
+                await genericAttributeService.SaveAttributeAsync(order, OmnisendDefaults.OrderFulfilledAttribute, true);
 
                 break;
             }

--- a/src/Plugins/Nop.Plugin.Misc.Omnisend/Services/OmnisendHelper.cs
+++ b/src/Plugins/Nop.Plugin.Misc.Omnisend/Services/OmnisendHelper.cs
@@ -13,40 +13,17 @@ namespace Nop.Plugin.Misc.Omnisend.Services;
 /// <summary>
 /// Represents the plugins helpers class
 /// </summary>
-public class OmnisendHelper
-{
-    #region Fields
-
-    private string _primaryStoreCurrencyCode;
-
-    private readonly CurrencySettings _currencySettings;
-    private readonly ICurrencyService _currencyService;
-    private readonly INopUrlHelper _nopUrlHelper;
-    private readonly IPictureService _pictureService;
-    private readonly IProductAttributeParser _productAttributeParser;
-    private readonly IUrlRecordService _urlRecordService;
-    private readonly IWebHelper _webHelper;
-
-    #endregion
-
-    #region Ctor
-
-    public OmnisendHelper(CurrencySettings currencySettings,
+public class OmnisendHelper(CurrencySettings currencySettings,
         ICurrencyService currencyService,
         INopUrlHelper nopUrlHelper,
         IPictureService pictureService,
         IProductAttributeParser productAttributeParser,
         IUrlRecordService urlRecordService,
         IWebHelper webHelper)
-    {
-        _currencySettings = currencySettings;
-        _currencyService = currencyService;
-        _nopUrlHelper = nopUrlHelper;
-        _pictureService = pictureService;
-        _productAttributeParser = productAttributeParser;
-        _urlRecordService = urlRecordService;
-        _webHelper = webHelper;
-    }
+{
+    #region Fields
+
+    private string _primaryStoreCurrencyCode;
 
     #endregion
 
@@ -60,7 +37,7 @@ public class OmnisendHelper
         if (!string.IsNullOrEmpty(_primaryStoreCurrencyCode))
             return _primaryStoreCurrencyCode;
 
-        var currency = await _currencyService.GetCurrencyByIdAsync(_currencySettings.PrimaryStoreCurrencyId);
+        var currency = await currencyService.GetCurrencyByIdAsync(currencySettings.PrimaryStoreCurrencyId);
 
         _primaryStoreCurrencyCode = currency.CurrencyCode;
 
@@ -78,7 +55,7 @@ public class OmnisendHelper
         var variantId = product.Id;
 
         var combination =
-            await _productAttributeParser.FindProductAttributeCombinationAsync(product, attributesXml);
+            await productAttributeParser.FindProductAttributeCombinationAsync(product, attributesXml);
 
         if (combination == null)
             return (sku, variantId);
@@ -95,9 +72,9 @@ public class OmnisendHelper
     /// <param name="product">Product</param>
     public async Task<string> GetProductUrlAsync(Product product)
     {
-        var values = new { SeName = await _urlRecordService.GetSeNameAsync(product) };
+        var values = new { SeName = await urlRecordService.GetSeNameAsync(product) };
 
-        return await _nopUrlHelper.RouteGenericUrlAsync<Product>(values, _webHelper.GetCurrentRequestProtocol());
+        return await nopUrlHelper.RouteGenericUrlAsync<Product>(values, webHelper.GetCurrentRequestProtocol());
     }
 
     /// <summary>
@@ -106,12 +83,12 @@ public class OmnisendHelper
     /// <param name="product">Product</param>
     public async Task<ProductDto.Image> GetProductPictureUrlAsync(Product product)
     {
-        var picture = (await _pictureService
+        var picture = (await pictureService
             .GetPicturesByProductIdAsync(product.Id, 1)).DefaultIfEmpty(null).FirstOrDefault();
 
-        var (url, _) = await _pictureService.GetPictureUrlAsync(picture);
+        var (url, _) = await pictureService.GetPictureUrlAsync(picture);
 
-        var storeLocation = _webHelper.GetStoreLocation();
+        var storeLocation = webHelper.GetStoreLocation();
 
         if (!url.StartsWith(storeLocation))
             url = storeLocation + url;

--- a/src/Plugins/Nop.Plugin.Misc.PowerBI/PowerBIPlugin.cs
+++ b/src/Plugins/Nop.Plugin.Misc.PowerBI/PowerBIPlugin.cs
@@ -7,23 +7,8 @@ namespace Nop.Plugin.Misc.PowerBI;
 /// <summary>
 /// Represents the Power BI helper plugin
 /// </summary>
-public class PowerBIPlugin : BasePlugin, IMiscPlugin
+public class PowerBIPlugin(IWebHelper webHelper) : BasePlugin, IMiscPlugin
 {
-    #region Fields
-
-    private readonly IWebHelper _webHelper;
-
-    #endregion
-
-    #region Ctor
-
-    public PowerBIPlugin(IWebHelper webHelper)
-    {
-        _webHelper = webHelper;
-    }
-
-    #endregion
-
     #region Methods
 
     /// <summary>
@@ -31,7 +16,7 @@ public class PowerBIPlugin : BasePlugin, IMiscPlugin
     /// </summary>
     public override string GetConfigurationPageUrl()
     {
-        return $"{_webHelper.GetStoreLocation()}Admin/PowerBI/Configure";
+        return $"{webHelper.GetStoreLocation()}Admin/PowerBI/Configure";
     }
 
     /// <summary>

--- a/src/Plugins/Nop.Plugin.Payments.AmazonPay/AmazonPayPlugin.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmazonPay/AmazonPayPlugin.cs
@@ -20,26 +20,7 @@ namespace Nop.Plugin.Payments.AmazonPay;
 /// <summary>
 /// Represents Amazon Pay plugin
 /// </summary>
-public class AmazonPayPlugin : BasePlugin, IExternalAuthenticationMethod, IPaymentMethod, IWidgetPlugin
-{
-    #region Fields
-
-    private readonly AmazonPayApiService _amazonPayApiService;
-    private readonly AmazonPayPaymentService _amazonPayPaymentService;
-    private readonly AmazonPaySettings _amazonPaySettings;
-    private readonly ExternalAuthenticationSettings _externalAuthenticationSettings;
-    private readonly IHttpContextAccessor _httpContextAccessor;
-    private readonly ILocalizationService _localizationService;
-    private readonly ISettingService _settingService;
-    private readonly IWebHelper _webHelper;
-    private readonly PaymentSettings _paymentSettings;
-    private readonly WidgetSettings _widgetSettings;
-
-    #endregion
-
-    #region Ctor
-
-    public AmazonPayPlugin(AmazonPayApiService amazonPayApiService,
+public class AmazonPayPlugin(AmazonPayApiService amazonPayApiService,
         AmazonPayPaymentService amazonPayPaymentService,
         AmazonPaySettings amazonPaySettings,
         ExternalAuthenticationSettings externalAuthenticationSettings,
@@ -48,22 +29,9 @@ public class AmazonPayPlugin : BasePlugin, IExternalAuthenticationMethod, IPayme
         ISettingService settingService,
         IWebHelper webHelper,
         PaymentSettings paymentSettings,
-        WidgetSettings widgetSettings)
-    {
-        _amazonPayApiService = amazonPayApiService;
-        _amazonPayPaymentService = amazonPayPaymentService;
-        _amazonPaySettings = amazonPaySettings;
-        _externalAuthenticationSettings = externalAuthenticationSettings;
-        _httpContextAccessor = httpContextAccessor;
-        _localizationService = localizationService;
-        _settingService = settingService;
-        _webHelper = webHelper;
-        _paymentSettings = paymentSettings;
-        _widgetSettings = widgetSettings;
-    }
-
-    #endregion
-
+        WidgetSettings widgetSettings) 
+    : BasePlugin, IExternalAuthenticationMethod, IPaymentMethod, IWidgetPlugin
+{
     #region Methods
 
     /// <summary>
@@ -73,7 +41,7 @@ public class AmazonPayPlugin : BasePlugin, IExternalAuthenticationMethod, IPayme
     public override async Task InstallAsync()
     {
         //settings
-        await _settingService.SaveSettingAsync(new AmazonPaySettings
+        await settingService.SaveSettingAsync(new AmazonPaySettings
         {
             SetCredentialsManually = false,
             PaymentRegion = PaymentRegion.Us,
@@ -86,7 +54,7 @@ public class AmazonPayPlugin : BasePlugin, IExternalAuthenticationMethod, IPayme
         });
 
         //locales
-        await _localizationService.AddOrUpdateLocaleResourceAsync(new Dictionary<string, string>
+        await localizationService.AddOrUpdateLocaleResourceAsync(new Dictionary<string, string>
         {
             ["Enums.Nop.Plugin.Payments.AmazonPay.Enums.ButtonColor.DarkGray"] = "Dark gray",
             ["Enums.Nop.Plugin.Payments.AmazonPay.Enums.ButtonColor.Gold"] = "Gold",
@@ -167,16 +135,16 @@ public class AmazonPayPlugin : BasePlugin, IExternalAuthenticationMethod, IPayme
             ["Plugins.Payments.AmazonPay.SignIn.LinkAccounts.ByEmail"] = "There is already a customer account registered for your email address in this store, you can associate it with your Amazon Pay account, use 'Link accounts' button below"
         });
 
-        if (!_widgetSettings.ActiveWidgetSystemNames.Contains(AmazonPayDefaults.PluginSystemName))
+        if (!widgetSettings.ActiveWidgetSystemNames.Contains(AmazonPayDefaults.PluginSystemName))
         {
-            _widgetSettings.ActiveWidgetSystemNames.Add(AmazonPayDefaults.PluginSystemName);
-            await _settingService.SaveSettingAsync(_widgetSettings);
+            widgetSettings.ActiveWidgetSystemNames.Add(AmazonPayDefaults.PluginSystemName);
+            await settingService.SaveSettingAsync(widgetSettings);
         }
 
-        if (!_externalAuthenticationSettings.ActiveAuthenticationMethodSystemNames.Contains(AmazonPayDefaults.PluginSystemName))
+        if (!externalAuthenticationSettings.ActiveAuthenticationMethodSystemNames.Contains(AmazonPayDefaults.PluginSystemName))
         {
-            _externalAuthenticationSettings.ActiveAuthenticationMethodSystemNames.Add(AmazonPayDefaults.PluginSystemName);
-            await _settingService.SaveSettingAsync(_externalAuthenticationSettings);
+            externalAuthenticationSettings.ActiveAuthenticationMethodSystemNames.Add(AmazonPayDefaults.PluginSystemName);
+            await settingService.SaveSettingAsync(externalAuthenticationSettings);
         }
 
         await base.InstallAsync();
@@ -188,23 +156,23 @@ public class AmazonPayPlugin : BasePlugin, IExternalAuthenticationMethod, IPayme
     /// <returns>A task that represents the asynchronous operation</returns>
     public override async Task UninstallAsync()
     {
-        if (_widgetSettings.ActiveWidgetSystemNames.Contains(AmazonPayDefaults.PluginSystemName))
+        if (widgetSettings.ActiveWidgetSystemNames.Contains(AmazonPayDefaults.PluginSystemName))
         {
-            _widgetSettings.ActiveWidgetSystemNames.Remove(AmazonPayDefaults.PluginSystemName);
-            await _settingService.SaveSettingAsync(_widgetSettings);
+            widgetSettings.ActiveWidgetSystemNames.Remove(AmazonPayDefaults.PluginSystemName);
+            await settingService.SaveSettingAsync(widgetSettings);
         }
 
-        if (_paymentSettings.ActivePaymentMethodSystemNames.Contains(AmazonPayDefaults.PluginSystemName))
+        if (paymentSettings.ActivePaymentMethodSystemNames.Contains(AmazonPayDefaults.PluginSystemName))
         {
-            _paymentSettings.ActivePaymentMethodSystemNames.Remove(AmazonPayDefaults.PluginSystemName);
-            await _settingService.SaveSettingAsync(_paymentSettings);
+            paymentSettings.ActivePaymentMethodSystemNames.Remove(AmazonPayDefaults.PluginSystemName);
+            await settingService.SaveSettingAsync(paymentSettings);
         }
 
-        await _settingService.DeleteSettingAsync<AmazonPaySettings>();
+        await settingService.DeleteSettingAsync<AmazonPaySettings>();
 
         //locales
-        await _localizationService.DeleteLocaleResourcesAsync("Enums.Nop.Plugin.Payments.AmazonPay.Enums.");
-        await _localizationService.DeleteLocaleResourcesAsync("Plugins.Payments.AmazonPay.");
+        await localizationService.DeleteLocaleResourcesAsync("Enums.Nop.Plugin.Payments.AmazonPay.Enums.");
+        await localizationService.DeleteLocaleResourcesAsync("Plugins.Payments.AmazonPay.");
 
         await base.UninstallAsync();
     }
@@ -271,7 +239,7 @@ public class AmazonPayPlugin : BasePlugin, IExternalAuthenticationMethod, IPayme
     /// </returns>
     public async Task<CapturePaymentResult> CaptureAsync(CapturePaymentRequest capturePaymentRequest)
     {
-        return await _amazonPayPaymentService.CaptureAsync(capturePaymentRequest);
+        return await amazonPayPaymentService.CaptureAsync(capturePaymentRequest);
     }
 
     /// <summary>
@@ -284,7 +252,7 @@ public class AmazonPayPlugin : BasePlugin, IExternalAuthenticationMethod, IPayme
     /// </returns>
     public async Task<RefundPaymentResult> RefundAsync(RefundPaymentRequest refundPaymentRequest)
     {
-        return await _amazonPayPaymentService.RefundAsync(refundPaymentRequest);
+        return await amazonPayPaymentService.RefundAsync(refundPaymentRequest);
     }
 
     /// <summary>
@@ -297,7 +265,7 @@ public class AmazonPayPlugin : BasePlugin, IExternalAuthenticationMethod, IPayme
     /// </returns>
     public async Task<VoidPaymentResult> VoidAsync(VoidPaymentRequest voidPaymentRequest)
     {
-        return await _amazonPayPaymentService.VoidAsync(voidPaymentRequest);
+        return await amazonPayPaymentService.VoidAsync(voidPaymentRequest);
     }
 
     /// <summary>
@@ -310,7 +278,7 @@ public class AmazonPayPlugin : BasePlugin, IExternalAuthenticationMethod, IPayme
     /// </returns>
     public async Task<ProcessPaymentResult> ProcessRecurringPaymentAsync(ProcessPaymentRequest processPaymentRequest)
     {
-        return await _amazonPayPaymentService.ProcessRecurringPaymentAsync(processPaymentRequest);
+        return await amazonPayPaymentService.ProcessRecurringPaymentAsync(processPaymentRequest);
     }
 
     /// <summary>
@@ -323,7 +291,7 @@ public class AmazonPayPlugin : BasePlugin, IExternalAuthenticationMethod, IPayme
     /// </returns>
     public async Task<CancelRecurringPaymentResult> CancelRecurringPaymentAsync(CancelRecurringPaymentRequest cancelPaymentRequest)
     {
-        return await _amazonPayPaymentService.CancelRecurringPaymentAsync(cancelPaymentRequest);
+        return await amazonPayPaymentService.CancelRecurringPaymentAsync(cancelPaymentRequest);
     }
 
     /// <summary>
@@ -344,7 +312,7 @@ public class AmazonPayPlugin : BasePlugin, IExternalAuthenticationMethod, IPayme
     /// </summary>
     public override string GetConfigurationPageUrl()
     {
-        return $"{_webHelper.GetStoreLocation()}Admin/AmazonPay/Configure";
+        return $"{webHelper.GetStoreLocation()}Admin/AmazonPay/Configure";
     }
 
     /// <summary>
@@ -388,7 +356,7 @@ public class AmazonPayPlugin : BasePlugin, IExternalAuthenticationMethod, IPayme
     /// <returns>View component name</returns>
     Type IExternalAuthenticationMethod.GetPublicViewComponent()
     {
-        if (_amazonPayApiService.IsActiveAndConfiguredAsync().Result)
+        if (amazonPayApiService.IsActiveAndConfiguredAsync().Result)
             return typeof(PaymentInfoViewComponent);
 
         return null;
@@ -400,7 +368,7 @@ public class AmazonPayPlugin : BasePlugin, IExternalAuthenticationMethod, IPayme
     /// <returns>A task that represents the asynchronous operation</returns>
     public async Task<string> GetPaymentMethodDescriptionAsync()
     {
-        return await _localizationService.GetResourceAsync("Plugins.Payments.AmazonPay.PaymentMethodDescription");
+        return await localizationService.GetResourceAsync("Plugins.Payments.AmazonPay.PaymentMethodDescription");
     }
 
     /// <summary>
@@ -498,13 +466,13 @@ public class AmazonPayPlugin : BasePlugin, IExternalAuthenticationMethod, IPayme
     {
         get
         {
-            var values = _httpContextAccessor.HttpContext?.Request.RouteValues;
+            var values = httpContextAccessor.HttpContext?.Request.RouteValues;
 
             //checkout
             if (values != null &&
                 values.ContainsKey("controller") &&
                 (values["controller"]?.Equals("Checkout") ?? false) &&
-                _amazonPaySettings.ButtonPlacement.Contains(ButtonPlacement.PaymentMethod))
+                amazonPaySettings.ButtonPlacement.Contains(ButtonPlacement.PaymentMethod))
                 return PaymentMethodType.Standard;
 
             return PaymentMethodType.Button;

--- a/src/Plugins/Nop.Plugin.Payments.AmazonPay/Components/ChangeButtonViewComponent.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmazonPay/Components/ChangeButtonViewComponent.cs
@@ -11,26 +11,9 @@ namespace Nop.Plugin.Payments.AmazonPay.Components;
 /// <summary>
 /// Represents the view component to display change button
 /// </summary>
-public class ChangeButtonViewComponent : NopViewComponent
+public class ChangeButtonViewComponent(AmazonPayApiService amazonPayApiService,
+        AmazonPayCheckoutService amazonPayCheckoutService) : NopViewComponent
 {
-    #region Fields
-
-    private readonly AmazonPayApiService _amazonPayApiService;
-    private readonly AmazonPayCheckoutService _amazonPayCheckoutService;
-
-    #endregion
-
-    #region Ctor
-
-    public ChangeButtonViewComponent(AmazonPayApiService amazonPayApiService,
-        AmazonPayCheckoutService amazonPayCheckoutService)
-    {
-        _amazonPayApiService = amazonPayApiService;
-        _amazonPayCheckoutService = amazonPayCheckoutService;
-    }
-
-    #endregion
-
     #region Methods
 
     /// <summary>
@@ -56,14 +39,14 @@ public class ChangeButtonViewComponent : NopViewComponent
             return Content(string.Empty);
 
         //ensure that plugin is active and configured
-        if (!await _amazonPayApiService.IsActiveAndConfiguredAsync())
+        if (!await amazonPayApiService.IsActiveAndConfiguredAsync())
             return Content(string.Empty);
 
         var routeName = HttpContext.GetEndpoint()?.Metadata.GetMetadata<RouteNameMetadata>()?.RouteName;
         if (routeName == null || routeName != AmazonPayDefaults.ConfirmRouteName)
             return Content(string.Empty);
 
-        model.CheckoutSessionId = await _amazonPayCheckoutService.GetCheckoutSessionIdAsync();
+        model.CheckoutSessionId = await amazonPayCheckoutService.GetCheckoutSessionIdAsync();
 
         return View("~/Plugins/Payments.AmazonPay/Views/ChangeLink.cshtml", model);
     }

--- a/src/Plugins/Nop.Plugin.Payments.AmazonPay/Components/DoNotUseWithAmazonPayViewComponent.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmazonPay/Components/DoNotUseWithAmazonPayViewComponent.cs
@@ -14,35 +14,13 @@ namespace Nop.Plugin.Payments.AmazonPay.Components;
 /// <summary>
 /// Represents a view component to render an additional field on product and category details
 /// </summary>
-public class DoNotUseWithAmazonPayViewComponent : NopViewComponent
-{
-    #region Fields
-
-    private readonly AmazonPayApiService _amazonPayApiService;
-    private readonly ICategoryService _categoryService;
-    private readonly IGenericAttributeService _genericAttributeService;
-    private readonly IPermissionService _permissionService;
-    private readonly IProductService _productService;
-
-    #endregion
-
-    #region Ctor
-
-    public DoNotUseWithAmazonPayViewComponent(AmazonPayApiService amazonPayApiService,
+public class DoNotUseWithAmazonPayViewComponent(AmazonPayApiService amazonPayApiService,
         ICategoryService categoryService,
         IGenericAttributeService genericAttributeService,
         IPermissionService permissionService,
-        IProductService productService)
-    {
-        _amazonPayApiService = amazonPayApiService;
-        _categoryService = categoryService;
-        _genericAttributeService = genericAttributeService;
-        _permissionService = permissionService;
-        _productService = productService;
-    }
-
-    #endregion
-
+        IProductService productService) 
+    : NopViewComponent
+{
     #region Methods
 
     /// <summary>
@@ -61,10 +39,10 @@ public class DoNotUseWithAmazonPayViewComponent : NopViewComponent
             return Content(string.Empty);
 
         //ensure that plugin is active and configured
-        if (!await _amazonPayApiService.IsActiveAndConfiguredAsync())
+        if (!await amazonPayApiService.IsActiveAndConfiguredAsync())
             return Content(string.Empty);
 
-        if (!await _permissionService.AuthorizeAsync(StandardPermission.Configuration.MANAGE_PAYMENT_METHODS))
+        if (!await permissionService.AuthorizeAsync(StandardPermission.Configuration.MANAGE_PAYMENT_METHODS))
             return Content(string.Empty);
 
         //ensure that it's a proper widget zone
@@ -78,14 +56,14 @@ public class DoNotUseWithAmazonPayViewComponent : NopViewComponent
         BaseEntity entity = null;
 
         if (widgetZone.Equals(AdminWidgetZones.ProductDetailsBlock))
-            entity = await _productService.GetProductByIdAsync(entityModel.Id);
+            entity = await productService.GetProductByIdAsync(entityModel.Id);
 
         if (widgetZone.Equals(AdminWidgetZones.CategoryDetailsBlock))
-            entity = await _categoryService.GetCategoryByIdAsync(entityModel.Id);
+            entity = await categoryService.GetCategoryByIdAsync(entityModel.Id);
 
         //try to get previously saved value
         model.DoNotUseWithAmazonPay = entity != null &&
-            await _genericAttributeService.GetAttributeAsync<bool>(entity, AmazonPayDefaults.DoNotUseWithAmazonPayAttributeName);
+            await genericAttributeService.GetAttributeAsync<bool>(entity, AmazonPayDefaults.DoNotUseWithAmazonPayAttributeName);
 
         return View("~/Plugins/Payments.AmazonPay/Views/DoNotUseWithAmazonPay.cshtml", model);
     }

--- a/src/Plugins/Nop.Plugin.Payments.AmazonPay/Components/LogoViewComponent.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmazonPay/Components/LogoViewComponent.cs
@@ -10,26 +10,9 @@ namespace Nop.Plugin.Payments.AmazonPay.Components;
 /// <summary>
 /// Represents the view component to display logo
 /// </summary>
-public class LogoViewComponent : NopViewComponent
+public class LogoViewComponent(AmazonPayApiService amazonPayApiService,
+        AmazonPaySettings amazonPaySettings) : NopViewComponent
 {
-    #region Fields
-
-    private readonly AmazonPayApiService _amazonPayApiService;
-    private readonly AmazonPaySettings _amazonPaySettings;
-
-    #endregion
-
-    #region Ctor
-
-    public LogoViewComponent(AmazonPayApiService amazonPayApiService,
-        AmazonPaySettings amazonPaySettings)
-    {
-        _amazonPayApiService = amazonPayApiService;
-        _amazonPaySettings = amazonPaySettings;
-    }
-
-    #endregion
-
     #region Methods
 
     /// <summary>
@@ -46,10 +29,10 @@ public class LogoViewComponent : NopViewComponent
         if (!widgetZone.Equals(PublicWidgetZones.Footer))
             return Content(string.Empty);
 
-        if (!await _amazonPayApiService.IsActiveAndConfiguredAsync())
+        if (!await amazonPayApiService.IsActiveAndConfiguredAsync())
             return Content(string.Empty);
 
-        return new HtmlContentViewComponentResult(new HtmlString(_amazonPaySettings.LogoInFooter ?? string.Empty));
+        return new HtmlContentViewComponentResult(new HtmlString(amazonPaySettings.LogoInFooter ?? string.Empty));
     }
 
     #endregion

--- a/src/Plugins/Nop.Plugin.Payments.AmazonPay/Components/PaymentInfoViewComponent.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmazonPay/Components/PaymentInfoViewComponent.cs
@@ -9,35 +9,13 @@ namespace Nop.Plugin.Payments.AmazonPay.Components;
 /// <summary>
 /// Represents the view component to display plugin payment info
 /// </summary>
-public class PaymentInfoViewComponent : NopViewComponent
-{
-    #region Fields
-
-    private readonly AmazonPayApiService _amazonPayApiService;
-    private readonly AmazonPayCheckoutService _amazonPayCheckoutService;
-    private readonly AmazonPayCustomerService _amazonPayCustomerService;
-    private readonly AmazonPaySettings _amazonPaySettings;
-    private readonly IHttpContextAccessor _httpContextAccessor;
-
-    #endregion
-
-    #region Ctor
-
-    public PaymentInfoViewComponent(AmazonPayApiService amazonPayApiService,
+public class PaymentInfoViewComponent(AmazonPayApiService amazonPayApiService,
         AmazonPayCheckoutService amazonPayCheckoutService,
         AmazonPayCustomerService amazonPayCustomerService,
         AmazonPaySettings amazonPaySettings,
-        IHttpContextAccessor httpContextAccessor)
-    {
-        _amazonPayApiService = amazonPayApiService;
-        _amazonPayCheckoutService = amazonPayCheckoutService;
-        _amazonPayCustomerService = amazonPayCustomerService;
-        _amazonPaySettings = amazonPaySettings;
-        _httpContextAccessor = httpContextAccessor;
-    }
-
-    #endregion
-
+        IHttpContextAccessor httpContextAccessor) 
+    : NopViewComponent
+{
     #region Methods
 
     /// <summary>
@@ -50,14 +28,14 @@ public class PaymentInfoViewComponent : NopViewComponent
     public async Task<IViewComponentResult> InvokeAsync()
     {
         //ensure that plugin is active and configured
-        if (!await _amazonPayApiService.IsActiveAndConfiguredAsync())
+        if (!await amazonPayApiService.IsActiveAndConfiguredAsync())
             return Content(string.Empty);
 
-        var values = _httpContextAccessor.HttpContext?.Request.RouteValues;
+        var values = httpContextAccessor.HttpContext?.Request.RouteValues;
 
         if (values != null && (values["controller"]?.Equals("Customer") ?? false))
         {
-            var signInModel = await _amazonPayCustomerService.GetSignInModelAsync();
+            var signInModel = await amazonPayCustomerService.GetSignInModelAsync();
             if (string.IsNullOrEmpty(signInModel?.Signature))
                 return Content(string.Empty);
 
@@ -66,20 +44,20 @@ public class PaymentInfoViewComponent : NopViewComponent
 
         if (values != null && values.ContainsKey("controller") && (values["controller"]?.Equals("Checkout") ?? false))
         {
-            if (!_amazonPaySettings.ButtonPlacement.Contains(ButtonPlacement.PaymentMethod))
+            if (!amazonPaySettings.ButtonPlacement.Contains(ButtonPlacement.PaymentMethod))
                 return Content(string.Empty);
 
-            var model = await _amazonPayCheckoutService.GetPaymentInfoModelAsync(ButtonPlacement.PaymentMethod);
+            var model = await amazonPayCheckoutService.GetPaymentInfoModelAsync(ButtonPlacement.PaymentMethod);
             if (model is null)
                 return Content(string.Empty);
 
             return View("~/Plugins/Payments.AmazonPay/Views/PaymentInfo.cshtml", model);
         }
 
-        if (!_amazonPaySettings.ButtonPlacement.Contains(ButtonPlacement.Cart))
+        if (!amazonPaySettings.ButtonPlacement.Contains(ButtonPlacement.Cart))
             return Content(string.Empty);
 
-        var cartModel = await _amazonPayCheckoutService.GetPaymentInfoModelAsync(ButtonPlacement.Cart);
+        var cartModel = await amazonPayCheckoutService.GetPaymentInfoModelAsync(ButtonPlacement.Cart);
         if (cartModel is null)
             return Content(string.Empty);
 

--- a/src/Plugins/Nop.Plugin.Payments.AmazonPay/Controllers/AmazonPayAdminController.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmazonPay/Controllers/AmazonPayAdminController.cs
@@ -17,25 +17,7 @@ namespace Nop.Plugin.Payments.AmazonPay.Controllers;
 [AuthorizeAdmin]
 [Area(AreaNames.ADMIN)]
 [AutoValidateAntiforgeryToken]
-public class AmazonPayController : BasePaymentController
-{
-    #region Fields
-
-    private readonly AmazonPayApiService _amazonPayApiService;
-    private readonly AmazonPayOnboardingService _amazonPayOnboardingService;
-    private readonly IGenericAttributeService _genericAttributeService;
-    private readonly ILocalizationService _localizationService;
-    private readonly INotificationService _notificationService;
-    private readonly IPermissionService _permissionService;
-    private readonly ISettingService _settingService;
-    private readonly IStoreContext _storeContext;
-    private readonly IWorkContext _workContext;
-
-    #endregion
-
-    #region Ctor
-
-    public AmazonPayController(AmazonPayApiService amazonPayApiService,
+public class AmazonPayController(AmazonPayApiService amazonPayApiService,
         AmazonPayOnboardingService amazonPayOnboardingService,
         IGenericAttributeService genericAttributeService,
         ILocalizationService localizationService,
@@ -43,30 +25,18 @@ public class AmazonPayController : BasePaymentController
         IPermissionService permissionService,
         ISettingService settingService,
         IStoreContext storeContext,
-        IWorkContext workContext)
-    {
-        _amazonPayApiService = amazonPayApiService;
-        _amazonPayOnboardingService = amazonPayOnboardingService;
-        _genericAttributeService = genericAttributeService;
-        _localizationService = localizationService;
-        _notificationService = notificationService;
-        _permissionService = permissionService;
-        _settingService = settingService;
-        _storeContext = storeContext;
-        _workContext = workContext;
-    }
-
-    #endregion
-
+        IWorkContext workContext) 
+    : BasePaymentController
+{
     #region Methods
 
     [CheckPermission(StandardPermission.Configuration.MANAGE_PAYMENT_METHODS)]
     public async Task<IActionResult> Configure()
     {
-        var storeId = await _storeContext.GetActiveStoreScopeConfigurationAsync();
-        var settings = await _settingService.LoadSettingAsync<AmazonPaySettings>(storeId);
+        var storeId = await storeContext.GetActiveStoreScopeConfigurationAsync();
+        var settings = await settingService.LoadSettingAsync<AmazonPaySettings>(storeId);
 
-        var customer = await _workContext.GetCurrentCustomerAsync();
+        var customer = await workContext.GetCurrentCustomerAsync();
 
         var model = new ConfigurationModel
         {
@@ -86,32 +56,32 @@ public class AmazonPayController : BasePaymentController
 
             IsConnected = !string.IsNullOrEmpty(settings.MerchantId) && !string.IsNullOrEmpty(settings.StoreId) && !string.IsNullOrEmpty(settings.PublicKeyId),
             ActiveStoreScopeConfiguration = storeId,
-            HideCredentialsBlock = await _genericAttributeService.GetAttributeAsync<bool>(customer, AmazonPayDefaults.HideCredentialsBlock),
-            HideConfigurationBlock = await _genericAttributeService.GetAttributeAsync<bool>(customer, AmazonPayDefaults.HideConfigurationBlock),
-            IpnUrl = _amazonPayApiService.GetUrl(AmazonPayDefaults.IPNHandlerRouteName)
+            HideCredentialsBlock = await genericAttributeService.GetAttributeAsync<bool>(customer, AmazonPayDefaults.HideCredentialsBlock),
+            HideConfigurationBlock = await genericAttributeService.GetAttributeAsync<bool>(customer, AmazonPayDefaults.HideConfigurationBlock),
+            IpnUrl = amazonPayApiService.GetUrl(AmazonPayDefaults.IPNHandlerRouteName)
         };
 
         if (storeId > 0)
         {
-            model.SetCredentialsManually_OverrideForStore = await _settingService.SettingExistsAsync(settings, setting => setting.SetCredentialsManually, storeId);
-            model.Region_OverrideForStore = await _settingService.SettingExistsAsync(settings, setting => setting.PaymentRegion, storeId);
-            model.Payload_OverrideForStore = await _settingService.SettingExistsAsync(settings, setting => setting.Payload, storeId);
-            model.PaymentRegion_OverrideForStore = await _settingService.SettingExistsAsync(settings, setting => setting.PaymentRegion, storeId);
-            model.PrivateKey_OverrideForStore = await _settingService.SettingExistsAsync(settings, setting => setting.PrivateKey, storeId);
-            model.PublicKeyId_OverrideForStore = await _settingService.SettingExistsAsync(settings, setting => setting.PublicKeyId, storeId);
-            model.MerchantId_OverrideForStore = await _settingService.SettingExistsAsync(settings, setting => setting.MerchantId, storeId);
-            model.StoreId_OverrideForStore = await _settingService.SettingExistsAsync(settings, setting => setting.StoreId, storeId);
+            model.SetCredentialsManually_OverrideForStore = await settingService.SettingExistsAsync(settings, setting => setting.SetCredentialsManually, storeId);
+            model.Region_OverrideForStore = await settingService.SettingExistsAsync(settings, setting => setting.PaymentRegion, storeId);
+            model.Payload_OverrideForStore = await settingService.SettingExistsAsync(settings, setting => setting.Payload, storeId);
+            model.PaymentRegion_OverrideForStore = await settingService.SettingExistsAsync(settings, setting => setting.PaymentRegion, storeId);
+            model.PrivateKey_OverrideForStore = await settingService.SettingExistsAsync(settings, setting => setting.PrivateKey, storeId);
+            model.PublicKeyId_OverrideForStore = await settingService.SettingExistsAsync(settings, setting => setting.PublicKeyId, storeId);
+            model.MerchantId_OverrideForStore = await settingService.SettingExistsAsync(settings, setting => setting.MerchantId, storeId);
+            model.StoreId_OverrideForStore = await settingService.SettingExistsAsync(settings, setting => setting.StoreId, storeId);
 
-            model.UseSandbox_OverrideForStore = await _settingService.SettingExistsAsync(settings, setting => setting.UseSandbox, storeId);
-            model.PaymentType_OverrideForStore = await _settingService.SettingExistsAsync(settings, setting => setting.PaymentType, storeId);
-            model.ButtonPlacement_OverrideForStore = await _settingService.SettingExistsAsync(settings, setting => setting.ButtonPlacement, storeId);
-            model.ButtonColor_OverrideForStore = await _settingService.SettingExistsAsync(settings, setting => setting.ButtonColor, storeId);
-            model.EnableLogging_OverrideForStore = await _settingService.SettingExistsAsync(settings, setting => setting.EnableLogging, storeId);
+            model.UseSandbox_OverrideForStore = await settingService.SettingExistsAsync(settings, setting => setting.UseSandbox, storeId);
+            model.PaymentType_OverrideForStore = await settingService.SettingExistsAsync(settings, setting => setting.PaymentType, storeId);
+            model.ButtonPlacement_OverrideForStore = await settingService.SettingExistsAsync(settings, setting => setting.ButtonPlacement, storeId);
+            model.ButtonColor_OverrideForStore = await settingService.SettingExistsAsync(settings, setting => setting.ButtonColor, storeId);
+            model.EnableLogging_OverrideForStore = await settingService.SettingExistsAsync(settings, setting => setting.EnableLogging, storeId);
         }
 
         //check currency
         if (model.IsConnected)
-            await _amazonPayApiService.EnsureCurrencyIsValidAsync();
+            await amazonPayApiService.EnsureCurrencyIsValidAsync();
 
         return View("~/Plugins/Payments.AmazonPay/Views/Configure.cshtml", model);
     }
@@ -123,18 +93,18 @@ public class AmazonPayController : BasePaymentController
         if (!ModelState.IsValid)
             return await Configure();
 
-        var storeId = await _storeContext.GetActiveStoreScopeConfigurationAsync();
-        var amazonPaySettings = await _settingService.LoadSettingAsync<AmazonPaySettings>(storeId);
+        var storeId = await storeContext.GetActiveStoreScopeConfigurationAsync();
+        var amazonPaySettings = await settingService.LoadSettingAsync<AmazonPaySettings>(storeId);
 
         //set credentials from payload
         if (!string.IsNullOrEmpty(model.Payload))
         {
-            var (credentials, error) = await _amazonPayOnboardingService.PrepareCredentialsAsync(model.Payload, amazonPaySettings.PrivateKey);
+            var (credentials, error) = await amazonPayOnboardingService.PrepareCredentialsAsync(model.Payload, amazonPaySettings.PrivateKey);
             if (!string.IsNullOrEmpty(error) || string.IsNullOrEmpty(credentials?.PublicKeyId))
             {
-                var locale = await _localizationService.GetResourceAsync("Plugins.Payments.AmazonPay.Onboarding.Error");
+                var locale = await localizationService.GetResourceAsync("Plugins.Payments.AmazonPay.Onboarding.Error");
                 var errorMessage = string.Format(locale, error, Url.Action("List", "Log"));
-                _notificationService.ErrorNotification(errorMessage, false);
+                notificationService.ErrorNotification(errorMessage, false);
             }
             else
             {
@@ -160,22 +130,22 @@ public class AmazonPayController : BasePaymentController
         amazonPaySettings.ButtonColor = model.ButtonColor > 0 ? (ButtonColor)model.ButtonColor : amazonPaySettings.ButtonColor;
         amazonPaySettings.EnableLogging = model.EnableLogging;
 
-        await _settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.SetCredentialsManually, model.SetCredentialsManually_OverrideForStore, storeId, false);
-        await _settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.PaymentRegion, model.PaymentRegion_OverrideForStore, storeId, false);
-        await _settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.Payload, model.Payload_OverrideForStore, storeId, false);
-        await _settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.PrivateKey, model.PrivateKey_OverrideForStore, storeId, false);
-        await _settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.PublicKeyId, model.PublicKeyId_OverrideForStore, storeId, false);
-        await _settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.MerchantId, model.MerchantId_OverrideForStore, storeId, false);
-        await _settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.StoreId, model.StoreId_OverrideForStore, storeId, false);
-        await _settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.UseSandbox, model.UseSandbox_OverrideForStore, storeId, false);
-        await _settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.PaymentType, model.PaymentType_OverrideForStore, storeId, false);
-        await _settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.ButtonPlacement, model.ButtonPlacement_OverrideForStore, storeId, false);
-        await _settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.ButtonColor, model.ButtonColor_OverrideForStore, storeId, false);
-        await _settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.EnableLogging, model.EnableLogging_OverrideForStore, storeId, false);
+        await settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.SetCredentialsManually, model.SetCredentialsManually_OverrideForStore, storeId, false);
+        await settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.PaymentRegion, model.PaymentRegion_OverrideForStore, storeId, false);
+        await settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.Payload, model.Payload_OverrideForStore, storeId, false);
+        await settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.PrivateKey, model.PrivateKey_OverrideForStore, storeId, false);
+        await settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.PublicKeyId, model.PublicKeyId_OverrideForStore, storeId, false);
+        await settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.MerchantId, model.MerchantId_OverrideForStore, storeId, false);
+        await settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.StoreId, model.StoreId_OverrideForStore, storeId, false);
+        await settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.UseSandbox, model.UseSandbox_OverrideForStore, storeId, false);
+        await settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.PaymentType, model.PaymentType_OverrideForStore, storeId, false);
+        await settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.ButtonPlacement, model.ButtonPlacement_OverrideForStore, storeId, false);
+        await settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.ButtonColor, model.ButtonColor_OverrideForStore, storeId, false);
+        await settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.EnableLogging, model.EnableLogging_OverrideForStore, storeId, false);
 
-        await _settingService.ClearCacheAsync();
+        await settingService.ClearCacheAsync();
 
-        _notificationService.SuccessNotification(await _localizationService.GetResourceAsync("Admin.Plugins.Saved"));
+        notificationService.SuccessNotification(await localizationService.GetResourceAsync("Admin.Plugins.Saved"));
 
         return RedirectToAction("Configure");
     }
@@ -188,33 +158,33 @@ public class AmazonPayController : BasePaymentController
         if (!ModelState.IsValid)
             return await Configure();
 
-        var storeId = await _storeContext.GetActiveStoreScopeConfigurationAsync();
-        var amazonPaySettings = await _settingService.LoadSettingAsync<AmazonPaySettings>(storeId);
+        var storeId = await storeContext.GetActiveStoreScopeConfigurationAsync();
+        var amazonPaySettings = await settingService.LoadSettingAsync<AmazonPaySettings>(storeId);
 
         amazonPaySettings.PaymentRegion = (PaymentRegion)model.Region;
-        await _settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.PaymentRegion, model.Region_OverrideForStore, storeId, false);
+        await settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.PaymentRegion, model.Region_OverrideForStore, storeId, false);
 
         if (model.Region == (int)PaymentRegion.Eu || model.Region == (int)PaymentRegion.Uk || model.Region == (int)PaymentRegion.Jp)
         {
             amazonPaySettings.SetCredentialsManually = true;
-            await _settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.SetCredentialsManually, model.Region_OverrideForStore, storeId, false);
-            await _settingService.ClearCacheAsync();
+            await settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.SetCredentialsManually, model.Region_OverrideForStore, storeId, false);
+            await settingService.ClearCacheAsync();
 
-            _notificationService.WarningNotification(await _localizationService.GetResourceAsync("Plugins.Payments.AmazonPay.Onboarding.Region.Warning"));
+            notificationService.WarningNotification(await localizationService.GetResourceAsync("Plugins.Payments.AmazonPay.Onboarding.Region.Warning"));
 
             return RedirectToAction("Configure");
         }
 
         //try to register merchant (US only)
-        var (privateKey, publicKey) = await _amazonPayOnboardingService.RegisterAsync((PaymentRegion)model.Region, amazonPaySettings);
+        var (privateKey, publicKey) = await amazonPayOnboardingService.RegisterAsync((PaymentRegion)model.Region, amazonPaySettings);
 
         amazonPaySettings.SetCredentialsManually = model.SetCredentialsManually;
         amazonPaySettings.PrivateKey = privateKey;
         amazonPaySettings.PublicKey = publicKey;
-        await _settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.SetCredentialsManually, model.Region_OverrideForStore, storeId, false);
-        await _settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.PrivateKey, model.Region_OverrideForStore, storeId, false);
-        await _settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.PublicKey, model.Region_OverrideForStore, storeId, false);
-        await _settingService.ClearCacheAsync();
+        await settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.SetCredentialsManually, model.Region_OverrideForStore, storeId, false);
+        await settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.PrivateKey, model.Region_OverrideForStore, storeId, false);
+        await settingService.SaveSettingOverridablePerStoreAsync(amazonPaySettings, settings => settings.PublicKey, model.Region_OverrideForStore, storeId, false);
+        await settingService.ClearCacheAsync();
 
         return Empty;
     }

--- a/src/Plugins/Nop.Plugin.Payments.AmazonPay/Controllers/AmazonPayCustomerController.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmazonPay/Controllers/AmazonPayCustomerController.cs
@@ -5,34 +5,19 @@ using Nop.Web.Framework.Controllers;
 namespace Nop.Plugin.Payments.AmazonPay.Controllers;
 
 [AutoValidateAntiforgeryToken]
-public class AmazonPayCustomerController : BasePaymentController
+public class AmazonPayCustomerController(AmazonPayCustomerService amazonPayCustomerService) : BasePaymentController
 {
-    #region Fields
-
-    private readonly AmazonPayCustomerService _amazonPayCustomerService;
-
-    #endregion
-
-    #region Ctor
-
-    public AmazonPayCustomerController(AmazonPayCustomerService amazonPayCustomerService)
-    {
-        _amazonPayCustomerService = amazonPayCustomerService;
-    }
-
-    #endregion
-
     #region Methods
 
     public async Task<IActionResult> SignIn()
     {
-        return await _amazonPayCustomerService.SignInAsync();
+        return await amazonPayCustomerService.SignInAsync();
     }
 
     [HttpPost]
     public async Task<IActionResult> AssociateOrCreateAccount(string buyerId, string buyerEmail, string buyerName)
     {
-        if (await _amazonPayCustomerService.AssociateOrCreateCustomerAsync(buyerId, buyerEmail, buyerName))
+        if (await amazonPayCustomerService.AssociateOrCreateCustomerAsync(buyerId, buyerEmail, buyerName))
             return Json(new { Redirect = true });
 
         return Json(new { Status = "Ok!" });
@@ -41,7 +26,7 @@ public class AmazonPayCustomerController : BasePaymentController
     [HttpPost]
     public async Task<IActionResult> SignOut(string buyerId)
     {
-        await _amazonPayCustomerService.SignOutAsync(buyerId);
+        await amazonPayCustomerService.SignOutAsync(buyerId);
 
         return Json(new { Status = "Ok!" });
     }

--- a/src/Plugins/Nop.Plugin.Payments.AmazonPay/Controllers/AmazonPayIpnController.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmazonPay/Controllers/AmazonPayIpnController.cs
@@ -3,29 +3,14 @@ using Nop.Plugin.Payments.AmazonPay.Services;
 
 namespace Nop.Plugin.Payments.AmazonPay.Controllers;
 
-public class AmazonPayIpnController : Controller
+public class AmazonPayIpnController(AmazonPayPaymentService amazonPayPaymentService) : Controller
 {
-    #region Fields
-
-    private readonly AmazonPayPaymentService _amazonPayPaymentService;
-
-    #endregion
-
-    #region Ctor
-
-    public AmazonPayIpnController(AmazonPayPaymentService amazonPayPaymentService)
-    {
-        _amazonPayPaymentService = amazonPayPaymentService;
-    }
-
-    #endregion
-
     #region Methods
 
     [HttpPost]
     public async Task<IActionResult> IPNHandler()
     {
-        await _amazonPayPaymentService.ProcessIPNRequestAsync();
+        await amazonPayPaymentService.ProcessIPNRequestAsync();
 
         return Ok();
     }

--- a/src/Plugins/Nop.Plugin.Payments.AmazonPay/Controllers/AmazonPayOnboardingController.cs
+++ b/src/Plugins/Nop.Plugin.Payments.AmazonPay/Controllers/AmazonPayOnboardingController.cs
@@ -4,23 +4,8 @@ using Nop.Plugin.Payments.AmazonPay.Services;
 
 namespace Nop.Plugin.Payments.AmazonPay.Controllers;
 
-public class AmazonPayOnboardingController : Controller
+public class AmazonPayOnboardingController(AmazonPayOnboardingService amazonPayOnboardingService) : Controller
 {
-    #region Fields
-
-    private readonly AmazonPayOnboardingService _amazonPayOnboardingService;
-
-    #endregion
-
-    #region Ctor
-
-    public AmazonPayOnboardingController(AmazonPayOnboardingService amazonPayOnboardingService)
-    {
-        _amazonPayOnboardingService = amazonPayOnboardingService;
-    }
-
-    #endregion
-
     #region Methods
 
     [HttpPost]
@@ -31,7 +16,7 @@ public class AmazonPayOnboardingController : Controller
         Response.Headers.TryAdd("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
         Response.Headers.TryAdd("Access-Control-Allow-Headers", "Content-Type, X-CSRF-Token");
 
-        var error = await _amazonPayOnboardingService.AutomaticKeyExchangeAsync(model.Payload);
+        var error = await amazonPayOnboardingService.AutomaticKeyExchangeAsync(model.Payload);
 
         if (string.IsNullOrEmpty(error))
             return Json(new { result = "success" });

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Components/Admin/PaymentMethodViewComponent.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Components/Admin/PaymentMethodViewComponent.cs
@@ -8,26 +8,9 @@ namespace Nop.Plugin.Payments.PayPalCommerce.Components.Admin;
 /// <summary>
 /// Represents the view component to display PayPal on the payment methods page in the admin area
 /// </summary>
-public class PaymentMethodViewComponent : NopViewComponent
+public class PaymentMethodViewComponent(PayPalCommerceSettings settings,
+        PayPalCommerceServiceManager serviceManager) : NopViewComponent
 {
-    #region Fields
-
-    private readonly PayPalCommerceSettings _settings;
-    private readonly PayPalCommerceServiceManager _serviceManager;
-
-    #endregion
-
-    #region Ctor
-
-    public PaymentMethodViewComponent(PayPalCommerceSettings settings,
-        PayPalCommerceServiceManager serviceManager)
-    {
-        _settings = settings;
-        _serviceManager = serviceManager;
-    }
-
-    #endregion
-
     #region Methods
 
     /// <summary>
@@ -44,7 +27,7 @@ public class PaymentMethodViewComponent : NopViewComponent
         if (!widgetZone.Equals(AdminWidgetZones.PaymentMethodListTop))
             return Content(string.Empty);
 
-        var (active, _) = await _serviceManager.IsActiveAsync(_settings);
+        var (active, _) = await serviceManager.IsActiveAsync(settings);
 
         return View("~/Plugins/Payments.PayPalCommerce/Views/Admin/_PaymentMethod.cshtml", active);
     }

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Components/Admin/ShipmentCarrierViewComponent.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Components/Admin/ShipmentCarrierViewComponent.cs
@@ -12,32 +12,11 @@ namespace Nop.Plugin.Payments.PayPalCommerce.Components.Admin;
 /// <summary>
 /// Represents the view component to render an additional input on the shipment details page in the admin area
 /// </summary>
-public class ShipmentCarrierViewComponent : NopViewComponent
-{
-    #region Fields
-
-    private readonly IGenericAttributeService _genericAttributeService;
-    private readonly IShipmentService _shipmentService;
-    private readonly PayPalCommerceServiceManager _serviceManager;
-    private readonly PayPalCommerceSettings _settings;
-
-    #endregion
-
-    #region Ctor
-
-    public ShipmentCarrierViewComponent(IGenericAttributeService genericAttributeService,
+public class ShipmentCarrierViewComponent(IGenericAttributeService genericAttributeService,
         IShipmentService shipmentService,
         PayPalCommerceServiceManager serviceManager,
-        PayPalCommerceSettings settings)
-    {
-        _genericAttributeService = genericAttributeService;
-        _shipmentService = shipmentService;
-        _serviceManager = serviceManager;
-        _settings = settings;
-    }
-
-    #endregion
-
+        PayPalCommerceSettings settings) : NopViewComponent
+{
     #region Methods
 
     /// <summary>
@@ -51,11 +30,11 @@ public class ShipmentCarrierViewComponent : NopViewComponent
     /// </returns>
     public async Task<IViewComponentResult> InvokeAsync(string widgetZone, object additionalData)
     {
-        var (active, _) = await _serviceManager.IsActiveAsync(_settings);
+        var (active, _) = await serviceManager.IsActiveAsync(settings);
         if (!active)
             return Content(string.Empty);
 
-        if (!_settings.UseShipmentTracking)
+        if (!settings.UseShipmentTracking)
             return Content(string.Empty);
 
         if (!widgetZone.Equals(AdminWidgetZones.OrderShipmentDetailsButtons) && !widgetZone.Equals(AdminWidgetZones.OrderShipmentAddButtons))
@@ -64,12 +43,12 @@ public class ShipmentCarrierViewComponent : NopViewComponent
         if (additionalData is not ShipmentModel shipmentModel)
             return Content(string.Empty);
 
-        var shipment = await _shipmentService.GetShipmentByIdAsync(shipmentModel.Id);
+        var shipment = await shipmentService.GetShipmentByIdAsync(shipmentModel.Id);
         var model = new ShipmentCarrierModel
         {
             TrackingNumber = shipmentModel.TrackingNumber,
             PayPalCommerceShipmentCarrier = shipment is not null
-                ? await _genericAttributeService.GetAttributeAsync<string>(shipment, PayPalCommerceDefaults.ShipmentCarrierAttribute)
+                ? await genericAttributeService.GetAttributeAsync<string>(shipment, PayPalCommerceDefaults.ShipmentCarrierAttribute)
                 : null
         };
 

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Components/Public/ButtonsViewComponent.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Components/Public/ButtonsViewComponent.cs
@@ -15,32 +15,11 @@ namespace Nop.Plugin.Payments.PayPalCommerce.Components.Public;
 /// <summary>
 /// Represents the view component to display PayPal buttons in the public store
 /// </summary>
-public class ButtonsViewComponent : NopViewComponent
-{
-    #region Fields
-
-    private readonly IProductService _productService;
-    private readonly PayPalCommerceModelFactory _modelFactory;
-    private readonly PayPalCommerceServiceManager _serviceManager;
-    private readonly PayPalCommerceSettings _settings;
-
-    #endregion
-
-    #region Ctor
-
-    public ButtonsViewComponent(IProductService productService,
+public class ButtonsViewComponent(IProductService productService,
         PayPalCommerceModelFactory modelFactory,
         PayPalCommerceServiceManager serviceManager,
-        PayPalCommerceSettings settings)
-    {
-        _productService = productService;
-        _modelFactory = modelFactory;
-        _serviceManager = serviceManager;
-        _settings = settings;
-    }
-
-    #endregion
-
+        PayPalCommerceSettings settings) : NopViewComponent
+{
     #region Methods
 
     /// <summary>
@@ -54,7 +33,7 @@ public class ButtonsViewComponent : NopViewComponent
     /// </returns>
     public async Task<IViewComponentResult> InvokeAsync(string widgetZone, object additionalData)
     {
-        var (active, _) = await _serviceManager.IsActiveAsync(_settings);
+        var (active, _) = await serviceManager.IsActiveAsync(settings);
         if (!active)
             return Content(string.Empty);
 
@@ -62,26 +41,26 @@ public class ButtonsViewComponent : NopViewComponent
 
         if (widgetZone.Equals(PublicWidgetZones.ProductDetailsAddInfo))
         {
-            if (_settings.DisplayButtonsOnProductDetails)
+            if (settings.DisplayButtonsOnProductDetails)
             {
                 var productId = additionalData is ProductDetailsModel.AddToCartModel product ? (int?)product.ProductId : null;
-                if (productId is null || (await _productService.GetProductByIdAsync(productId ?? 0))?.ParentGroupedProductId == 0)
-                    model = await _modelFactory.PreparePaymentInfoModelAsync(ButtonPlacement.Product, productId);
+                if (productId is null || (await productService.GetProductByIdAsync(productId ?? 0))?.ParentGroupedProductId == 0)
+                    model = await modelFactory.PreparePaymentInfoModelAsync(ButtonPlacement.Product, productId);
             }
         }
         else if (widgetZone.Equals(PublicWidgetZones.OrderSummaryContentBefore))
         {
-            if (_settings.DisplayButtonsOnShoppingCart)
+            if (settings.DisplayButtonsOnShoppingCart)
             {
                 var routeName = HttpContext.GetEndpoint()?.Metadata.GetMetadata<RouteNameMetadata>()?.RouteName;
                 if (routeName == PayPalCommerceDefaults.Route.ShoppingCart)
-                    model = await _modelFactory.PreparePaymentInfoModelAsync(ButtonPlacement.Cart);
+                    model = await modelFactory.PreparePaymentInfoModelAsync(ButtonPlacement.Cart);
             }
         }
         else
         {
-            if (_settings.DisplayButtonsOnPaymentMethod)
-                model = await _modelFactory.PreparePaymentInfoModelAsync(ButtonPlacement.PaymentMethod);
+            if (settings.DisplayButtonsOnPaymentMethod)
+                model = await modelFactory.PreparePaymentInfoModelAsync(ButtonPlacement.PaymentMethod);
         }
 
         if (model?.Cart.IsRecurring is null)

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Components/Public/LogoViewComponent.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Components/Public/LogoViewComponent.cs
@@ -10,26 +10,9 @@ namespace Nop.Plugin.Payments.PayPalCommerce.Components.Public;
 /// <summary>
 /// Represents the view component to display PayPal logo in the public store
 /// </summary>
-public class LogoViewComponent : NopViewComponent
+public class LogoViewComponent(PayPalCommerceSettings settings,
+        PayPalCommerceServiceManager serviceManager) : NopViewComponent
 {
-    #region Fields
-
-    private readonly PayPalCommerceSettings _settings;
-    private readonly PayPalCommerceServiceManager _serviceManager;
-
-    #endregion
-
-    #region Ctor
-
-    public LogoViewComponent(PayPalCommerceSettings settings,
-        PayPalCommerceServiceManager serviceManager)
-    {
-        _settings = settings;
-        _serviceManager = serviceManager;
-    }
-
-    #endregion
-
     #region Methods
 
     /// <summary>
@@ -43,14 +26,14 @@ public class LogoViewComponent : NopViewComponent
     /// </returns>
     public async Task<IViewComponentResult> InvokeAsync(string widgetZone, object additionalData)
     {
-        var (active, _) = await _serviceManager.IsActiveAsync(_settings);
+        var (active, _) = await serviceManager.IsActiveAsync(settings);
         if (!active)
             return Content(string.Empty);
 
-        var script = widgetZone.Equals(PublicWidgetZones.HeaderLinksBefore) && _settings.DisplayLogoInHeaderLinks
-            ? _settings.LogoInHeaderLinks
-            : widgetZone.Equals(PublicWidgetZones.Footer) && _settings.DisplayLogoInFooter
-            ? _settings.LogoInFooter
+        var script = widgetZone.Equals(PublicWidgetZones.HeaderLinksBefore) && settings.DisplayLogoInHeaderLinks
+            ? settings.LogoInHeaderLinks
+            : widgetZone.Equals(PublicWidgetZones.Footer) && settings.DisplayLogoInFooter
+            ? settings.LogoInFooter
             : null;
 
         return new HtmlContentViewComponentResult(new HtmlString(script ?? string.Empty));

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Components/Public/MessagesViewComponent.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Components/Public/MessagesViewComponent.cs
@@ -12,29 +12,10 @@ namespace Nop.Plugin.Payments.PayPalCommerce.Components.Public;
 /// <summary>
 /// Represents the view component to display Pay Later messages in the public store
 /// </summary>
-public class MessagesViewComponent : NopViewComponent
-{
-    #region Fields
-
-    private readonly PayPalCommerceModelFactory _modelFactory;
-    private readonly PayPalCommerceServiceManager _serviceManager;
-    private readonly PayPalCommerceSettings _settings;
-
-    #endregion
-
-    #region Ctor
-
-    public MessagesViewComponent(PayPalCommerceModelFactory modelFactory,
+public class MessagesViewComponent(PayPalCommerceModelFactory modelFactory,
         PayPalCommerceServiceManager serviceManager,
-        PayPalCommerceSettings settings)
-    {
-        _modelFactory = modelFactory;
-        _serviceManager = serviceManager;
-        _settings = settings;
-    }
-
-    #endregion
-
+        PayPalCommerceSettings settings) : NopViewComponent
+{
     #region Methods
 
     /// <summary>
@@ -48,14 +29,14 @@ public class MessagesViewComponent : NopViewComponent
     /// </returns>
     public async Task<IViewComponentResult> InvokeAsync(string widgetZone, object additionalData)
     {
-        var (active, _) = await _serviceManager.IsActiveAsync(_settings);
+        var (active, _) = await serviceManager.IsActiveAsync(settings);
         if (!active)
             return Content(string.Empty);
 
         if (!widgetZone.Equals(PublicWidgetZones.OrderSummaryTotals))
             return Content(string.Empty);
 
-        if (!_settings.UseSandbox && !_settings.ConfiguratorSupported)
+        if (!settings.UseSandbox && !settings.ConfiguratorSupported)
             return Content(string.Empty);
 
         //get messages placement
@@ -70,7 +51,7 @@ public class MessagesViewComponent : NopViewComponent
         //load script only on checkout pages (excluding payment method page) to avoid double loading
         var loadScript = !isCartPage && !isPaymentMethodPage;
         var placement = isCartPage ? ButtonPlacement.Cart : ButtonPlacement.PaymentMethod;
-        var model = await _modelFactory.PrepareMessagesModelAsync(placement, loadScript);
+        var model = await modelFactory.PrepareMessagesModelAsync(placement, loadScript);
 
         return View("~/Plugins/Payments.PayPalCommerce/Views/Public/_Messages.cshtml", model);
     }

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Controllers/PayPalCommercePublicController.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Controllers/PayPalCommercePublicController.cs
@@ -11,39 +11,18 @@ using Nop.Web.Framework.Mvc.Filters;
 namespace Nop.Plugin.Payments.PayPalCommerce.Controllers;
 
 [AutoValidateAntiforgeryToken]
-public class PayPalCommercePublicController : BasePublicController
-{
-    #region Fields
-
-    private readonly ILocalizationService _localizationService;
-    private readonly INotificationService _notificationService;
-    private readonly IWebHelper _webHelper;
-    private readonly PayPalCommerceModelFactory _modelFactory;
-
-    #endregion
-
-    #region Ctor
-
-    public PayPalCommercePublicController(ILocalizationService localizationService,
+public class PayPalCommercePublicController(ILocalizationService localizationService,
         INotificationService notificationService,
         IWebHelper webHelper,
-        PayPalCommerceModelFactory modelFactory)
-    {
-        _localizationService = localizationService;
-        _notificationService = notificationService;
-        _webHelper = webHelper;
-        _modelFactory = modelFactory;
-    }
-
-    #endregion
-
+        PayPalCommerceModelFactory modelFactory) : BasePublicController
+{
     #region Methods
 
     #region Checkout
 
     public async Task<IActionResult> PluginPaymentInfo()
     {
-        var model = await _modelFactory.PrepareCheckoutPaymentInfoModelAsync();
+        var model = await modelFactory.PrepareCheckoutPaymentInfoModelAsync();
 
         return View("~/Plugins/Payments.PayPalCommerce/Views/Public/PluginPaymentInfo.cshtml", model);
     }
@@ -51,7 +30,7 @@ public class PayPalCommercePublicController : BasePublicController
     [CheckLanguageSeoCode(ignore: true)]
     public async Task<IActionResult> ValidateShoppingCart()
     {
-        var warnings = await _modelFactory.GetShoppingCartWarningsAsync();
+        var warnings = await modelFactory.GetShoppingCartWarningsAsync();
         if (warnings?.Any() ?? false)
             return ErrorJson(warnings.ToArray());
 
@@ -61,7 +40,7 @@ public class PayPalCommercePublicController : BasePublicController
     [HttpPost]
     public async Task<IActionResult> CreateOrder(int placement, string paymentSource, int cardId, bool saveCard)
     {
-        var model = await _modelFactory.PrepareOrderModelAsync((ButtonPlacement)placement, null, paymentSource, cardId, saveCard);
+        var model = await modelFactory.PrepareOrderModelAsync((ButtonPlacement)placement, null, paymentSource, cardId, saveCard);
         if (model.LoginIsRequired)
             return Json(new { redirect = Url.RouteUrl("Login", new { returnUrl = Url.RouteUrl(PayPalCommerceDefaults.Route.ShoppingCart) }) });
 
@@ -81,7 +60,7 @@ public class PayPalCommercePublicController : BasePublicController
     [HttpPost]
     public async Task<IActionResult> GetOrderStatus(int placement, string orderId)
     {
-        var model = await _modelFactory.PrepareOrderModelAsync((ButtonPlacement)placement, orderId, null, null, false);
+        var model = await modelFactory.PrepareOrderModelAsync((ButtonPlacement)placement, orderId, null, null, false);
         if (!string.IsNullOrEmpty(model.Error))
             return ErrorJson(model.Error);
 
@@ -91,7 +70,7 @@ public class PayPalCommercePublicController : BasePublicController
     [HttpPost]
     public async Task<IActionResult> UpdateOrderShipping(OrderShippingModel model)
     {
-        model = await _modelFactory.PrepareOrderShippingModelAsync(model);
+        model = await modelFactory.PrepareOrderShippingModelAsync(model);
         if (!string.IsNullOrEmpty(model.Error))
             return ErrorJson(model.Error);
 
@@ -101,7 +80,7 @@ public class PayPalCommercePublicController : BasePublicController
     [HttpPost]
     public async Task<IActionResult> ApproveOrder(string orderId, string liabilityShift)
     {
-        var model = await _modelFactory.PrepareOrderApprovedModelAsync(orderId, liabilityShift);
+        var model = await modelFactory.PrepareOrderApprovedModelAsync(orderId, liabilityShift);
         if (model.LoginIsRequired)
             return Json(new { redirect = Url.RouteUrl("Login", new { returnUrl = Url.RouteUrl(PayPalCommerceDefaults.Route.ShoppingCart) }) });
 
@@ -121,7 +100,7 @@ public class PayPalCommercePublicController : BasePublicController
         }
 
         //or pay it right now
-        var completedModel = await _modelFactory.PrepareOrderCompletedModelAsync(orderId, liabilityShift);
+        var completedModel = await modelFactory.PrepareOrderCompletedModelAsync(orderId, liabilityShift);
         if (!string.IsNullOrEmpty(completedModel.Error))
             return ErrorJson(completedModel.Error);
 
@@ -131,9 +110,9 @@ public class PayPalCommercePublicController : BasePublicController
     public async Task<IActionResult> ConfirmOrder(string orderId, string token, string liabilityShift, bool approve)
     {
         if (string.IsNullOrEmpty(liabilityShift))
-            liabilityShift = _webHelper.QueryString<string>("liability_shift");
+            liabilityShift = webHelper.QueryString<string>("liability_shift");
 
-        var model = await _modelFactory.PrepareOrderConfirmModelAsync(orderId, token, liabilityShift, approve);
+        var model = await modelFactory.PrepareOrderConfirmModelAsync(orderId, token, liabilityShift, approve);
         if (model.LoginIsRequired)
             return RedirectToRoute("Login", new { returnUrl = Url.RouteUrl(PayPalCommerceDefaults.Route.ShoppingCart) });
 
@@ -141,7 +120,7 @@ public class PayPalCommercePublicController : BasePublicController
             return RedirectToRoute(PayPalCommerceDefaults.Route.ShoppingCart);
 
         if (!string.IsNullOrEmpty(model.Error))
-            _notificationService.ErrorNotification(model.Error);
+            notificationService.ErrorNotification(model.Error);
 
         return View("~/Plugins/Payments.PayPalCommerce/Views/Public/ConfirmOrder.cshtml", model);
     }
@@ -150,7 +129,7 @@ public class PayPalCommercePublicController : BasePublicController
     [HttpPost]
     public async Task<IActionResult> ConfirmOrderPost(string orderId, string orderGuid, string liabilityShift, bool captchaValid)
     {
-        var model = await _modelFactory.PrepareOrderConfirmModelAsync(orderId, orderGuid, null, false);
+        var model = await modelFactory.PrepareOrderConfirmModelAsync(orderId, orderGuid, null, false);
         if (model.LoginIsRequired)
             return RedirectToRoute("Login", new { returnUrl = Url.RouteUrl(PayPalCommerceDefaults.Route.ShoppingCart) });
 
@@ -158,24 +137,24 @@ public class PayPalCommercePublicController : BasePublicController
             return RedirectToRoute(PayPalCommerceDefaults.Route.ShoppingCart);
 
         if (!string.IsNullOrEmpty(model.Error))
-            _notificationService.ErrorNotification(model.Error);
+            notificationService.ErrorNotification(model.Error);
 
         if (model.DisplayCaptcha && !captchaValid)
         {
-            model.Warnings.Add(await _localizationService.GetResourceAsync("Common.WrongCaptchaMessage"));
+            model.Warnings.Add(await localizationService.GetResourceAsync("Common.WrongCaptchaMessage"));
             return View("~/Plugins/Payments.PayPalCommerce/Views/Public/ConfirmOrder.cshtml", model);
         }
 
-        var completedModel = await _modelFactory.PrepareOrderCompletedModelAsync(orderId, liabilityShift);
+        var completedModel = await modelFactory.PrepareOrderCompletedModelAsync(orderId, liabilityShift);
 
         if (!string.IsNullOrEmpty(completedModel.Error))
         {
-            _notificationService.ErrorNotification(completedModel.Error);
+            notificationService.ErrorNotification(completedModel.Error);
             return View("~/Plugins/Payments.PayPalCommerce/Views/Public/ConfirmOrder.cshtml", model);
         }
 
         if (!string.IsNullOrEmpty(completedModel.Warning))
-            _notificationService.ErrorNotification(completedModel.Warning);
+            notificationService.ErrorNotification(completedModel.Warning);
 
         return RedirectToRoute(PayPalCommerceDefaults.Route.CheckoutCompleted, new { orderId = completedModel.OrderId });
     }
@@ -183,7 +162,7 @@ public class PayPalCommercePublicController : BasePublicController
     [HttpPost]
     public async Task<IActionResult> AppleTransactionInfo(int placement)
     {
-        var model = await _modelFactory.PrepareApplePayModelAsync((ButtonPlacement)placement);
+        var model = await modelFactory.PrepareApplePayModelAsync((ButtonPlacement)placement);
         if (model.LoginIsRequired)
             return Json(new { redirect = Url.RouteUrl("Login", new { returnUrl = Url.RouteUrl(PayPalCommerceDefaults.Route.ShoppingCart) }) });
 
@@ -239,7 +218,7 @@ public class PayPalCommercePublicController : BasePublicController
     [HttpPost]
     public async Task<IActionResult> UpdateAppleShipping(ApplePayShippingModel model)
     {
-        model = await _modelFactory.PrepareApplePayShippingModelAsync(model);
+        model = await modelFactory.PrepareApplePayShippingModelAsync(model);
         if (!string.IsNullOrEmpty(model.Error))
             return ErrorJson(model.Error);
 
@@ -261,7 +240,7 @@ public class PayPalCommercePublicController : BasePublicController
     [HttpPost]
     public async Task<IActionResult> GoogleTransactionInfo(int placement)
     {
-        var model = await _modelFactory.PrepareGooglePayModelAsync((ButtonPlacement)placement);
+        var model = await modelFactory.PrepareGooglePayModelAsync((ButtonPlacement)placement);
         if (model.LoginIsRequired)
             return Json(new { redirect = Url.RouteUrl("Login", new { returnUrl = Url.RouteUrl(PayPalCommerceDefaults.Route.ShoppingCart) }) });
 
@@ -301,7 +280,7 @@ public class PayPalCommercePublicController : BasePublicController
     [HttpPost]
     public async Task<IActionResult> CheckGoogleShipping(int placement, int? productId)
     {
-        var (shippingIsRequired, error) = await _modelFactory.CheckShippingIsRequiredAsync(productId);
+        var (shippingIsRequired, error) = await modelFactory.CheckShippingIsRequiredAsync(productId);
         if (!string.IsNullOrEmpty(error))
             return ErrorJson(error);
 
@@ -311,7 +290,7 @@ public class PayPalCommercePublicController : BasePublicController
     [HttpPost]
     public async Task<IActionResult> UpdateGoogleShipping(GooglePayShippingModel model)
     {
-        model = await _modelFactory.PrepareGooglePayShippingModelAsync(model);
+        model = await modelFactory.PrepareGooglePayShippingModelAsync(model);
         if (!string.IsNullOrEmpty(model.Error))
             return ErrorJson(model.Error);
 
@@ -350,7 +329,7 @@ public class PayPalCommercePublicController : BasePublicController
     [HttpPost]
     public async Task<IActionResult> CreateSetupToken()
     {
-        var model = await _modelFactory.PrepareSetupTokenModelAsync();
+        var model = await modelFactory.PrepareSetupTokenModelAsync();
         if (model.LoginIsRequired)
             return Json(new { redirect = Url.RouteUrl("Login", new { returnUrl = Url.RouteUrl(PayPalCommerceDefaults.Route.ShoppingCart) }) });
 
@@ -366,10 +345,10 @@ public class PayPalCommercePublicController : BasePublicController
     public async Task<IActionResult> ApproveToken(string approvalTokenId)
     {
         if (string.IsNullOrEmpty(approvalTokenId))
-            approvalTokenId = _webHelper.QueryString<string>("approval_token_id");
+            approvalTokenId = webHelper.QueryString<string>("approval_token_id");
 
         //create new recurring order
-        var orderModel = await _modelFactory.PrepareRecurringOrderModelAsync(approvalTokenId);
+        var orderModel = await modelFactory.PrepareRecurringOrderModelAsync(approvalTokenId);
         if (orderModel.LoginIsRequired)
             return RedirectToRoute("Login", new { returnUrl = Url.RouteUrl(PayPalCommerceDefaults.Route.ShoppingCart) });
 
@@ -378,17 +357,17 @@ public class PayPalCommercePublicController : BasePublicController
 
         if (!string.IsNullOrEmpty(orderModel.Error))
         {
-            _notificationService.ErrorNotification(orderModel.Error);
+            notificationService.ErrorNotification(orderModel.Error);
             return RedirectToRoute(PayPalCommerceDefaults.Route.ShoppingCart);
         }
 
         //order is created, let's approve it
         var liabilityShift = string.Empty;
-        var approvedModel = await _modelFactory.PrepareOrderApprovedModelAsync(orderModel.OrderId, liabilityShift);
+        var approvedModel = await modelFactory.PrepareOrderApprovedModelAsync(orderModel.OrderId, liabilityShift);
 
         if (!string.IsNullOrEmpty(approvedModel.Error))
         {
-            _notificationService.ErrorNotification(approvedModel.Error);
+            notificationService.ErrorNotification(approvedModel.Error);
             return RedirectToRoute(PayPalCommerceDefaults.Route.ShoppingCart);
         }
 
@@ -397,10 +376,10 @@ public class PayPalCommercePublicController : BasePublicController
             return RedirectToRoute(PayPalCommerceDefaults.Route.ConfirmOrder, new { orderId = approvedModel.OrderId, liabilityShift = liabilityShift });
 
         //or pay it right now
-        var completedModel = await _modelFactory.PrepareOrderCompletedModelAsync(orderModel.OrderId, liabilityShift);
+        var completedModel = await modelFactory.PrepareOrderCompletedModelAsync(orderModel.OrderId, liabilityShift);
         if (!string.IsNullOrEmpty(completedModel.Error))
         {
-            _notificationService.ErrorNotification(completedModel.Error);
+            notificationService.ErrorNotification(completedModel.Error);
             return RedirectToRoute(PayPalCommerceDefaults.Route.ShoppingCart);
         }
 
@@ -411,12 +390,12 @@ public class PayPalCommercePublicController : BasePublicController
 
     public async Task<IActionResult> PaymentTokens()
     {
-        var model = await _modelFactory.PreparePaymentTokenListModelAsync();
+        var model = await modelFactory.PreparePaymentTokenListModelAsync();
         if (!model.VaultIsEnabled)
             return RedirectToRoute(PayPalCommerceDefaults.Route.CustomerInfo);
 
         if (!string.IsNullOrEmpty(model.Error))
-            _notificationService.ErrorNotification(model.Error);
+            notificationService.ErrorNotification(model.Error);
 
         return View("~/Plugins/Payments.PayPalCommerce/Views/Public/PaymentTokens.cshtml", model);
 
@@ -425,7 +404,7 @@ public class PayPalCommercePublicController : BasePublicController
     [HttpPost]
     public async Task<IActionResult> PaymentTokensDelete(int tokenId)
     {
-        var model = await _modelFactory.PreparePaymentTokenListModelAsync(deleteTokenId: tokenId);
+        var model = await modelFactory.PreparePaymentTokenListModelAsync(deleteTokenId: tokenId);
         if (!model.VaultIsEnabled)
             return Json(new { redirect = Url.RouteUrl(PayPalCommerceDefaults.Route.CustomerInfo) });
 
@@ -438,7 +417,7 @@ public class PayPalCommercePublicController : BasePublicController
     [HttpPost]
     public async Task<IActionResult> PaymentTokensMarkDefault(int tokenId)
     {
-        var model = await _modelFactory.PreparePaymentTokenListModelAsync(defaultTokenId: tokenId);
+        var model = await modelFactory.PreparePaymentTokenListModelAsync(defaultTokenId: tokenId);
         if (!model.VaultIsEnabled)
             return Json(new { redirect = Url.RouteUrl(PayPalCommerceDefaults.Route.CustomerInfo) });
 
@@ -451,7 +430,7 @@ public class PayPalCommercePublicController : BasePublicController
     [HttpPost]
     public async Task<IActionResult> GetSavedCards(int placement)
     {
-        var model = await _modelFactory.PrepareSavedCardListModelAsync((ButtonPlacement)placement);
+        var model = await modelFactory.PrepareSavedCardListModelAsync((ButtonPlacement)placement);
         if (!string.IsNullOrEmpty(model.Error))
             return ErrorJson(model.Error);
 

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Controllers/PayPalCommerceWebhookController.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Controllers/PayPalCommerceWebhookController.cs
@@ -3,32 +3,15 @@ using Nop.Plugin.Payments.PayPalCommerce.Services;
 
 namespace Nop.Plugin.Payments.PayPalCommerce.Controllers;
 
-public class PayPalCommerceWebhookController : Controller
+public class PayPalCommerceWebhookController(PayPalCommerceServiceManager serviceManager,
+        PayPalCommerceSettings settings) : Controller
 {
-    #region Fields
-
-    private readonly PayPalCommerceServiceManager _serviceManager;
-    private readonly PayPalCommerceSettings _settings;
-
-    #endregion
-
-    #region Ctor
-
-    public PayPalCommerceWebhookController(PayPalCommerceServiceManager serviceManager,
-        PayPalCommerceSettings settings)
-    {
-        _serviceManager = serviceManager;
-        _settings = settings;
-    }
-
-    #endregion
-
     #region Methods
 
     [HttpPost]
     public async Task<IActionResult> WebhookHandler()
     {
-        await _serviceManager.HandleWebhookAsync(_settings, Request);
+        await serviceManager.HandleWebhookAsync(settings, Request);
         return Ok();
     }
 

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Data/AdvancedCardsMigration.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Data/AdvancedCardsMigration.cs
@@ -11,35 +11,12 @@ using Nop.Web.Framework.Extensions;
 namespace Nop.Plugin.Payments.PayPalCommerce.Data;
 
 [NopMigration("2024-06-06 00:00:01", "Payments.PayPalCommerce 4.70.10. Advanced cards", MigrationProcessType.Update)]
-public class AdvancedCardsMigration : MigrationBase
-{
-    #region Fields
-
-    private readonly ILocalizationService _localizationService;
-    private readonly ISettingService _settingService;
-    private readonly OnboardingHttpClient _httpClient;
-    private readonly PayPalCommerceServiceManager _serviceManager;
-    private readonly PayPalCommerceSettings _settings;
-
-    #endregion
-
-    #region Ctor
-
-    public AdvancedCardsMigration(ILocalizationService localizationService,
+public class AdvancedCardsMigration(ILocalizationService localizationService,
         ISettingService settingService,
         OnboardingHttpClient httpClient,
         PayPalCommerceServiceManager serviceManager,
-        PayPalCommerceSettings settings)
-    {
-        _localizationService = localizationService;
-        _settingService = settingService;
-        _httpClient = httpClient;
-        _serviceManager = serviceManager;
-        _settings = settings;
-    }
-
-    #endregion
-
+        PayPalCommerceSettings settings) : MigrationBase
+{
     #region Methods
 
     /// <summary>
@@ -55,7 +32,7 @@ public class AdvancedCardsMigration : MigrationBase
 
         var (languageId, languages) = this.GetLanguageData();
 
-        _localizationService.AddOrUpdateLocaleResource(new Dictionary<string, string>
+        localizationService.AddOrUpdateLocaleResource(new Dictionary<string, string>
         {
             ["Enums.Nop.Plugin.Payments.PayPalCommerce.Domain.ButtonPlacement.Cart"] = "Shopping cart",
             ["Enums.Nop.Plugin.Payments.PayPalCommerce.Domain.ButtonPlacement.Product"] = "Product",
@@ -119,68 +96,68 @@ public class AdvancedCardsMigration : MigrationBase
             ["Plugins.Payments.PayPalCommerce.Shipment.Carrier.Hint"] = "Specify the carrier for the shipment (e.g. UPS or FEDEX_UK, see allowed values on PayPal site).",
         }, languageId);
 
-        if (!_settingService.SettingExists(_settings, settings => settings.MerchantId))
-            _settings.MerchantId = null;
+        if (!settingService.SettingExists(settings, settings => settings.MerchantId))
+            settings.MerchantId = null;
 
-        if (!_settingService.SettingExists(_settings, settings => settings.UseCardFields))
-            _settings.UseCardFields = false;
+        if (!settingService.SettingExists(settings, settings => settings.UseCardFields))
+            settings.UseCardFields = false;
 
-        if (!_settingService.SettingExists(_settings, settings => settings.CustomerAuthenticationRequired))
-            _settings.CustomerAuthenticationRequired = true;
+        if (!settingService.SettingExists(settings, settings => settings.CustomerAuthenticationRequired))
+            settings.CustomerAuthenticationRequired = true;
 
-        if (!_settingService.SettingExists(_settings, settings => settings.UseApplePay))
-            _settings.UseApplePay = false;
+        if (!settingService.SettingExists(settings, settings => settings.UseApplePay))
+            settings.UseApplePay = false;
 
-        if (!_settingService.SettingExists(_settings, settings => settings.UseGooglePay))
-            _settings.UseGooglePay = false;
+        if (!settingService.SettingExists(settings, settings => settings.UseGooglePay))
+            settings.UseGooglePay = false;
 
-        if (!_settingService.SettingExists(_settings, settings => settings.UseAlternativePayments))
-            _settings.UseAlternativePayments = false;
+        if (!settingService.SettingExists(settings, settings => settings.UseAlternativePayments))
+            settings.UseAlternativePayments = false;
 
-        if (!_settingService.SettingExists(_settings, settings => settings.UseVault))
-            _settings.UseVault = false;
+        if (!settingService.SettingExists(settings, settings => settings.UseVault))
+            settings.UseVault = false;
 
-        if (!_settingService.SettingExists(_settings, settings => settings.SkipOrderConfirmPage))
-            _settings.SkipOrderConfirmPage = false;
+        if (!settingService.SettingExists(settings, settings => settings.SkipOrderConfirmPage))
+            settings.SkipOrderConfirmPage = false;
 
-        if (!_settingService.SettingExists(_settings, settings => settings.UseShipmentTracking))
-            _settings.UseShipmentTracking = false;
+        if (!settingService.SettingExists(settings, settings => settings.UseShipmentTracking))
+            settings.UseShipmentTracking = false;
 
-        if (!_settingService.SettingExists(_settings, settings => settings.DisplayButtonsOnPaymentMethod))
-            _settings.DisplayButtonsOnPaymentMethod = true;
+        if (!settingService.SettingExists(settings, settings => settings.DisplayButtonsOnPaymentMethod))
+            settings.DisplayButtonsOnPaymentMethod = true;
 
-        if (!_settingService.SettingExists(_settings, settings => settings.HideCheckoutButton))
-            _settings.HideCheckoutButton = false;
+        if (!settingService.SettingExists(settings, settings => settings.HideCheckoutButton))
+            settings.HideCheckoutButton = false;
 
-        if (!_settingService.SettingExists(_settings, settings => settings.ImmediatePaymentRequired))
-            _settings.ImmediatePaymentRequired = false;
+        if (!settingService.SettingExists(settings, settings => settings.ImmediatePaymentRequired))
+            settings.ImmediatePaymentRequired = false;
 
-        if (!_settingService.SettingExists(_settings, settings => settings.OrderValidityInterval))
-            _settings.OrderValidityInterval = 300;
+        if (!settingService.SettingExists(settings, settings => settings.OrderValidityInterval))
+            settings.OrderValidityInterval = 300;
 
-        if (!_settingService.SettingExists(_settings, settings => settings.ConfiguratorSupported))
-            _settings.ConfiguratorSupported = false;
+        if (!settingService.SettingExists(settings, settings => settings.ConfiguratorSupported))
+            settings.ConfiguratorSupported = false;
 
-        if (!_settingService.SettingExists(_settings, settings => settings.PayLaterConfig))
-            _settings.PayLaterConfig = null;
+        if (!settingService.SettingExists(settings, settings => settings.PayLaterConfig))
+            settings.PayLaterConfig = null;
 
-        if (!_settingService.SettingExists(_settings, settings => settings.MerchantIdRequired))
-            _settings.MerchantIdRequired = false;
+        if (!settingService.SettingExists(settings, settings => settings.MerchantIdRequired))
+            settings.MerchantIdRequired = false;
 
         try
         {
-            if (_settings.SetCredentialsManually)
-                _settings.MerchantIdRequired = true;
-            else if (!string.IsNullOrEmpty(_settings.MerchantGuid) && _serviceManager.IsActiveAsync(_settings).Result.Active)
+            if (settings.SetCredentialsManually)
+                settings.MerchantIdRequired = true;
+            else if (!string.IsNullOrEmpty(settings.MerchantGuid) && serviceManager.IsActiveAsync(settings).Result.Active)
             {
-                _settings.MerchantIdRequired = true;
-                _settings.MerchantId = _httpClient.GetMerchantAsync(_settings.MerchantGuid).Result?.MerchantId;
-                _settings.MerchantIdRequired = string.IsNullOrEmpty(_settings.MerchantId);
+                settings.MerchantIdRequired = true;
+                settings.MerchantId = httpClient.GetMerchantAsync(settings.MerchantGuid).Result?.MerchantId;
+                settings.MerchantIdRequired = string.IsNullOrEmpty(settings.MerchantId);
             }
         }
         catch { }
 
-        _settingService.SaveSetting(_settings);
+        settingService.SaveSetting(settings);
     }
 
     /// <summary>

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Services/PayPalCommerceHttpClient.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Services/PayPalCommerceHttpClient.cs
@@ -12,22 +12,11 @@ namespace Nop.Plugin.Payments.PayPalCommerce.Services;
 /// <summary>
 /// Represents the HTTP client to request PayPal API
 /// </summary>
-public class PayPalCommerceHttpClient
+public class PayPalCommerceHttpClient(HttpClient httpClient)
 {
     #region Fields
 
-    private readonly HttpClient _httpClient;
-
     private static Dictionary<string, AccessToken> _accessTokens = new();
-
-    #endregion
-
-    #region Ctor
-
-    public PayPalCommerceHttpClient(HttpClient httpClient)
-    {
-        _httpClient = httpClient;
-    }
 
     #endregion
 
@@ -102,8 +91,8 @@ public class PayPalCommerceHttpClient
         try
         {
             var timeout = TimeSpan.FromSeconds(settings.RequestTimeout ?? PayPalCommerceDefaults.RequestTimeout);
-            if (_httpClient.Timeout != timeout)
-                _httpClient.Timeout = timeout;
+            if (httpClient.Timeout != timeout)
+                httpClient.Timeout = timeout;
         }
         catch { }
 
@@ -125,7 +114,7 @@ public class PayPalCommerceHttpClient
         requestMessage.Headers.Add("Prefer", "return=representation");
 
         //execute the request and get a result
-        var httpResponse = await _httpClient.SendAsync(requestMessage);
+        var httpResponse = await httpClient.SendAsync(requestMessage);
         var responseString = await httpResponse.Content.ReadAsStringAsync();
 
         //successful request processing

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Services/PayPalTokenService.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Services/PayPalTokenService.cs
@@ -6,23 +6,8 @@ namespace Nop.Plugin.Payments.PayPalCommerce.Services;
 /// <summary>
 /// Represents the payment token service
 /// </summary>
-public class PayPalTokenService
+public class PayPalTokenService(IRepository<PayPalToken> tokenRepository)
 {
-    #region Fields
-
-    private readonly IRepository<PayPalToken> _tokenRepository;
-
-    #endregion
-
-    #region Ctor
-
-    public PayPalTokenService(IRepository<PayPalToken> tokenRepository)
-    {
-        _tokenRepository = tokenRepository;
-    }
-
-    #endregion
-
     #region Methods
 
     /// <summary>
@@ -40,7 +25,7 @@ public class PayPalTokenService
     public async Task<IList<PayPalToken>> GetAllTokensAsync(string clientId, int customerId = 0,
         string vaultId = null, string vaultCustomerId = null, string type = null)
     {
-        return await _tokenRepository.GetAllAsync(query =>
+        return await tokenRepository.GetAllAsync(query =>
         {
             query = query.Where(token => token.ClientId == clientId);
 
@@ -86,7 +71,7 @@ public class PayPalTokenService
     /// </returns>
     public async Task<PayPalToken> GetByIdAsync(int id)
     {
-        return await _tokenRepository.GetByIdAsync(id, null);
+        return await tokenRepository.GetByIdAsync(id, null);
     }
 
     /// <summary>
@@ -120,7 +105,7 @@ public class PayPalTokenService
             token.IsPrimaryMethod = true;
 
         //or insert a new one
-        await _tokenRepository.InsertAsync(token, false);
+        await tokenRepository.InsertAsync(token, false);
     }
 
     /// <summary>
@@ -130,7 +115,7 @@ public class PayPalTokenService
     /// <returns>A task that represents the asynchronous operation</returns>
     public async Task UpdateAsync(PayPalToken token)
     {
-        await _tokenRepository.UpdateAsync(token, false);
+        await tokenRepository.UpdateAsync(token, false);
     }
 
     /// <summary>
@@ -140,7 +125,7 @@ public class PayPalTokenService
     /// <returns>A task that represents the asynchronous operation</returns>
     public async Task DeleteAsync(PayPalToken token)
     {
-        await _tokenRepository.DeleteAsync(token, false);
+        await tokenRepository.DeleteAsync(token, false);
 
         //mark one of the remaining tokens as default
         var tokens = await GetAllTokensAsync(token.ClientId, token.CustomerId);
@@ -162,7 +147,7 @@ public class PayPalTokenService
     /// <returns>A task that represents the asynchronous operation</returns>
     public async Task DeleteAsync(IList<PayPalToken> tokens)
     {
-        await _tokenRepository.DeleteAsync(tokens, false);
+        await tokenRepository.DeleteAsync(tokens, false);
     }
 
     #endregion

--- a/src/Plugins/Nop.Plugin.Search.Lucene/LuceneSearchProvider.cs
+++ b/src/Plugins/Nop.Plugin.Search.Lucene/LuceneSearchProvider.cs
@@ -7,23 +7,8 @@ namespace Nop.Plugin.Search.Lucene;
 /// <summary>
 /// Represents Lucene search provider helper plugin
 /// </summary>
-public class LuceneSearchProvider : BasePlugin, IMiscPlugin
+public class LuceneSearchProvider(IWebHelper webHelper) : BasePlugin, IMiscPlugin
 {
-    #region Fields
-
-    private readonly IWebHelper _webHelper;
-
-    #endregion
-
-    #region Ctor
-
-    public LuceneSearchProvider(IWebHelper webHelper)
-    {
-        _webHelper = webHelper;
-    }
-
-    #endregion
-
     #region Methods
 
     /// <summary>
@@ -31,7 +16,7 @@ public class LuceneSearchProvider : BasePlugin, IMiscPlugin
     /// </summary>
     public override string GetConfigurationPageUrl()
     {
-        return $"{_webHelper.GetStoreLocation()}Admin/Lucene/Configure";
+        return $"{webHelper.GetStoreLocation()}Admin/Lucene/Configure";
     }
 
     /// <summary>

--- a/src/Plugins/Nop.Plugin.Shipping.UPS/API/NullToEmptyStringValueProvider.cs
+++ b/src/Plugins/Nop.Plugin.Shipping.UPS/API/NullToEmptyStringValueProvider.cs
@@ -3,23 +3,16 @@ using Newtonsoft.Json.Serialization;
 
 namespace Nop.Plugin.Shipping.UPS.API;
 
-public class NullToEmptyStringValueProvider : IValueProvider
+public class NullToEmptyStringValueProvider(PropertyInfo memberInfo) : IValueProvider
 {
-    private readonly PropertyInfo _memberInfo;
-
-    public NullToEmptyStringValueProvider(PropertyInfo memberInfo)
-    {
-        _memberInfo = memberInfo;
-    }
-
     public object GetValue(object target)
     {
-        var result = _memberInfo.GetValue(target);
+        var result = memberInfo.GetValue(target);
 
-        if (_memberInfo.PropertyType != typeof(string))
+        if (memberInfo.PropertyType != typeof(string))
             return result;
 
-        var attributes = _memberInfo
+        var attributes = memberInfo
             .GetCustomAttributes(typeof(System.ComponentModel.DataAnnotations.RequiredAttribute)).FirstOrDefault() as System.ComponentModel.DataAnnotations.RequiredAttribute;
             
         if ((attributes?.AllowEmptyStrings ?? false) && result == null)
@@ -30,6 +23,6 @@ public class NullToEmptyStringValueProvider : IValueProvider
 
     public void SetValue(object target, object value)
     {
-        _memberInfo.SetValue(target, value);
+        memberInfo.SetValue(target, value);
     }
 }

--- a/src/Plugins/Nop.Plugin.Shipping.UPS/UPSComputationMethod.cs
+++ b/src/Plugins/Nop.Plugin.Shipping.UPS/UPSComputationMethod.cs
@@ -12,32 +12,11 @@ namespace Nop.Plugin.Shipping.UPS;
 /// <summary>
 /// Represents UPS computation method
 /// </summary>
-public class UPSComputationMethod : BasePlugin, IShippingRateComputationMethod
-{
-    #region Fields
-
-    private readonly ILocalizationService _localizationService;
-    private readonly ISettingService _settingService;
-    private readonly IWebHelper _webHelper;
-    private readonly UPSService _upsService;
-
-    #endregion
-
-    #region Ctor
-
-    public UPSComputationMethod(ILocalizationService localizationService,
+public class UPSComputationMethod(ILocalizationService localizationService,
         ISettingService settingService,
         IWebHelper webHelper,
-        UPSService upsService)
-    {
-        _localizationService = localizationService;
-        _settingService = settingService;
-        _webHelper = webHelper;
-        _upsService = upsService;
-    }
-
-    #endregion
-
+        UPSService upsService) : BasePlugin, IShippingRateComputationMethod
+{
     #region Methods
 
     /// <summary>
@@ -58,7 +37,7 @@ public class UPSComputationMethod : BasePlugin, IShippingRateComputationMethod
         if (getShippingOptionRequest.ShippingAddress?.CountryId == null)
             return new GetShippingOptionResponse { Errors = new[] { "Shipping address is not set" } };
 
-        return await _upsService.GetRatesAsync(getShippingOptionRequest);
+        return await upsService.GetRatesAsync(getShippingOptionRequest);
     }
 
     /// <summary>
@@ -83,7 +62,7 @@ public class UPSComputationMethod : BasePlugin, IShippingRateComputationMethod
     /// </returns>
     public Task<IShipmentTracker> GetShipmentTrackerAsync()
     {
-        return Task.FromResult<IShipmentTracker>(new UPSShipmentTracker(_upsService));
+        return Task.FromResult<IShipmentTracker>(new UPSShipmentTracker(upsService));
     }
 
     /// <summary>
@@ -91,7 +70,7 @@ public class UPSComputationMethod : BasePlugin, IShippingRateComputationMethod
     /// </summary>
     public override string GetConfigurationPageUrl()
     {
-        return $"{_webHelper.GetStoreLocation()}Admin/UPSShipping/Configure";
+        return $"{webHelper.GetStoreLocation()}Admin/UPSShipping/Configure";
     }
 
     /// <summary>
@@ -101,7 +80,7 @@ public class UPSComputationMethod : BasePlugin, IShippingRateComputationMethod
     public override async Task InstallAsync()
     {
         //settings
-        await _settingService.SaveSettingAsync(new UPSSettings
+        await settingService.SaveSettingAsync(new UPSSettings
         {
             UseSandbox = true,
             CustomerClassification = CustomerClassification.StandardListRates,
@@ -116,7 +95,7 @@ public class UPSComputationMethod : BasePlugin, IShippingRateComputationMethod
         });
 
         //locales
-        await _localizationService.AddOrUpdateLocaleResourceAsync(new Dictionary<string, string>
+        await localizationService.AddOrUpdateLocaleResourceAsync(new Dictionary<string, string>
         {
             ["Enums.Nop.Plugin.Shipping.UPS.PackingType.PackByDimensions"] = "Pack by dimensions",
             ["Enums.Nop.Plugin.Shipping.UPS.PackingType.PackByOneItemPerPackage"] = "Pack by one item per package",
@@ -175,11 +154,11 @@ public class UPSComputationMethod : BasePlugin, IShippingRateComputationMethod
     public override async Task UninstallAsync()
     {
         //settings
-        await _settingService.DeleteSettingAsync<UPSSettings>();
+        await settingService.DeleteSettingAsync<UPSSettings>();
 
         //locales
-        await _localizationService.DeleteLocaleResourcesAsync("Enums.Nop.Plugin.Shipping.UPS");
-        await _localizationService.DeleteLocaleResourcesAsync("Plugins.Shipping.UPS");
+        await localizationService.DeleteLocaleResourcesAsync("Enums.Nop.Plugin.Shipping.UPS");
+        await localizationService.DeleteLocaleResourcesAsync("Plugins.Shipping.UPS");
 
         await base.UninstallAsync();
     }

--- a/src/Plugins/Nop.Plugin.Shipping.UPS/UPSShipmentTracker.cs
+++ b/src/Plugins/Nop.Plugin.Shipping.UPS/UPSShipmentTracker.cs
@@ -7,23 +7,8 @@ namespace Nop.Plugin.Shipping.UPS;
 /// <summary>
 /// Represents the USP shipment tracker
 /// </summary>
-public class UPSShipmentTracker : IShipmentTracker
+public class UPSShipmentTracker(UPSService upsService) : IShipmentTracker
 {
-    #region Fields
-
-    private readonly UPSService _upsService;
-
-    #endregion
-
-    #region Ctor
-
-    public UPSShipmentTracker(UPSService upsService)
-    {
-        _upsService = upsService;
-    }
-
-    #endregion
-
     #region Methods
 
     /// <summary>
@@ -56,7 +41,7 @@ public class UPSShipmentTracker : IShipmentTracker
         if (string.IsNullOrEmpty(trackingNumber))
             return result;
 
-        result.AddRange(await _upsService.GetShipmentEventsAsync(trackingNumber));
+        result.AddRange(await upsService.GetShipmentEventsAsync(trackingNumber));
 
         return result;
     }

--- a/src/Plugins/Nop.Plugin.Widgets.Swiper/Infrastructure/Cache/ModelCacheEventConsumer.cs
+++ b/src/Plugins/Nop.Plugin.Widgets.Swiper/Infrastructure/Cache/ModelCacheEventConsumer.cs
@@ -8,27 +8,11 @@ namespace Nop.Plugin.Widgets.Swiper.Infrastructure.Cache;
 /// <summary>
 /// Model cache event consumer (used for caching of presentation layer models)
 /// </summary>
-public class ModelCacheEventConsumer :
+public class ModelCacheEventConsumer(IStaticCacheManager staticCacheManager) :
     IConsumer<EntityInsertedEvent<Setting>>,
     IConsumer<EntityUpdatedEvent<Setting>>,
     IConsumer<EntityDeletedEvent<Setting>>
 {
-
-    #region Fields
-
-    private readonly IStaticCacheManager _staticCacheManager;
-
-    #endregion
-
-    #region Ctor
-
-    public ModelCacheEventConsumer(IStaticCacheManager staticCacheManager)
-    {
-        _staticCacheManager = staticCacheManager;
-    }
-
-    #endregion
-
     #region Methods
 
     /// <summary>
@@ -38,7 +22,7 @@ public class ModelCacheEventConsumer :
     /// <returns>A task that represents the asynchronous operation</returns>
     public async Task HandleEventAsync(EntityInsertedEvent<Setting> eventMessage)
     {
-        await _staticCacheManager.RemoveByPrefixAsync(PictureUrlPrefix);
+        await staticCacheManager.RemoveByPrefixAsync(PictureUrlPrefix);
     }
 
     /// <summary>
@@ -48,7 +32,7 @@ public class ModelCacheEventConsumer :
     /// <returns>A task that represents the asynchronous operation</returns>
     public async Task HandleEventAsync(EntityUpdatedEvent<Setting> eventMessage)
     {
-        await _staticCacheManager.RemoveByPrefixAsync(PictureUrlPrefix);
+        await staticCacheManager.RemoveByPrefixAsync(PictureUrlPrefix);
     }
 
     /// <summary>
@@ -58,7 +42,7 @@ public class ModelCacheEventConsumer :
     /// <returns>A task that represents the asynchronous operation</returns>
     public async Task HandleEventAsync(EntityDeletedEvent<Setting> eventMessage)
     {
-        await _staticCacheManager.RemoveByPrefixAsync(PictureUrlPrefix);
+        await staticCacheManager.RemoveByPrefixAsync(PictureUrlPrefix);
     }
 
     #endregion

--- a/src/Presentation/Nop.Web.Framework/Events/BaseMenuItemCreatedEvent.cs
+++ b/src/Presentation/Nop.Web.Framework/Events/BaseMenuItemCreatedEvent.cs
@@ -5,15 +5,8 @@ namespace Nop.Web.Framework.Events;
 /// <summary>
 /// Represents the base event that occurs after admin menu item create
 /// </summary>
-public abstract partial class BaseMenuItemCreatedEvent
+public abstract partial class BaseMenuItemCreatedEvent(IAdminMenu adminMenu)
 {
-    private readonly IAdminMenu _adminMenu;
-
-    protected BaseMenuItemCreatedEvent(IAdminMenu adminMenu)
-    {
-        _adminMenu = adminMenu;
-    }
-
     /// <summary>
     /// Generates an admin menu item URL 
     /// </summary>
@@ -21,6 +14,6 @@ public abstract partial class BaseMenuItemCreatedEvent
     /// <param name="actionName">The name of the action method</param>
     public virtual string GetMenuItemUrl(string controllerName, string actionName)
     {
-        return _adminMenu.GetMenuItemUrl(controllerName, actionName);
+        return adminMenu.GetMenuItemUrl(controllerName, actionName);
     }
 }

--- a/src/Presentation/Nop.Web/Areas/Admin/Factories/LanguageModelFactory.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Factories/LanguageModelFactory.cs
@@ -11,35 +11,12 @@ namespace Nop.Web.Areas.Admin.Factories;
 /// <summary>
 /// Represents the language model factory implementation
 /// </summary>
-public partial class LanguageModelFactory : ILanguageModelFactory
-{
-    #region Fields
-
-    private readonly IBaseAdminModelFactory _baseAdminModelFactory;
-    private readonly INopFileProvider _fileProvider;
-    private readonly ILanguageService _languageService;
-    private readonly ILocalizationService _localizationService;
-    private readonly IStoreMappingSupportedModelFactory _storeMappingSupportedModelFactory;
-
-    #endregion
-
-    #region Ctor
-
-    public LanguageModelFactory(IBaseAdminModelFactory baseAdminModelFactory,
+public partial class LanguageModelFactory(IBaseAdminModelFactory baseAdminModelFactory,
         INopFileProvider fileProvider,
         ILanguageService languageService,
         ILocalizationService localizationService,
-        IStoreMappingSupportedModelFactory storeMappingSupportedModelFactory)
-    {
-        _baseAdminModelFactory = baseAdminModelFactory;
-        _fileProvider = fileProvider;
-        _languageService = languageService;
-        _localizationService = localizationService;
-        _storeMappingSupportedModelFactory = storeMappingSupportedModelFactory;
-    }
-
-    #endregion
-
+        IStoreMappingSupportedModelFactory storeMappingSupportedModelFactory) : ILanguageModelFactory
+{
     #region Utilities
 
     /// <summary>
@@ -97,7 +74,7 @@ public partial class LanguageModelFactory : ILanguageModelFactory
         ArgumentNullException.ThrowIfNull(searchModel);
 
         //get languages
-        var languages = (await _languageService.GetAllLanguagesAsync(showHidden: true)).ToPagedList(searchModel);
+        var languages = (await languageService.GetAllLanguagesAsync(showHidden: true)).ToPagedList(searchModel);
 
         //prepare list model
         var model = new LanguageListModel().PrepareToGrid(searchModel, languages, () =>
@@ -132,12 +109,12 @@ public partial class LanguageModelFactory : ILanguageModelFactory
         //set default values for the new model
         if (language == null)
         {
-            model.DisplayOrder = (await _languageService.GetAllLanguagesAsync()).Max(l => l.DisplayOrder) + 1;
+            model.DisplayOrder = (await languageService.GetAllLanguagesAsync()).Max(l => l.DisplayOrder) + 1;
             model.Published = true;
         }
-        var flagNames = _fileProvider
-            .EnumerateFiles(_fileProvider.GetAbsolutePath(@"images\flags"), "*.png")
-            .Select(_fileProvider.GetFileName)
+        var flagNames = fileProvider
+            .EnumerateFiles(fileProvider.GetAbsolutePath(@"images\flags"), "*.png")
+            .Select(fileProvider.GetFileName)
             .ToList();
 
         model.AvailableFlagImages = flagNames.ConvertAll(flagName => new Microsoft.AspNetCore.Mvc.Rendering.SelectListItem
@@ -147,11 +124,11 @@ public partial class LanguageModelFactory : ILanguageModelFactory
         });
 
         //prepare available currencies
-        await _baseAdminModelFactory.PrepareCurrenciesAsync(model.AvailableCurrencies,
-            defaultItemText: await _localizationService.GetResourceAsync("Admin.Common.EmptyItemText"));
+        await baseAdminModelFactory.PrepareCurrenciesAsync(model.AvailableCurrencies,
+            defaultItemText: await localizationService.GetResourceAsync("Admin.Common.EmptyItemText"));
 
         //prepare available stores
-        await _storeMappingSupportedModelFactory.PrepareModelStoresAsync(model, language, excludeProperties);
+        await storeMappingSupportedModelFactory.PrepareModelStoresAsync(model, language, excludeProperties);
 
         return model;
     }
@@ -172,7 +149,7 @@ public partial class LanguageModelFactory : ILanguageModelFactory
         ArgumentNullException.ThrowIfNull(language);
 
         //get locale resources
-        var localeResources = (await _localizationService.GetAllResourceValuesAsync(language.Id, loadPublicLocales: null))
+        var localeResources = (await localizationService.GetAllResourceValuesAsync(language.Id, loadPublicLocales: null))
             .OrderBy(localeResource => localeResource.Key).AsQueryable();
 
         //filter locale resources


### PR DESCRIPTION
This commit modifies multiple classes to use parameterized constructors instead of traditional field assignments, enhancing dependency injection. The `_` prefix for private fields has been removed, and fields are now accessed directly through constructor parameters, improving code readability and consistency.

Method calls have been updated to replace private fields with their corresponding parameterized versions. Additionally, logging and error handling have been refined to align with the new field access patterns.

These changes aim to create a cleaner, more maintainable codebase by leveraging constructor injection and reducing reliance on private fields, ultimately making the code easier to manage and understand.