### PR TITLE
fix: [7654] update TinyMCE toolbar for v6 compatibility

### DIFF
--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/RichEditor.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/EditorTemplates/RichEditor.cshtml
@@ -87,7 +87,8 @@
                 'searchreplace', 'visualblocks', 'code', 'fullscreen',
                 'insertdatetime', 'media', 'table'
             ],
-            toolbar: "ltr rtl | insertfile undo redo | styleselect | fontselect | fontsizeselect | bold italic | forecolor backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
+			// Updated toolbar items for TinyMCE v6: styleselect -> style, fontselect -> fontfamily, fontsizeselect -> fontsize
+			toolbar: "ltr rtl | insertfile undo redo | style | fontfamily | fontsize | bold italic | forecolor backcolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link image",
             relative_urls: false,
             suffix: '.min',
             base_url: '@Url.Content("~/lib_npm/tinymce")',


### PR DESCRIPTION
### Description
This PR fixes an issue with the TinyMCE editor toolbar not displaying correctly after upgrading to TinyMCE 6.x. The problem was caused by renamed toolbar item identifiers that are no longer recognized in version 6.

### Changes Made
Replaced deprecated toolbar items:

styleselect ➡️ style
fontselect ➡️ fontfamily
fontsizeselect ➡️ fontsize

These changes were made in RichEditor.cshtml to align with the [TinyMCE 6 Migration Guide](https://www.tiny.cloud/docs/tinymce/6/migration-from-5x/#things-we-renamed).

### Related Issue
Fixes #7564