### PR TITLE
ci: add CodeQL analysis for security scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,42 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+  schedule:
+    - cron: '0 4 * * 1'  # Every Monday at 4 AM UTC
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: windows-latest
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: csharp
+            build-mode: autobuild
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Description
Adds [CodeQL](https://codeql.github.com/) security analysis to nopCommerce CI. Runs on every push, pull request, and weekly (Monday 4 AM UTC) to catch security vulnerabilities before they reach production.

## What it scans for
- SQL injection, XSS, CSRF
- Insecure deserialization
- Hardcoded credentials and secrets
- Path traversal and file disclosure
- Unsafe cryptographic algorithms
- Dependency confusion and supply-chain risks

## Impact
- **Zero runtime overhead** — runs in parallel to the existing build workflow
- Results visible in GitHub Security → Code Scanning tab
- Weekly full scan catches regressions even without code changes
- No false positives block the build — results are advisory for review

## Checklist
- [x] Weekly schedule + push + pull_request triggers
- [x] Uses `autobuild` mode (compatible with nopCommerce's .NET 10 solution structure)
- [x] Least-privilege permissions (`security-events: write` only for SARIF upload)
- [x] No changes to existing build workflow