### PR TITLE
Show default value for product review rating(#8090)

### DIFF
--- a/src/Presentation/Nop.Web/Factories/ProductModelFactory.cs
+++ b/src/Presentation/Nop.Web/Factories/ProductModelFactory.cs
@@ -1802,6 +1802,7 @@ public partial class ProductModelFactory : IProductModelFactory
         model.AddProductReview.CanCurrentCustomerLeaveReview = _catalogSettings.AllowAnonymousUsersToReviewProduct || !await _customerService.IsGuestAsync(currentCustomer);
         model.AddProductReview.DisplayCaptcha = _captchaSettings.Enabled && _captchaSettings.ShowOnProductReviewPage;
         model.AddProductReview.CanAddNewReview = await _productReviewService.CanAddReviewAsync(product.Id, _catalogSettings.ShowProductReviewsPerStore ? currentStore.Id : 0);
+        model.AddProductReview.Rating = _catalogSettings.DefaultProductRatingValue;
 
         return model;
     }


### PR DESCRIPTION
Hi @exileDev,

The base branch for this PR is now 4.90-bug-fixes.
This PR references issue #8090.

The default rating value is set based on CatalogSettings.DefaultProductRatingValue.

Please let me know if you have any suggestions.