### PR TITLE
refactor: cache parent→child lookup with full Category objects

### DIFF
--- a/src/Libraries/Nop.Services/Catalog/NopCatalogDefaults.cs
+++ b/src/Libraries/Nop.Services/Catalog/NopCatalogDefaults.cs
@@ -54,6 +54,16 @@ public static partial class NopCatalogDefaults
     public static CacheKey CategoriesByParentCategoryCacheKey => new("Nop.category.byparent.{0}-{1}-{2}-{3}");
 
     /// <summary>
+    /// Key for caching category lookup by parent category ID
+    /// </summary>
+    /// <remarks>
+    /// {0} : store ID
+    /// {1} : show hidden
+    /// {2} : customer role IDs
+    /// </remarks>
+    public static CacheKey ChildCategoryLookupCacheKey => new("Nop.category.lookup.byparent.{0}-{1}-{2}");
+
+    /// <summary>
     /// Gets a key pattern to clear cache
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
Description:

This PR contains the following points:
- This PR updates CategoryService to cache a parent→children lookup of full Category objects instead of just IDs.
- Added GetCachedCategoryLookupAsync() method that creates a cached dictionary lookup storing full Category objects instead of just IDs
- Optimized GetChildCategoryIdsAsync and GetAllCategoriesByParentCategoryIdAsync methods