### PR TITLE
ci: add Linux build matrix alongside Windows

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,6 +1,3 @@
-# This workflow will build a .NET project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
 name: .NET
 
 on:
@@ -11,8 +8,10 @@ on:
 
 jobs:
   build:
-
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Description
Adds `ubuntu-latest` to the CI build matrix alongside `windows-latest`, doubling test coverage to catch cross-platform compatibility issues early.

## Impact
- Catches Linux-specific build failures before they hit production
- NuGet caching works per-OS with separate cache keys
- No additional build time — matrix jobs run in parallel

## Checklist
- [x] Matrix strategy with ubuntu-latest + windows-latest
- [x] NuGet cache path works on both OS (~/.nuget/packages)
- [x] Cache key includes runner OS so caches don't mix