### PR TITLE
Fix #7816: Make admin footer time live-updating

### DIFF
--- a/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/_AdminLayout.cshtml
+++ b/src/Presentation/Nop.Web/Areas/Admin/Views/Shared/_AdminLayout.cshtml
@@ -200,8 +200,12 @@
                         {
                             <div class="col-md-4 col-xs-12"></div>
                         }
+                        <!-- Display current date and time (initially rendered from server, then updated by JS) -->
                         <div class="col-md-4 col-xs-12 text-center">
-                            @((await dateTimeHelper.ConvertToUserTimeAsync(DateTime.Now)).ToString("f", CultureInfo.CurrentCulture))
+                            <span id="admin-now"
+                                  data-utc="@DateTime.UtcNow.ToString("o")">
+                                @((await dateTimeHelper.ConvertToUserTimeAsync(DateTime.UtcNow)).ToString("f", CultureInfo.CurrentCulture))
+                            </span>
                         </div>
                         <div class="col-md-4 col-xs-12 text-md-right text-center">
                             <b>nopCommerce version @NopVersion.FULL_VERSION</b>
@@ -311,6 +315,9 @@
             </script>
         </text>
     }
+    <!-- Load custom script for updating the admin time dynamically -->
+    <script src="~/js/admin-footer-time.js"></script>
+
     @NopHtml.GenerateScripts(ResourceLocation.Footer)
     @NopHtml.GenerateInlineScripts(ResourceLocation.Footer)
 </body>

--- a/src/Presentation/Nop.Web/wwwroot/js/admin-footer-time.js
+++ b/src/Presentation/Nop.Web/wwwroot/js/admin-footer-time.js
@@ -1,0 +1,46 @@
+﻿(function () {
+  var el = document.getElementById('admin-now');
+  if (!el) return;
+
+  var utc = el.getAttribute('data-utc');
+  if (!utc) return;
+
+  // Initial UTC value from the server
+  var startUtc = new Date(utc).getTime();
+  // When the script started (client timestamp)
+  var mountedAt = Date.now();
+
+  // Format similar to .NET "f" (Long date + short time, without seconds)
+  function formatLikeF(d) {
+    try {
+      return d.toLocaleString(undefined, {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      });
+    } catch {
+      return d.toLocaleString();
+    }
+  }
+
+  function render() {
+    // How much time has passed on the client since mount
+    var elapsed = Date.now() - mountedAt;
+    // "Now" = server UTC + elapsed time, displayed in the admin's local zone
+    var nowLocal = new Date(startUtc + elapsed);
+    el.textContent = formatLikeF(nowLocal);
+  }
+
+  // First update immediately
+  render();
+
+  // Update every minute (enough since we don’t show seconds)
+  var timer = setInterval(render, 60 * 1000);
+
+  // Cleanup (best practice)
+  window.addEventListener('unload', function () {
+    clearInterval(timer);
+  });
+})();


### PR DESCRIPTION
This PR resolves issue #7816 by updating the admin footer clock so it refreshes dynamically on the client side.

### Changes made:
- Updated `_AdminLayout.cshtml` footer: wrapped time in <span id="admin-now"> with a `data-utc` attribute.
- Added new JavaScript file `admin-footer-time.js` in `wwwroot/js/`.
- Implemented script that updates the displayed time every minute without a page reload.

### Result:
The footer time is now accurate and continuously updated for the admin user.