### PR TITLE
#7767 Restrict Razor runtime compilation to Development environment only

### DIFF
--- a/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -1,7 +1,8 @@
-﻿using System.Threading.RateLimiting;
+using System.Threading.RateLimiting;
 using FluentValidation;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationParts;
@@ -10,6 +11,7 @@ using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
 using Newtonsoft.Json.Serialization;
 using Nop.Core;
 using Nop.Core.Configuration;
@@ -304,7 +306,11 @@ public static class ServiceCollectionExtensions
         //add basic MVC feature
         var mvcBuilder = services.AddControllersWithViews();
 
-        mvcBuilder.AddRazorRuntimeCompilation();
+        var webHostEnvironment = EngineContext.Current.Resolve<IWebHostEnvironment>();
+        if (webHostEnvironment.IsDevelopment())
+        {
+            mvcBuilder.AddRazorRuntimeCompilation();
+        }
 
         var appSettings = Singleton<AppSettings>.Instance;
         if (appSettings.Get<CommonConfig>().UseSessionStateTempDataProvider)


### PR DESCRIPTION
## Summary

Fixes #7767

`AddRazorRuntimeCompilation()` in `ServiceCollectionExtensions.AddNopMvc()` is currently called **unconditionally**, meaning it is active in all environments including Production. This change wraps the call with an `IsDevelopment()` check so that Razor runtime compilation is only enabled during development.

## Problem

In Production, the Razor runtime compiler triggers tag helper discovery on every view cache miss. During this process, `ViewComponentTagHelperDescriptorFactory.CreateDescriptor()` uses regex to process type information from assemblies. In large nopCommerce installations with many plugins, this regex experiences **catastrophic backtracking**, resulting in a `RegexMatchTimeoutException`:

```
System.Text.RegularExpressions.RegexMatchTimeoutException:
The Regex engine has timed out while trying to match a pattern to an input string.

   at System.Text.RegularExpressions.RegexRunner.<CheckTimeout>g__ThrowRegexTimeout|25_0()
   at System.Text.RegularExpressions.RegexReplacement.ReplaceNonSimpleText(...)
   at Microsoft.AspNetCore.Mvc.Razor.Extensions.ViewComponentTagHelperDescriptorFactory.CreateDescriptor(...)
   at Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation.RuntimeViewCompiler.CompileAndEmit(...)
```

## Why this should be changed

1. **Production crash**: The regex timeout causes unhandled exceptions in Production, breaking page rendering (observed on `Admin/Home/Index`)
2. **Unnecessary overhead**: Views are already precompiled during `dotnet publish`, making runtime compilation redundant in Production
3. **Microsoft's recommendation**: [Official documentation](https://learn.microsoft.com/en-us/aspnet/core/mvc/views/view-compilation#runtime-compilation) explicitly states runtime compilation should not be used in Production
4. **Performance**: Runtime compilation adds CPU/memory overhead for on-the-fly view compilation that is completely unnecessary when views are precompiled

## Changes

- **File**: `src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ServiceCollectionExtensions.cs`
- Wrapped `mvcBuilder.AddRazorRuntimeCompilation()` with `IsDevelopment()` environment check
- Added required `using` directives for `IWebHostEnvironment` and `IsDevelopment()` extension method
