### PR TITLE
Bug Fix - 8065: Shipping.UPS sends InvoiceLineTotal with culture-specific decimal separator (comma)

### DIFF
--- a/src/Plugins/Nop.Plugin.Shipping.UPS/Services/UPSService.cs
+++ b/src/Plugins/Nop.Plugin.Shipping.UPS/Services/UPSService.cs
@@ -433,14 +433,14 @@ public class UPSService
                 Code = _upsSettings.WeightType,
                 Description = _upsSettings.WeightType
             },
-            Weight = request.Shipment.Package.Sum(x => decimal.TryParse(x.PackageWeight.Weight, out var wt) ? wt : 0).ToString()
+            Weight = request.Shipment.Package.Sum(x => decimal.TryParse(x.PackageWeight.Weight, out var wt) ? wt : 0).ToString("F2", CultureInfo.InvariantCulture)
         };
 
         var currencyCode = (await _currencyService.GetCurrencyByIdAsync(_currencySettings.PrimaryStoreCurrencyId))?.CurrencyCode;
         request.Shipment.InvoiceLineTotal = new Shipment_InvoiceLineTotal
         {
             CurrencyCode = currencyCode,
-            MonetaryValue = shippingOptionRequest.Items.Sum(x => x.Product.Price * x.GetQuantity()).ToString("F2")
+            MonetaryValue = shippingOptionRequest.Items.Sum(x => x.Product.Price * x.GetQuantity()).ToString("F2", CultureInfo.InvariantCulture)
         };
 
         return request;

--- a/src/Plugins/Nop.Plugin.Shipping.UPS/plugin.json
+++ b/src/Plugins/Nop.Plugin.Shipping.UPS/plugin.json
@@ -2,7 +2,7 @@
   "Group": "Shipping rate computation",
   "FriendlyName": "UPS (United Parcel Service)",
   "SystemName": "Shipping.UPS",
-  "Version": "5.00.2",
+  "Version": "5.00.3",
   "SupportedVersions": [ "5.00" ],
   "Author": "nopCommerce team",
   "DisplayOrder": 1,


### PR DESCRIPTION
FYI - https://www.ups.com/worldshiphelp/WSA/ENU/AppHelp/mergedProjects/CORE/CONNECT/Trade_Direct_Shipment_Data_Field_Descriptions.htm

Search 'Total Weight' and 'Invoice Line Total'
Both of the properties type is N (Numeric), it does not support any special character like comma