### PR TITLE
Simplified DataSettingsManager class

### DIFF
--- a/src/Libraries/Nop.Data/DataProviders/BaseDataProvider.cs
+++ b/src/Libraries/Nop.Data/DataProviders/BaseDataProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Data.Common;
+using System.Data.Common;
 using System.Linq.Expressions;
 using System.Reflection;
 using FluentMigrator;
@@ -17,6 +17,18 @@ namespace Nop.Data.DataProviders;
 public abstract partial class BaseDataProvider
 {
     #region Utilities
+
+    private static BulkCopyOptions CreateBulkCopyOptions(DataConfig settings)
+    {
+        if (settings is null)
+            return new BulkCopyOptions();
+
+        return new BulkCopyOptions
+        {
+            CheckConstraints = settings.BulkCopyWithCheckConstraints,
+            KeepIdentity = true
+        };
+    }
 
     /// <summary>
     /// Gets a connection to the database for a current data provider
@@ -48,7 +60,7 @@ public abstract partial class BaseDataProvider
             .UseMappingSchema(NopMappingSchema.GetMappingSchema(ConfigurationName, LinqToDbDataProvider))
             );
 
-        var sqlCommandTimeout = DataSettingsManager.GetSqlCommandTimeout();
+        var sqlCommandTimeout = DataSettings.SQLCommandTimeout ?? -1;
         if (sqlCommandTimeout == -1)
             dataConnection.ResetCommandTimeout();
         else
@@ -194,10 +206,10 @@ public abstract partial class BaseDataProvider
 
         var dataContext = new DataContext(options)
         {
-            CloseAfterUse = DataSettingsManager.GetCloseDataContextAfterUse()
+            CloseAfterUse = DataSettings.CloseDataContextAfterUse
         };
 
-        var sqlCommandTimeout = DataSettingsManager.GetSqlCommandTimeout();
+        var sqlCommandTimeout = DataSettings.SQLCommandTimeout ?? -1;
 
         if (sqlCommandTimeout == -1)
             dataContext.ResetCommandTimeout();
@@ -400,7 +412,7 @@ public abstract partial class BaseDataProvider
     public virtual async Task BulkInsertEntitiesAsync<TEntity>(IEnumerable<TEntity> entities) where TEntity : BaseEntity
     {
         using var dataContext = CreateDataConnection(LinqToDbDataProvider);
-        await dataContext.BulkCopyAsync(DataSettingsManager.GetBulkCopyOptions(), entities.RetrieveIdentity(dataContext, useSequenceName: false));
+        await dataContext.BulkCopyAsync(CreateBulkCopyOptions(DataSettings), entities.RetrieveIdentity(dataContext, useSequenceName: false));
     }
 
     /// <summary>
@@ -411,7 +423,7 @@ public abstract partial class BaseDataProvider
     public virtual void BulkInsertEntities<TEntity>(IEnumerable<TEntity> entities) where TEntity : BaseEntity
     {
         using var dataContext = CreateDataConnection(LinqToDbDataProvider);
-        dataContext.BulkCopy(DataSettingsManager.GetBulkCopyOptions(), entities.RetrieveIdentity(dataContext, useSequenceName: false));
+        dataContext.BulkCopy(CreateBulkCopyOptions(DataSettings), entities.RetrieveIdentity(dataContext, useSequenceName: false));
     }
 
     /// <summary>

