### PR TITLE
Optimize entity deletions in multiple methods by batching operations into single transactions

### DIFF
--- a/src/Libraries/Nop.Services/Catalog/CategoryService.cs
+++ b/src/Libraries/Nop.Services/Catalog/CategoryService.cs
@@ -584,6 +584,16 @@ public partial class CategoryService : ICategoryService
     }
 
     /// <summary>
+    /// Deletes a list of product category mapping
+    /// </summary>
+    /// <param name="productCategories">Product categories</param>
+    /// <returns>A task that represents the asynchronous operation</returns>
+    public virtual async Task DeleteProductCategoriesAsync(IList<ProductCategory> productCategories)
+    {
+        await _productCategoryRepository.DeleteAsync(productCategories);
+    }
+
+    /// <summary>
     /// Gets product category mapping collection
     /// </summary>
     /// <param name="categoryId">Category identifier</param>

--- a/src/Libraries/Nop.Services/Catalog/ICategoryService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ICategoryService.cs
@@ -160,6 +160,13 @@ public partial interface ICategoryService
     Task DeleteProductCategoryAsync(ProductCategory productCategory);
 
     /// <summary>
+    /// Deletes a list of product category mapping
+    /// </summary>
+    /// <param name="productCategories">Product category</param>
+    /// <returns>A task that represents the asynchronous operation</returns>
+    Task DeleteProductCategoriesAsync(IList<ProductCategory> productCategories);
+
+    /// <summary>
     /// Get a discount-category mapping record
     /// </summary>
     /// <param name="categoryId">Category identifier</param>

--- a/src/Libraries/Nop.Services/Catalog/IManufacturerService.cs
+++ b/src/Libraries/Nop.Services/Catalog/IManufacturerService.cs
@@ -139,6 +139,13 @@ public partial interface IManufacturerService
     Task DeleteProductManufacturerAsync(ProductManufacturer productManufacturer);
 
     /// <summary>
+    /// Deletes a list of product manufacturer mapping
+    /// </summary>
+    /// <param name="productManufacturers">Product manufacturer mappings</param>
+    /// <returns>A task that represents the asynchronous operation</returns>
+    Task DeleteProductManufacturersAsync(IList<ProductManufacturer> productManufacturers);
+
+    /// <summary>
     /// Gets product manufacturer collection
     /// </summary>
     /// <param name="manufacturerId">Manufacturer identifier</param>

--- a/src/Libraries/Nop.Services/Catalog/IProductAttributeService.cs
+++ b/src/Libraries/Nop.Services/Catalog/IProductAttributeService.cs
@@ -175,11 +175,11 @@ public partial interface IProductAttributeService
     #region Product attribute value pictures
 
     /// <summary>
-    /// Deletes a product attribute value picture
+    /// Deletes a list of product attribute value picture
     /// </summary>
-    /// <param name="value">Product attribute value picture</param>
+    /// <param name="value">Product attribute value pictures</param>
     /// <returns>A task that represents the asynchronous operation</returns>
-    Task DeleteProductAttributeValuePictureAsync(ProductAttributeValuePicture valuePicture);
+    Task DeleteProductAttributeValuePicturesAsync(IList<ProductAttributeValuePicture> valuePictures);
 
     /// <summary>
     /// Inserts a product attribute value picture

--- a/src/Libraries/Nop.Services/Catalog/ManufacturerService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ManufacturerService.cs
@@ -337,6 +337,16 @@ public partial class ManufacturerService : IManufacturerService
     }
 
     /// <summary>
+    /// Deletes a list of product manufacturer mapping
+    /// </summary>
+    /// <param name="productManufacturers">Product manufacturer mappings</param>
+    /// <returns>A task that represents the asynchronous operation</returns>
+    public virtual async Task DeleteProductManufacturersAsync(IList<ProductManufacturer> productManufacturers)
+    {
+        await _productManufacturerRepository.DeleteAsync(productManufacturers);
+    }
+
+    /// <summary>
     /// Gets product manufacturer collection
     /// </summary>
     /// <param name="manufacturerId">Manufacturer identifier</param>

