### PR TITLE
Add support for language exclusion in sitemap.xml

### DIFF
--- a/src/Libraries/Nop.Core/Http/NopHttpDefaults.cs
+++ b/src/Libraries/Nop.Core/Http/NopHttpDefaults.cs
@@ -19,9 +19,4 @@ public static partial class NopHttpDefaults
     /// Gets the name of a request item that stores the value that indicates whether the request is being redirected by the generic route transformer
     /// </summary>
     public static string GenericRouteInternalRedirect => "nop.RedirectFromGenericPathRoute";
-
-    /// <summary>
-    /// Gets the name of a request item that stores the value with default language for sitemap.xml
-    /// </summary>
-    public static string ForcedSitemapXmlLanguage => "nop.ForcedSitemapXmlLanguage";
 }

--- a/src/Presentation/Nop.Web.Framework/Mvc/Routing/LanguageParameterTransformer.cs
+++ b/src/Presentation/Nop.Web.Framework/Mvc/Routing/LanguageParameterTransformer.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Nop.Core;
-using Nop.Core.Http;
 using Nop.Core.Infrastructure;
 using Nop.Services.Localization;
 
@@ -39,11 +38,7 @@ public partial class LanguageParameterTransformer : IOutboundParameterTransforme
     /// <returns>The transformed value</returns>
     public string TransformOutbound(object value)
     {
-        // first check if we have forced value for sitemap.xml
-        if (_httpContextAccessor.HttpContext?.Items[NopHttpDefaults.ForcedSitemapXmlLanguage] is string forcedLang && !string.IsNullOrEmpty(forcedLang))
-            return forcedLang;
-        
-        // then try to get a language code from the route values
+        //first try to get a language code from the route values
         var routeValues = _httpContextAccessor.HttpContext.Request.RouteValues;
         if (routeValues.TryGetValue(NopRoutingDefaults.RouteValue.Language, out var routeValue))
         {


### PR DESCRIPTION
This PR adds the ability to exclude specific languages from sitemap.xml generation.

### What’s new:
- New property `DisallowLanguages` in `SitemapXmlSettings`
- `SitemapModelFactory` and alternate URL logic now respects this setting
- Default behavior remains unchanged (no exclusions)

### Why:
In some scenarios, site owners may want to:
- Prevent certain language versions from being listed in sitemaps (e.g. test/staging content)
- Avoid conflicting SEO signals when the same languages are excluded in `robots.txt`

This setting provides fine-grained control and separates concerns between `robots.txt` and sitemap configuration.

Closes #7777