--- a/src/Libraries/Nop.Data/DataProviders/BaseDataProvider.cs
+++ b/src/Libraries/Nop.Data/DataProviders/BaseDataProvider.cs
@@ -18,14 +18,15 @@ public abstract partial class BaseDataProvider
 {
     #region Utilities
 
-    private static BulkCopyOptions CreateBulkCopyOptions(DataConfig settings)
+    /// <summary>
+    /// Creates options used for bulk insert operations
+    /// </summary>
+    /// <returns>Bulk copy options derived from current data configuration</returns>
+    protected virtual BulkCopyOptions CreateBulkCopyOptions()
     {
-        if (settings is null)
-            return new BulkCopyOptions();
-
         return new BulkCopyOptions
         {
-            CheckConstraints = settings.BulkCopyWithCheckConstraints,
+            CheckConstraints = DataSettings.BulkCopyWithCheckConstraints,
             KeepIdentity = true
         };
     }
@@ -412,7 +413,7 @@ public abstract partial class BaseDataProvider
     public virtual async Task BulkInsertEntitiesAsync<TEntity>(IEnumerable<TEntity> entities) where TEntity : BaseEntity
     {
         using var dataContext = CreateDataConnection(LinqToDbDataProvider);
-        await dataContext.BulkCopyAsync(CreateBulkCopyOptions(DataSettings), entities.RetrieveIdentity(dataContext, useSequenceName: false));
+        await dataContext.BulkCopyAsync(CreateBulkCopyOptions(), entities.RetrieveIdentity(dataContext, useSequenceName: false));
     }
 
     /// <summary>
@@ -423,7 +424,7 @@ public abstract partial class BaseDataProvider
     public virtual void BulkInsertEntities<TEntity>(IEnumerable<TEntity> entities) where TEntity : BaseEntity
     {
         using var dataContext = CreateDataConnection(LinqToDbDataProvider);
-        dataContext.BulkCopy(CreateBulkCopyOptions(DataSettings), entities.RetrieveIdentity(dataContext, useSequenceName: false));
+        dataContext.BulkCopy(CreateBulkCopyOptions(), entities.RetrieveIdentity(dataContext, useSequenceName: false));
     }
 
     /// <summary>

--- a/src/Libraries/Nop.Data/DataProviders/MsSqlDataProvider.cs
+++ b/src/Libraries/Nop.Data/DataProviders/MsSqlDataProvider.cs
@@ -1,10 +1,11 @@
-﻿using System.Data.Common;
+using System.Data.Common;
 using LinqToDB;
 using LinqToDB.Data;
 using LinqToDB.DataProvider;
 using LinqToDB.DataProvider.SqlServer;
 using Microsoft.Data.SqlClient;
 using Nop.Core;
+using Nop.Data;
 using Nop.Data.Mapping;
 
 namespace Nop.Data.DataProviders;
@@ -145,7 +146,9 @@ public partial class MsSqlNopDataProvider : BaseDataProvider, INopDataProvider
     {
         var table = (ITable<TEntity>)base.GetTable<TEntity>();
 
-        return DataSettingsManager.UseNoLock() ? table.With("NOLOCK") : table;
+        return DataSettings.DataProvider == DataProviderType.SqlServer && DataSettings.WithNoLock
+            ? table.With("NOLOCK")
+            : table;
     }
 
     /// <summary>

--- a/src/Libraries/Nop.Data/DataSettingsManager.cs
+++ b/src/Libraries/Nop.Data/DataSettingsManager.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using LinqToDB.Data;
+using System.Text;
 using Newtonsoft.Json;
 using Nop.Core;
 using Nop.Core.Configuration;
@@ -147,64 +146,6 @@ public partial class DataSettingsManager
         _databaseIsInstalled ??= !string.IsNullOrEmpty(LoadSettings()?.ConnectionString);
 
         return _databaseIsInstalled.Value;
-    }
-
-    /// <summary>
-    /// Gets the command execution timeout.
-    /// </summary>
-    /// <value>
-    /// Number of seconds. Negative timeout value means that a default timeout will be used. 0 timeout value corresponds to infinite timeout.
-    /// </value>
-    public static int GetSqlCommandTimeout()
-    {
-        return LoadSettings()?.SQLCommandTimeout ?? -1;
-    }
-
-    /// <summary>
-    /// Gets a value that indicates whether to add NoLock hint to SELECT statements (applies only to SQL Server, otherwise returns false)
-    /// </summary>
-    public static bool UseNoLock()
-    {
-        var settings = LoadSettings();
-
-        if (settings is null)
-            return false;
-
-        return settings.DataProvider == DataProviderType.SqlServer && settings.WithNoLock;
-    }
-
-    /// <summary>
-    /// Gets the bulk copy options configured according to the current data settings.
-    /// </summary>
-    /// <returns>
-    /// A <see cref="BulkCopyOptions"/> instance containing the options for bulk copy operations. If no settings are
-    /// available, default options are returned.
-    /// </returns>
-    public static BulkCopyOptions GetBulkCopyOptions()
-    {
-        var settings = LoadSettings();
-
-        if (settings is null)
-            return new BulkCopyOptions();
-
-        var options = new BulkCopyOptions
-        {
-            CheckConstraints = settings.BulkCopyWithCheckConstraints,
-            KeepIdentity = true
-        };
-
-        return options;
-    }
-
-    /// <summary>
-    /// Determines whether the data context should be closed after use based on the current application settings.
-    /// </summary>
-    /// <returns>true if the settings indicate that the data context should be closed after use; otherwise, false.</returns>
-    public static bool GetCloseDataContextAfterUse()
-    {
-        var settings = LoadSettings();
-
-        return settings is null || settings.CloseDataContextAfterUse;
     }
 
     #endregion


### PR DESCRIPTION
Closes #8141 

## Summary

Simplifies `DataSettingsManager` so it only handles persistence and installation state, not per-call reads from `DataConfig`.

## What changed

- Removed forwarding helpers from `DataSettingsManager` (`GetSqlCommandTimeout`, `UseNoLock`, `GetBulkCopyOptions`, `GetCloseDataContextAfterUse`).
- Call sites use the existing `DataSettings` / `DataConfig` instance instead (`BaseDataProvider`, `MsSqlDataProvider`).