### PR TITLE
Prevent Overwriting of Configuration File by Adding Existence Check

### DIFF
--- a/src/Libraries/Nop.Core/Configuration/AppSettingsHelper.cs
+++ b/src/Libraries/Nop.Core/Configuration/AppSettingsHelper.cs
@@ -39,7 +39,11 @@ public partial class AppSettingsHelper
         //create file if not exists
         var filePath = fileProvider.MapPath(NopConfigurationDefaults.AppSettingsFilePath);
         var fileExists = fileProvider.FileExists(filePath);
-        fileProvider.CreateFile(filePath);
+        // Only create the file if it doesn't exist
+        if (!fileExists)
+        {
+            fileProvider.CreateFile(filePath);
+        }
 
         //get raw configuration parameters
         var configuration = JsonConvert.DeserializeObject<AppSettings>(fileProvider.ReadAllText(filePath, Encoding.UTF8))


### PR DESCRIPTION
Fix: Check if configuration file exists before creating it

Prevent overwriting existing configuration (e.g., appsettings.json). Only create the file if it doesn't already exist.
Ensure default values are used only when the file is missing, keeping user settings intact.