### PR TITLE
implement RenderCurrency

### DIFF
--- a/src/Presentation/Nop.Web.Framework/Models/DataTables/RenderCurrency.cs
+++ b/src/Presentation/Nop.Web.Framework/Models/DataTables/RenderCurrency.cs
@@ -1,0 +1,24 @@
+﻿namespace Nop.Web.Framework.Models.DataTables;
+
+public partial class RenderCurrency : IRender
+{
+    private const Align ALIGN_DEFAULT = Align.Right;
+
+    private const string CURRENCY_DEFAULT = "USD";
+
+    public string Currency { get; set; }
+    public Align TextAlign { get; set; }
+
+    public RenderCurrency()
+    {
+        TextAlign = ALIGN_DEFAULT;
+        Currency = CURRENCY_DEFAULT;
+    }
+
+    public enum Align
+    {
+        Left,
+        Right,
+        Center
+    }
+}

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/Table.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/Table.cshtml
@@ -226,7 +226,14 @@
                     });
 
                     if (columnType == 'number') {
-                        $($(curRow).children("[data-columnname='" + cellName + "']")[0]).html('<input value="' + editRowData_@(tableName)[cellName] + '" class="userinput form-control" type="number" step="any" min="@int.MinValue" max="@int.MaxValue"/>');
+                        var cellValue = editRowData_@(tableName)[cellName];
+                        if(isNaN(parseFloat(cellValue))) {
+                            var container = document.createElement('div');
+                            container.innerHTML = cellValue;
+                            cellValue = container.children[0].getAttribute('nop-value');
+                        }
+
+                        $($(curRow).children("[data-columnname='" + cellName + "']")[0]).html('<input value="' + cellValue + '" class="userinput form-control" type="number" step="any" min="@int.MinValue" max="@int.MaxValue"/>');
                     }
                     if (columnType == 'checkbox') {
                         var cellValue = editRowData_@(tableName)[cellName];

--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/_Table.Definition.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/_Table.Definition.cshtml
@@ -499,6 +499,13 @@ columns: [
                             },
                         </text>
                         break;
+                    case RenderCurrency currency:
+                        <text>
+                            render: function (data, type, row) {
+                                return '<div style="text-align:@currency.TextAlign.ToString().ToLowerInvariant();" nop-value="' + data + '">' + new Intl.NumberFormat('@locale', { currency: '@currency.Currency', style: 'currency', }).format(data) + '</div>';
+                            },
+                        </text>
+                        break;
                 }
                 data: '@column.Data'
             }


### PR DESCRIPTION
implements #7835 

The only change I would make is setting "CURRENCY_DEFAULT" to the store default, but I don't believe there's a way to gather that information from a static field, so the alternative I see is not having a default and then requiring a currencyCode parameter in the ctor and eliminate the parameterless ctor.

```csharp
    public RenderCurrency(string currencyCode)
    {
        TextAlign = ALIGN_DEFAULT;
        Currency = currencyCode;
    }
```