### PR TITLE
Refactor: simplify null and published check for language

### DIFF
--- a/src/Presentation/Nop.Web/Controllers/CommonController.cs
+++ b/src/Presentation/Nop.Web/Controllers/CommonController.cs
@@ -112,7 +112,7 @@ public partial class CommonController : BasePublicController
     public virtual async Task<IActionResult> SetLanguage(int langid, string returnUrl = "")
     {
         var language = await _languageService.GetLanguageByIdAsync(langid);
-        if (!language?.Published ?? false)
+        if (language == null || !language.Published)
             language = await _workContext.GetWorkingLanguageAsync();
 
         //home page


### PR DESCRIPTION
### Summary
Simplified the conditional check for language retrieval to improve readability.

### Changes
- Replaced the expression `if (!language?.Published ?? false)` with a clearer equivalent:
  ```csharp
  if (language == null || !language.Published)
      language = await _workContext.GetWorkingLanguageAsync();
