### PR TITLE
Corrected spelling of "email" in Account.BackInStockSubscriptions.Description resource

### DIFF
--- a/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
+++ b/src/Presentation/Nop.Web/App_Data/Localization/defaultResources.nopres.xml
@@ -58,7 +58,7 @@
     <Value>Delete selected</Value>
   </LocaleResource>
   <LocaleResource Name="Account.BackInStockSubscriptions.Description">
-    <Value>You will receive an e-mail when a particular product is back in stock.</Value>
+    <Value>You will receive an email when a particular product is back in stock.</Value>
   </LocaleResource>
   <LocaleResource Name="Account.BackInStockSubscriptions.NoSubscriptions">
     <Value>You are not currently subscribed to any Back In Stock notification lists</Value>


### PR DESCRIPTION
Corrected the spelling of "e-mail" to "email" in the Account.BackInStockSubscriptions.Description resource string to maintain consistency across the platform.

Updated the resource string value in Account.BackInStockSubscriptions.Description from "e-mail" to "email".

Type of change: Code style/consistency improvement

No related issues.

No functional changes involved.