### PR TITLE
Add AppStartedEvent and publish it on application startup using background thread

### DIFF
--- a/src/Libraries/Nop.Core/Events/AppStartedEvent.cs
+++ b/src/Libraries/Nop.Core/Events/AppStartedEvent.cs
@@ -1,0 +1,24 @@
+﻿namespace Nop.Core.Events
+{
+    /// <summary>
+    /// Event that is published when the application has started.
+    /// This event can be consumed by plugins or services that need to perform actions
+    /// once the application is fully initialized.
+    /// </summary>
+    public partial class AppStartedEvent
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AppStartedEvent"/> class.
+        /// Sets the timestamp of when the application was started in UTC.
+        /// </summary>
+        public AppStartedEvent()
+        {
+            StartedAtUtc = DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// Gets the UTC date and time when the application started.
+        /// </summary>
+        public DateTime StartedAtUtc { get; }
+    }
+}


### PR DESCRIPTION
Adds a new `AppStartedEvent` that is published after the application completes its startup process (`StartEngineAsync`).

- The event is published after key startup steps like plugin installation, DB migrations, and task scheduler initialization.
- Uses `Task.Run` to publish the event in a background thread, ensuring that long-running consumers (e.g., plugins) do not block the app from handling HTTP requests.
- Ensures dependency injection works correctly.
