### PR TITLE
Enhance rate limiter with whitelist support

### DIFF
--- a/src/Libraries/Nop.Core/Configuration/CommonConfig.cs
+++ b/src/Libraries/Nop.Core/Configuration/CommonConfig.cs
@@ -70,4 +70,11 @@ public partial class CommonConfig : IConfig
     /// Default status code to set on the response when a request is rejected.
     /// </summary>
     public int RejectionStatusCode { get; set; } = 503;
+
+    /// <summary>
+    /// Gets or sets the collection of user identifiers that are exempt from rate limiting.
+    /// </summary>
+    /// <remarks>Add user IDs or IP Addresses to this collection to allow them to bypass rate limit checks. Changes to the
+    /// collection take effect immediately.</remarks>
+    public HashSet<string> RateLimitWhitelist { get; set; } = new();
 }


### PR DESCRIPTION
Added `RateLimitWhitelist` to `CommonConfig` to exempt specific IPs from rate limiting. Updated `ServiceCollectionExtensions` to bypass rate limiting for whitelisted IPs, admin-allowed IPs, and localhost. Improved partition key logic for more granular rate limiting. Maintained backward compatibility with existing configurations.

Localhost must be allowed to prevent scheduled tasks from being rate limited, as well as any other internal functions.

I've started using the rate limited because non-standard webscrapers are bogging down my site, but not quite enough traffic to trigger other protections. This seeks to improve upon existing code, making it a bit more extensible and also more robust, but improving how the partition key is created. If it is a guest account that needs rate limiting, it will fall back to `httpContext.Request.Headers.Host` which is unreliable because it is provided by the client and even if it isn't tampered with, it would be the domain, which would essentially ratelimit traffic to whole website for all guests if triggered, so there should be other unique identifiers considered before falling back to host (if it should ever be fallen back on).
```c#
var partitionKey = username ?? ip ?? httpContext.Session?.Id ?? httpContext.Request.Headers.Host;
```

appsettings.json will also need a field added, but it is not tracked in git.
```json
"CommonConfig": {
    "RateLimitWhitelist": [] //to be filled with ip list, eg. [ "192.168.0.1", "192.168.0.2"... ]4
}
```