### PR TITLE
Replace obsolete SKBitmap.Resize method in PictureService

### DIFF
--- a/src/Libraries/Nop.Services/Media/PictureService.cs
+++ b/src/Libraries/Nop.Services/Media/PictureService.cs
@@ -390,7 +390,8 @@ public partial class PictureService : IPictureService
         }
         try
         {
-            using var resizedBitmap = image.Resize(new SKImageInfo((int)width, (int)height), SKFilterQuality.Medium);
+            var samplingOption = new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.Linear);
+            using var resizedBitmap = image.Resize(new SKImageInfo((int)width, (int)height), samplingOption);
             using var cropImage = SKImage.FromBitmap(resizedBitmap);
 
             //In order to exclude saving pictures in low quality at the time of installation, we will set the value of this parameter to 80 (as by default)


### PR DESCRIPTION
Replaced the deprecated SKBitmap.Resize method that used SKFilterQuality.Medium with the recommended SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.Linear), which preserves the same image resize behavior.

In SKPaint.cs, SKFilterQuality.Medium maps to new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.Linear) (see attached screenshot)

![image](https://github.com/user-attachments/assets/c5435d44-677c-48f7-8222-743fe9d25b21)
