### PR TITLE
Migrate PayPal Commerce plugin from custom HTTP client to official PayPal Server SDK

### DIFF
--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Infrastructure/NopStartup.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Infrastructure/NopStartup.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Nop.Core.Infrastructure;
@@ -20,6 +21,18 @@ public class NopStartup : INopStartup
     /// <param name="configuration">Configuration of the application</param>
     public void ConfigureServices(IServiceCollection services, IConfiguration configuration)
     {
+        //remove the PayPal SDK assembly from MVC application parts to prevent
+        //Autofac from trying to register SDK internal "Controller" types (e.g. BaseController)
+        //which have no public constructors and are not MVC controllers
+        var partManager = services
+            .FirstOrDefault(d => d.ServiceType == typeof(ApplicationPartManager))
+            ?.ImplementationInstance as ApplicationPartManager;
+        var sdkPart = partManager?.ApplicationParts
+            .FirstOrDefault(p => p.Name.Equals("PayPalServerSDK", StringComparison.OrdinalIgnoreCase));
+        if (sdkPart != null)
+            partManager.ApplicationParts.Remove(sdkPart);
+
+        services.AddSingleton<PayPalSdkClientFactory>();
         services.AddHttpClient<OnboardingHttpClient>().WithProxy();
         services.AddHttpClient<PayPalCommerceHttpClient>().WithProxy();
         services.AddScoped<PayPalCommerceModelFactory>();

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Nop.Plugin.Payments.PayPalCommerce.csproj
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Nop.Plugin.Payments.PayPalCommerce.csproj
@@ -14,7 +14,7 @@
     <!--Set this parameter to true to get the dlls copied from the NuGet cache to the output of your project.
     You need to set this parameter to true if your plugin has a nuget package
     to ensure that the dlls copied from the NuGet cache to the output of your project-->
-    <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
@@ -86,6 +86,10 @@
     <Content Include="Views\_ViewImports.cshtml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="PayPalServerSDK" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Services/PayPalCommerceHttpClient.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Services/PayPalCommerceHttpClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using Microsoft.Net.Http.Headers;
 using Newtonsoft.Json;
 using Nop.Core;
@@ -6,27 +6,38 @@ using Nop.Plugin.Payments.PayPalCommerce.Services.Api;
 using Nop.Plugin.Payments.PayPalCommerce.Services.Api.Authentication;
 using Nop.Plugin.Payments.PayPalCommerce.Services.Api.Models;
 using Nop.Plugin.Payments.PayPalCommerce.Services.Api.Onboarding;
+using PaypalServerSdk.Standard.Exceptions;
+using SdkModels = PaypalServerSdk.Standard.Models;
 
 namespace Nop.Plugin.Payments.PayPalCommerce.Services;
 
 /// <summary>
-/// Represents the HTTP client to request PayPal API
+/// Represents the HTTP client to request PayPal API.
+/// Uses the official PayPal Server SDK for Orders, Payments, Vault, and Tracking operations.
+/// Falls back to direct HTTP for webhooks, identity tokens, and onboarding.
 /// </summary>
 public class PayPalCommerceHttpClient
 {
     #region Fields
 
     private readonly HttpClient _httpClient;
+    private readonly PayPalSdkClientFactory _sdkClientFactory;
 
     private static Dictionary<string, AccessToken> _accessTokens = new();
+
+    private static readonly JsonSerializerSettings _jsonSettings = new()
+    {
+        NullValueHandling = NullValueHandling.Ignore
+    };
 
     #endregion
 
     #region Ctor
 
-    public PayPalCommerceHttpClient(HttpClient httpClient)
+    public PayPalCommerceHttpClient(HttpClient httpClient, PayPalSdkClientFactory sdkClientFactory)
     {
         _httpClient = httpClient;
+        _sdkClientFactory = sdkClientFactory;
     }
 
     #endregion
@@ -52,7 +63,7 @@ public class PayPalCommerceHttpClient
             accessToken.IsExpired)
         {
             //get new access token
-            accessToken = await RequestAsync<GetAccessTokenRequest, GetAccessTokenResponse>(new()
+            accessToken = await RequestViaHttpAsync<GetAccessTokenRequest, GetAccessTokenResponse>(new()
             {
                 ClientId = settings.ClientId,
                 Secret = settings.SecretKey,
@@ -64,26 +75,330 @@ public class PayPalCommerceHttpClient
         return accessToken.Token;
     }
 
-    #endregion
+    /// <summary>
+    /// Convert SDK ApiException to NopException with detailed error information
+    /// </summary>
+    private static NopException ConvertSdkException(ApiException sdkException)
+    {
+        var error = $"Failed request ({sdkException.ResponseCode})";
 
-    #region Methods
+        if (sdkException is ErrorException errorEx)
+        {
+            if (!string.IsNullOrEmpty(errorEx.Name))
+            {
+                error += $": {(!string.IsNullOrEmpty(errorEx.Message) ? errorEx.Message : errorEx.Name)}";
+                if (errorEx.Details?.Any() == true)
+                {
+                    var details = string.Join(Environment.NewLine,
+                        errorEx.Details.Select(d => $"  [{d.Field}] {d.Issue}: {d.Description}"));
+                    error += $"{Environment.NewLine}{details}";
+                }
+            }
+        }
+        else
+        {
+            error += $": {sdkException.Message}";
+        }
+
+        return new NopException("Failed request", new NopException(error));
+    }
 
     /// <summary>
-    /// Request remote service
+    /// Serialize an SDK response model to JSON, then deserialize to an internal model type.
+    /// Both model sets use Newtonsoft.Json and map to the same PayPal REST API JSON schema.
     /// </summary>
-    /// <typeparam name="TRequest">Request type</typeparam>
-    /// <typeparam name="TResponse">Response type</typeparam>
-    /// <param name="request">Request</param>
-    /// <param name="settings">Plugin settings</param>
-    /// <returns>
-    /// A task that represents the asynchronous operation
-    /// The task result contains the response details
-    /// </returns>
-    public async Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest request, PayPalCommerceSettings settings)
+    private static TResponse ConvertSdkResponse<TResponse>(object sdkResponse) where TResponse : IApiResponse
+    {
+        if (typeof(TResponse) == typeof(EmptyResponse))
+            return default;
+
+        var json = JsonConvert.SerializeObject(sdkResponse, _jsonSettings);
+        return JsonConvert.DeserializeObject<TResponse>(json) ?? default;
+    }
+
+    #region SDK-routed operations
+
+    /// <summary>
+    /// Try to handle the request via the PayPal Server SDK.
+    /// Returns (true, response) if handled, (false, default) if the request type is not supported by the SDK.
+    /// </summary>
+    private async Task<(bool Handled, TResponse Response)> TryHandleViaSdkAsync<TRequest, TResponse>(
+        TRequest request, PayPalCommerceSettings settings)
+        where TRequest : IApiRequest where TResponse : IApiResponse
+    {
+        try
+        {
+            // Orders - Create
+            if (request is Api.Orders.CreateOrderRequest createOrderReq)
+            {
+                var client = _sdkClientFactory.GetClient(settings);
+                var json = JsonConvert.SerializeObject(createOrderReq, _jsonSettings);
+                var sdkBody = JsonConvert.DeserializeObject<SdkModels.OrderRequest>(json);
+
+                var input = new SdkModels.CreateOrderInput
+                {
+                    Body = sdkBody,
+                    Prefer = "return=representation",
+                    PaypalRequestId = Guid.NewGuid().ToString(),
+                    PaypalPartnerAttributionId = PayPalCommerceDefaults.PartnerHeader.Value
+                };
+
+                var result = await client.OrdersController.CreateOrderAsync(input);
+                return (true, ConvertSdkResponse<TResponse>(result.Data));
+            }
+
+            // Orders - Get
+            if (request is Api.Orders.GetOrderRequest getOrderReq)
+            {
+                var client = _sdkClientFactory.GetClient(settings);
+                var input = new SdkModels.GetOrderInput
+                {
+                    Id = getOrderReq.OrderId
+                };
+
+                var result = await client.OrdersController.GetOrderAsync(input);
+                return (true, ConvertSdkResponse<TResponse>(result.Data));
+            }
+
+            // Orders - Patch/Update
+            if (request.GetType().IsGenericType &&
+                request.GetType().GetGenericTypeDefinition() == typeof(Api.Orders.UpdateOrderRequest<>))
+            {
+                var client = _sdkClientFactory.GetClient(settings);
+                var orderIdProp = request.GetType().GetProperty("OrderId");
+                var orderId = orderIdProp?.GetValue(request)?.ToString();
+
+                // Serialize internal patches to JSON, then deserialize to SDK Patch list
+                var json = JsonConvert.SerializeObject(request, _jsonSettings);
+                var sdkPatches = JsonConvert.DeserializeObject<List<SdkModels.Patch>>(json);
+
+                var input = new SdkModels.PatchOrderInput
+                {
+                    Id = orderId,
+                    Body = sdkPatches
+                };
+
+                await client.OrdersController.PatchOrderAsync(input);
+                return (true, default);
+            }
+
+            // Orders - Authorize
+            if (request is Api.Orders.CreateAuthorizationRequest authReq)
+            {
+                var client = _sdkClientFactory.GetClient(settings);
+                var input = new SdkModels.AuthorizeOrderInput
+                {
+                    Id = authReq.OrderId,
+                    Prefer = "return=representation",
+                    PaypalRequestId = Guid.NewGuid().ToString()
+                };
+
+                var result = await client.OrdersController.AuthorizeOrderAsync(input);
+                return (true, ConvertSdkResponse<TResponse>(result.Data));
+            }
+
+            // Orders - Capture (capture an approved order)
+            if (request is Api.Orders.CreateCaptureRequest captureOrderReq)
+            {
+                var client = _sdkClientFactory.GetClient(settings);
+                var input = new SdkModels.CaptureOrderInput
+                {
+                    Id = captureOrderReq.OrderId,
+                    Prefer = "return=representation",
+                    PaypalRequestId = Guid.NewGuid().ToString()
+                };
+
+                var result = await client.OrdersController.CaptureOrderAsync(input);
+                return (true, ConvertSdkResponse<TResponse>(result.Data));
+            }
+
+            // Orders - Tracking
+            if (request is Api.Orders.CreateTrackingRequest trackingReq)
+            {
+                var client = _sdkClientFactory.GetClient(settings);
+
+                var sdkItems = trackingReq.Items?.Select(item =>
+                {
+                    var itemJson = JsonConvert.SerializeObject(item, _jsonSettings);
+                    return JsonConvert.DeserializeObject<SdkModels.OrderTrackerItem>(itemJson);
+                }).ToList();
+
+                var input = new SdkModels.CreateOrderTrackingInput
+                {
+                    Id = trackingReq.OrderId,
+                    Body = new SdkModels.OrderTrackerRequest
+                    {
+                        CaptureId = trackingReq.CaptureId,
+                        TrackingNumber = trackingReq.TrackingNumber,
+                        NotifyPayer = trackingReq.NotifyPayer,
+                        Items = sdkItems
+                    }
+                };
+
+                // Set carrier - the SDK uses an enum, try to parse it
+                if (!string.IsNullOrEmpty(trackingReq.Carrier))
+                {
+                    if (Enum.TryParse<SdkModels.ShipmentCarrier>(trackingReq.Carrier, true, out var sdkCarrier))
+                        input.Body.Carrier = sdkCarrier;
+                    else
+                        input.Body.CarrierNameOther = trackingReq.Carrier;
+                }
+
+                var result = await client.OrdersController.CreateOrderTrackingAsync(input);
+                return (true, ConvertSdkResponse<TResponse>(result.Data));
+            }
+
+            // Payments - Capture an authorization
+            if (request is Api.Payments.CreateCaptureRequest captureAuthReq)
+            {
+                var client = _sdkClientFactory.GetClient(settings);
+
+                var json = JsonConvert.SerializeObject(captureAuthReq, _jsonSettings);
+                var sdkBody = JsonConvert.DeserializeObject<SdkModels.CaptureRequest>(json);
+
+                var input = new SdkModels.CaptureAuthorizedPaymentInput
+                {
+                    AuthorizationId = captureAuthReq.AuthorizationId,
+                    Body = sdkBody,
+                    Prefer = "return=representation",
+                    PaypalRequestId = Guid.NewGuid().ToString()
+                };
+
+                var result = await client.PaymentsController.CaptureAuthorizedPaymentAsync(input);
+                return (true, ConvertSdkResponse<TResponse>(result.Data));
+            }
+
+            // Payments - Void
+            if (request is Api.Payments.CreateVoidRequest voidReq)
+            {
+                var client = _sdkClientFactory.GetClient(settings);
+                var input = new SdkModels.VoidPaymentInput
+                {
+                    AuthorizationId = voidReq.AuthorizationId,
+                    PaypalRequestId = Guid.NewGuid().ToString()
+                };
+
+                await client.PaymentsController.VoidPaymentAsync(input);
+                return (true, default);
+            }
+
+            // Payments - Refund
+            if (request is Api.Payments.CreateRefundRequest refundReq)
+            {
+                var client = _sdkClientFactory.GetClient(settings);
+
+                SdkModels.Money sdkAmount = null;
+                if (refundReq.Amount is not null)
+                {
+                    sdkAmount = new SdkModels.Money
+                    {
+                        CurrencyCode = refundReq.Amount.CurrencyCode,
+                        MValue = refundReq.Amount.Value
+                    };
+                }
+
+                var input = new SdkModels.RefundCapturedPaymentInput
+                {
+                    CaptureId = refundReq.CaptureId,
+                    Body = new SdkModels.RefundRequest
+                    {
+                        Amount = sdkAmount
+                    },
+                    Prefer = "return=representation",
+                    PaypalRequestId = Guid.NewGuid().ToString()
+                };
+
+                var result = await client.PaymentsController.RefundCapturedPaymentAsync(input);
+                return (true, ConvertSdkResponse<TResponse>(result.Data));
+            }
+
+            // Vault - Create Setup Token
+            if (request is Api.PaymentTokens.CreateSetupTokenRequest setupTokenReq)
+            {
+                var client = _sdkClientFactory.GetClient(settings);
+                var json = JsonConvert.SerializeObject(setupTokenReq, _jsonSettings);
+                var sdkBody = JsonConvert.DeserializeObject<SdkModels.SetupTokenRequest>(json);
+
+                var input = new SdkModels.CreateSetupTokenInput
+                {
+                    Body = sdkBody,
+                    PaypalRequestId = Guid.NewGuid().ToString()
+                };
+
+                var result = await client.VaultController.CreateSetupTokenAsync(input);
+                return (true, ConvertSdkResponse<TResponse>(result.Data));
+            }
+
+            // Vault - Create Payment Token
+            if (request is Api.PaymentTokens.CreatePaymentTokenRequest paymentTokenReq)
+            {
+                var client = _sdkClientFactory.GetClient(settings);
+                var json = JsonConvert.SerializeObject(paymentTokenReq, _jsonSettings);
+                var sdkBody = JsonConvert.DeserializeObject<SdkModels.PaymentTokenRequest>(json);
+
+                var input = new SdkModels.CreatePaymentTokenInput
+                {
+                    Body = sdkBody,
+                    PaypalRequestId = Guid.NewGuid().ToString()
+                };
+
+                var result = await client.VaultController.CreatePaymentTokenAsync(input);
+                return (true, ConvertSdkResponse<TResponse>(result.Data));
+            }
+
+            // Vault - Get (List) Payment Tokens
+            if (request is Api.PaymentTokens.GetPaymentTokensRequest getTokensReq)
+            {
+                var client = _sdkClientFactory.GetClient(settings);
+                var input = new SdkModels.ListCustomerPaymentTokensInput
+                {
+                    CustomerId = getTokensReq.VaultCustomerId,
+                    TotalRequired = false
+                };
+
+                var result = await client.VaultController.ListCustomerPaymentTokensAsync(input);
+
+                // Convert SDK response to internal format
+                var json = JsonConvert.SerializeObject(result.Data, _jsonSettings);
+                var response = JsonConvert.DeserializeObject<TResponse>(json);
+                return (true, response ?? default);
+            }
+
+            // Vault - Delete Payment Token
+            if (request is Api.PaymentTokens.DeletePaymentTokenRequest deleteTokenReq)
+            {
+                var client = _sdkClientFactory.GetClient(settings);
+                await client.VaultController.DeletePaymentTokenAsync(deleteTokenReq.Id);
+                return (true, default);
+            }
+
+            // Vault - Get single Payment Token
+            if (request is Api.PaymentTokens.GetPaymentTokenRequest getTokenReq)
+            {
+                var client = _sdkClientFactory.GetClient(settings);
+                var result = await client.VaultController.GetPaymentTokenAsync(getTokenReq.Id);
+                return (true, ConvertSdkResponse<TResponse>(result.Data));
+            }
+        }
+        catch (ApiException sdkEx)
+        {
+            throw ConvertSdkException(sdkEx);
+        }
+
+        // Not handled by SDK
+        return (false, default);
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Request remote service via direct HTTP (for operations not covered by SDK)
+    /// </summary>
+    private async Task<TResponse> RequestViaHttpAsync<TRequest, TResponse>(TRequest request, PayPalCommerceSettings settings)
         where TRequest : IApiRequest where TResponse : IApiResponse
     {
         //prepare request body, content is always JSON except for access token requests
-        var requestString = JsonConvert.SerializeObject(request, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+        var requestString = JsonConvert.SerializeObject(request, _jsonSettings);
         var requestContent = request is GetAccessTokenRequest accessTokenRequest
             ? new FormUrlEncodedContent(PayPalCommerceServiceManager.ObjectToDictionary(accessTokenRequest))
             : (ByteArrayContent)new StringContent(requestString, Encoding.Default, MimeTypes.ApplicationJson);
@@ -156,6 +471,37 @@ public class PayPalCommerceHttpClient
         }
 
         throw new NopException("Failed request", new NopException(error));
+    }
+
+    #endregion
+
+    #region Methods
+
+    /// <summary>
+    /// Request remote service
+    /// </summary>
+    /// <typeparam name="TRequest">Request type</typeparam>
+    /// <typeparam name="TResponse">Response type</typeparam>
+    /// <param name="request">Request</param>
+    /// <param name="settings">Plugin settings</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation
+    /// The task result contains the response details
+    /// </returns>
+    public async Task<TResponse> RequestAsync<TRequest, TResponse>(TRequest request, PayPalCommerceSettings settings)
+        where TRequest : IApiRequest where TResponse : IApiResponse
+    {
+        // Try to route through the official PayPal Server SDK
+        if (PayPalCommerceServiceManager.IsConfigured(settings))
+        {
+            var (handled, response) = await TryHandleViaSdkAsync<TRequest, TResponse>(request, settings);
+            if (handled)
+                return response;
+        }
+
+        // Fall back to direct HTTP for operations not covered by the SDK
+        // (webhooks, identity tokens, access tokens, onboarding credentials)
+        return await RequestViaHttpAsync<TRequest, TResponse>(request, settings);
     }
 
     #endregion

--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Services/PayPalSdkClientFactory.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Services/PayPalSdkClientFactory.cs
@@ -1,0 +1,52 @@
+using System.Collections.Concurrent;
+using PaypalServerSdk.Standard;
+using PaypalServerSdk.Standard.Authentication;
+
+namespace Nop.Plugin.Payments.PayPalCommerce.Services;
+
+/// <summary>
+/// Creates and caches PayPal Server SDK client instances per configuration
+/// </summary>
+public class PayPalSdkClientFactory
+{
+    private readonly ConcurrentDictionary<string, PaypalServerSdkClient> _clients = new();
+
+    /// <summary>
+    /// Get or create a configured PayPal SDK client for the given settings
+    /// </summary>
+    /// <param name="settings">Plugin settings</param>
+    /// <returns>Configured PaypalServerSdkClient instance</returns>
+    public PaypalServerSdkClient GetClient(PayPalCommerceSettings settings)
+    {
+        var cacheKey = $"{settings.ClientId}_{settings.UseSandbox}";
+
+        return _clients.GetOrAdd(cacheKey, _ => CreateClient(settings));
+    }
+
+    /// <summary>
+    /// Remove a cached client (e.g. when credentials change)
+    /// </summary>
+    /// <param name="settings">Plugin settings</param>
+    public void InvalidateClient(PayPalCommerceSettings settings)
+    {
+        var cacheKey = $"{settings.ClientId}_{settings.UseSandbox}";
+        _clients.TryRemove(cacheKey, out _);
+    }
+
+    private static PaypalServerSdkClient CreateClient(PayPalCommerceSettings settings)
+    {
+        var timeout = TimeSpan.FromSeconds(settings.RequestTimeout ?? PayPalCommerceDefaults.RequestTimeout);
+
+        return new PaypalServerSdkClient.Builder()
+            .ClientCredentialsAuth(
+                new ClientCredentialsAuthModel.Builder(
+                    settings.ClientId,
+                    settings.SecretKey
+                ).Build())
+            .Environment(settings.UseSandbox
+                ? PaypalServerSdk.Standard.Environment.Sandbox
+                : PaypalServerSdk.Standard.Environment.Production)
+            .HttpClientConfig(config => config.Timeout(timeout))
+            .Build();
+    }
+}


### PR DESCRIPTION
Closes #8185 

Replace manual HttpClient-based PayPal API calls with the official PayPalServerSDK (v2.0.0) using an adapter pattern that routes Orders, Payments, Vault, and Tracking operations through the SDK while preserving HTTP fallback for webhooks, identity tokens, and onboarding.