--- a/src/Libraries/Nop.Services/Catalog/ProductAttributeService.cs
+++ b/src/Libraries/Nop.Services/Catalog/ProductAttributeService.cs
@@ -311,13 +311,13 @@ public partial class ProductAttributeService : IProductAttributeService
     #region Product attribute value pictures
 
     /// <summary>
-    /// Deletes a product attribute value picture
+    /// Deletes a list of product attribute value picture
     /// </summary>
-    /// <param name="value">Product attribute value picture</param>
+    /// <param name="value">Product attribute value pictures</param>
     /// <returns>A task that represents the asynchronous operation</returns>
-    public virtual async Task DeleteProductAttributeValuePictureAsync(ProductAttributeValuePicture valuePicture)
+    public virtual async Task DeleteProductAttributeValuePicturesAsync(IList<ProductAttributeValuePicture> valuePictures)
     {
-        await _productAttributeValuePictureRepository.DeleteAsync(valuePicture);
+        await _productAttributeValuePictureRepository.DeleteAsync(valuePictures);
     }
 
     /// <summary>

--- a/src/Presentation/Nop.Web/Areas/Admin/Controllers/ProductController.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Controllers/ProductController.cs
@@ -281,9 +281,8 @@ public partial class ProductController : BaseAdminController
         var existingProductCategories = await _categoryService.GetProductCategoriesByProductIdAsync(product.Id, true);
 
         //delete categories
-        foreach (var existingProductCategory in existingProductCategories)
-            if (!model.SelectedCategoryIds.Contains(existingProductCategory.CategoryId))
-                await _categoryService.DeleteProductCategoryAsync(existingProductCategory);
+        var productCategoriesToDelete = existingProductCategories.Where(pc => !model.SelectedCategoryIds.Contains(pc.CategoryId)).ToList();
+        await _categoryService.DeleteProductCategoriesAsync(productCategoriesToDelete);
 
         //add categories
         foreach (var categoryId in model.SelectedCategoryIds)
@@ -317,9 +316,8 @@ public partial class ProductController : BaseAdminController
         var existingProductManufacturers = await _manufacturerService.GetProductManufacturersByProductIdAsync(product.Id, true);
 
         //delete manufacturers
-        foreach (var existingProductManufacturer in existingProductManufacturers)
-            if (!model.SelectedManufacturerIds.Contains(existingProductManufacturer.ManufacturerId))
-                await _manufacturerService.DeleteProductManufacturerAsync(existingProductManufacturer);
+        var productManufacturersToDelete = existingProductManufacturers.Where(pm => !model.SelectedManufacturerIds.Contains(pm.ManufacturerId)).ToList();
+        await _manufacturerService.DeleteProductManufacturersAsync(productManufacturersToDelete);
 
         //add manufacturers
         foreach (var manufacturerId in model.SelectedManufacturerIds)
@@ -776,12 +774,11 @@ public partial class ProductController : BaseAdminController
         var existingValuePictures = await _productAttributeService.GetProductAttributeValuePicturesAsync(value.Id);
         var productPictureIds = (await _pictureService.GetPicturesByProductIdAsync(product.Id)).Select(p => p.Id).ToList();
 
-        //delete manufacturers
-        foreach (var existingValuePicture in existingValuePictures)
-            if (!model.PictureIds.Contains(existingValuePicture.PictureId) || !productPictureIds.Contains(existingValuePicture.PictureId))
-                await _productAttributeService.DeleteProductAttributeValuePictureAsync(existingValuePicture);
+        //delete product attribute value picture
+        var existingPicturesToDelete = existingValuePictures.Where(pavp => !model.PictureIds.Contains(pavp.PictureId) || !productPictureIds.Contains(pavp.PictureId)).ToList();
+        await _productAttributeService.DeleteProductAttributeValuePicturesAsync(existingPicturesToDelete);
 
-        //add manufacturers
+        //add product attribute value picture
         foreach (var pictureId in model.PictureIds)
         {
             if (!productPictureIds.Contains(pictureId))


### PR DESCRIPTION
Previously, entity deletions were executed one by one using individual async calls, which introduced unnecessary database round-trips. This PR optimizes the following methods to delete lists of entities in bulk within a single transaction:

`DeleteProductAttributeValuePicturesAsync`
`DeleteProductCategoriesAsync`
`DeleteProductManufacturersAsync`

This improves performance.