### PR TITLE
Replace obsolete SKBitmap.ScalePixels with recommended SKSamplingOptions in RoxyFilemanFileProvider

### DIFF
--- a/src/Libraries/Nop.Services/Media/RoxyFileman/RoxyFilemanFileProvider.cs
+++ b/src/Libraries/Nop.Services/Media/RoxyFileman/RoxyFilemanFileProvider.cs
@@ -199,8 +199,9 @@ using SkiaSharp;
          var (width, height) = ValidateImageMeasures(image, maxWidth, maxHeight);
 
          var toBitmap = new SKBitmap(width, height, image.ColorType, image.AlphaType);
+         var samplingOptions = new SKSamplingOptions(SKFilterMode.Nearest, SKMipmapMode.None);
 
-         if (!image.ScalePixels(toBitmap, SKFilterQuality.None))
+         if (!image.ScalePixels(toBitmap, samplingOptions))
              throw new Exception("Image scaling");
 
          var newImage = SKImage.FromBitmap(toBitmap);


### PR DESCRIPTION
Replaced the deprecated SKBitmap.ScalePixels method that used SKFilterQuality.None with the recommended SKSamplingOptions (SKFilterMode.Nearest, SKMipmapMode.None), which preserves the same ScalePixels behavior.

In SKPaint.cs, SKFilterQuality.None maps to new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.Linear) (see attached screenshot)

![image](https://github.com/user-attachments/assets/db8381f9-9dd5-4d35-a243-4dda49d27b08)
