### PR TITLE
Use ISO 8601 with timezone for DateTime properties in the JSON-LD models

### DIFF
--- a/src/Presentation/Nop.Web/Models/JsonLD/JsonDateTimeOffsetConverter.cs
+++ b/src/Presentation/Nop.Web/Models/JsonLD/JsonDateTimeOffsetConverter.cs
@@ -1,0 +1,5 @@
+﻿namespace Nop.Web.Models.JsonLD;
+
+public class JsonDateTimeOffsetConverter
+{
+}

--- a/src/Presentation/Nop.Web/Models/JsonLD/JsonLdOfferModel.cs
+++ b/src/Presentation/Nop.Web/Models/JsonLD/JsonLdOfferModel.cs
@@ -21,8 +21,11 @@ public record JsonLdOfferModel : JsonLdModel
     [JsonProperty("priceCurrency")]
     public string PriceCurrency { get; set; }
 
+    
     [JsonProperty("priceValidUntil")]
-    public DateTime? PriceValidUntil { get; set; }
+    public DateTimeOffset? PriceValidUntil { get; set; }
+
+    //public DateTime? PriceValidUntil { get; set; }
 
     #endregion
 }

--- a/src/Presentation/Nop.Web/Program.cs
+++ b/src/Presentation/Nop.Web/Program.cs
@@ -2,6 +2,7 @@
 using Nop.Core.Configuration;
 using Nop.Core.Infrastructure;
 using Nop.Web.Framework.Infrastructure.Extensions;
+using Nop.Web.Models.JsonLD;
 
 namespace Nop.Web;
 
@@ -18,6 +19,13 @@ public partial class Program
             builder.Configuration.AddJsonFile(path, true, true);
         }
         builder.Configuration.AddEnvironmentVariables();
+
+        builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new JsonDateTimeOffsetConverter());
+    });
+
 
         //load application settings
         builder.Services.ConfigureApplicationSettings(builder);


### PR DESCRIPTION
🔧 Fix: Serialize priceValidUntil using ISO 8601 with timezone
Changed DateTime? to DateTimeOffset? in JsonLdOfferModel to ensure proper timezone-aware JSON serialization for structured data as per issue #7789.

This helps Google and other consumers correctly interpret the expiry date of an offer with its associated timezone.

