### PR TITLE
Remove entrypoint and make it possible to do cross platform build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # create the build instance 
-FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS build
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
 
 WORKDIR /src                                                                    
 COPY ./src ./
@@ -39,11 +42,7 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
 # installs required packages
 RUN apk add tiff --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/main/ --allow-untrusted
 RUN apk add libgdiplus --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/community/ --allow-untrusted
-RUN apk add libc-dev tzdata --no-cache
-
-# copy entrypoint script
-COPY ./entrypoint.sh /entrypoint.sh
-RUN chmod 755 /entrypoint.sh
+RUN apk add libc-dev tzdata gcompat --no-cache
 
 WORKDIR /app
 
@@ -52,4 +51,4 @@ COPY --from=build /app/published .
 ENV ASPNETCORE_URLS=http://+:80
 EXPOSE 80
                             
-ENTRYPOINT "/entrypoint.sh"
+ENTRYPOINT ["dotnet", "Nop.Web.dll"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,2 +1,0 @@
-ln -s /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2
-exec dotnet Nop.Web.dll


### PR DESCRIPTION
This PR enables multi-platform Docker image builds using ```docker buildx``` to support both AMD64 and ARM64 architectures. 

It is really simple:
```
docker buildx build --push --platform linux/amd64,linux/arm64 -t stevefan1999/nopcommerce:latest .
```
Replace the image name and tag with official nopcommerce scope. That said, `stevefan1999/nopcommerce:latest` does exist for an example of a successful multi-arch build for nopCommerce.

The changes allow nopCommerce to run natively on ARM-based infrastructure including Oracle Cloud's Always Free ARM instances, AWS Graviton, Azure ARM VMs, and Apple Silicon development environments. I have manually confirmed it runs on my ARM VPS server, albeit not with additional testing, that I haven't installed it yet, and may have to think about how to store the config. 

Little nag: I also want to know how do I do automatic installation without human intervention, because I run in a Kubernetes environment and I want to auto deploy everything, and I need to know what paths I needed to store persistent data.

**Changes:**
- Updated build process to use ```docker buildx``` with ```--platform linux/amd64,linux/arm64```
- Maintained compatibility with existing AMD64 deployments
- No noticable changes required to the existing deployment using the older Dockerfile
