### PR TITLE
Deletes temporary tables before re-creating it

### DIFF
--- a/src/Libraries/Nop.Data/TempSqlDataStorage.cs
+++ b/src/Libraries/Nop.Data/TempSqlDataStorage.cs
@@ -11,7 +11,7 @@ public partial class TempSqlDataStorage<T> : TempTable<T>, ITempDataStorage<T> w
     #region Ctor
 
     public TempSqlDataStorage(string storageName, IQueryable<T> query, IDataContext dataConnection)
-        : base(dataConnection, storageName, query, tableOptions: TableOptions.NotSet | TableOptions.DropIfExists)
+        : base(dataConnection, storageName, query, tableOptions: TableOptions.NotSet | TableOptions.CheckExistence)
     {
         dataConnection.CloseAfterUse = true;
     }


### PR DESCRIPTION
"tmp_guestsToDelete and"
and
"tmp_guestsAddressesToDelete"

threw an "table already exsists" error when the shop restarted before the "deleteGuests" task was finished and you ran the job again.