### PR TITLE
We moved the PluginUpdatedEvent trigger to the very end of the POST;

### DIFF
--- a/src/Presentation/Nop.Web/Areas/Admin/Controllers/PluginController.cs
+++ b/src/Presentation/Nop.Web/Areas/Admin/Controllers/PluginController.cs
@@ -396,7 +396,7 @@ public partial class PluginController : BaseAdminController
             pluginDescriptor.Save();
 
             //raise event
-            await _eventPublisher.PublishAsync(new PluginUpdatedEvent(pluginDescriptor));
+            //await _eventPublisher.PublishAsync(new PluginUpdatedEvent(pluginDescriptor));
 
             //locales
             var pluginInstance = pluginDescriptor.Instance<IPlugin>();
@@ -553,6 +553,11 @@ public partial class PluginController : BaseAdminController
             //activity log
             await _customerActivityService.InsertActivityAsync("EditPlugin",
                 string.Format(await _localizationService.GetResourceAsync("ActivityLog.EditPlugin"), pluginDescriptor.FriendlyName));
+
+            //raise event
+
+            await _eventPublisher.PublishAsync(new PluginUpdatedEvent(pluginDescriptor));
+
 
             return View(model);
         }


### PR DESCRIPTION
🛠️ What did we do to fix it?
We moved the PluginUpdatedEvent trigger to the very end of the POST method — after:

The plugin's enabled/disabled logic runs,

All related settings are saved,

Activity log is recorded.

This ensures that the plugin is in its final and consistent state when the event is published, and all event subscribers get accurate information.



- await _eventPublisher.PublishAsync(new PluginUpdatedEvent(pluginDescriptor));
  // (Previously triggered too early)

...

+ await _customerActivityService.InsertActivityAsync(...);
+ await _eventPublisher.PublishAsync(new PluginUpdatedEvent(pluginDescriptor));
  // (Now triggered at the correct place, after all updates)
