### PR TITLE
fixed rtl layout for password change page (#7944)

### DIFF
--- a/src/Presentation/Nop.Web/Themes/DefaultClean/Content/css/styles.rtl.css
+++ b/src/Presentation/Nop.Web/Themes/DefaultClean/Content/css/styles.rtl.css
@@ -363,6 +363,11 @@ label, label + * {
   text-align: center;
 }
 
+.inputs .form-input-wrapper {
+  display: inline-block;
+  max-width: 100%;
+}
+
 .required {
   margin: 0 3px 0 -8px; /*siblings offset*/
   vertical-align: top;


### PR DESCRIPTION
### Summary

This PR add new CSS style in "nopCommerce\src\Presentation\Nop.Web\wwwroot\css\admin\styles.rtl.css", address [#7944](https://github.com/nopSolutions/nopCommerce/issues/7944)

### Detail

Before

<img width="1092" height="541" alt="image" src="https://github.com/user-attachments/assets/dfd11338-1740-467d-8c7e-de26db6013c9" />

After

<img width="1115" height="513" alt="image" src="https://github.com/user-attachments/assets/d95844c3-08d2-4f71-9632-00bbebd9c7a7" />
