### PR TITLE
fixed Product review link does not redirect to product details page i…

### DIFF
--- a/src/Presentation/Nop.Web/Views/Product/CustomerProductReviews.cshtml
+++ b/src/Presentation/Nop.Web/Views/Product/CustomerProductReviews.cshtml
@@ -63,7 +63,7 @@
                         <div class="review-info">
                             <span class="user">
                                 <label>@T("Account.CustomerProductReviews.ProductReviewFor"):</label>
-                                <a href="@(await NopUrl.RouteGenericUrlAsync<Product>(new { SeName = review.ProductSeName })))">@review.ProductName</a>
+                                <a href="@(await NopUrl.RouteGenericUrlAsync<Product>(new { SeName = review.ProductSeName }))">@review.ProductName</a>
 
                             </span>
                             <span class="separator">|</span>


### PR DESCRIPTION
there was an additional ")" in <a href="" tag   after deleting it now it navigates to the product details without 404 error