### PR TITLE
Add Cursor skills for local nopCommerce Docker workflows.

### DIFF
--- a/.cursor/skills/start-local-nopcommerce/SKILL.md
+++ b/.cursor/skills/start-local-nopcommerce/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: start-local-nopcommerce
+description: Build and run this nopCommerce app locally in Docker, then open it in the Cursor browser. Use when the user asks to bring up, run, start, launch, or open the local nopCommerce server or app.
+---
+
+# Start Local nopCommerce
+
+## Purpose
+
+Bring up this nopCommerce repo locally and open the app in the Cursor browser.
+
+This repo targets .NET 10. Prefer Docker because the host may not have the .NET SDK installed. On Apple Silicon, build and run as `linux/amd64`; the published app includes `IBM.Data.Db2.dll`, which is not compatible with an ARM64 process.
+
+## Workflow
+
+1. Check for an existing server:
+
+```bash
+docker ps -a --filter name=^/nopcommerce-local$ --format '{{.Names}} {{.Status}}'
+```
+
+If `nopcommerce-local` is already running, keep it and verify `http://localhost:8080/install`.
+
+2. Build the local image:
+
+```bash
+docker build --platform linux/amd64 -t nopcommerce-local-amd64 .
+```
+
+3. Remove a stale stopped container if needed:
+
+```bash
+docker rm nopcommerce-local
+```
+
+4. Start the server in the background:
+
+```bash
+docker run --platform linux/amd64 --name nopcommerce-local -p 8080:80 nopcommerce-local-amd64
+```
+
+5. Verify it responds:
+
+```bash
+curl -I --max-time 15 http://localhost:8080
+curl -I --max-time 15 http://localhost:8080/install
+```
+
+Expected results:
+- `/` returns `302 Found` to `/install` before setup.
+- `/install` returns `200 OK`.
+
+6. Open the app in the Cursor browser:
+
+Use the `cursor-ide-browser` MCP server. Before calling MCP tools, read the relevant tool descriptors. Then:
+- List tabs with `browser_tabs`.
+- Navigate to `http://localhost:8080/install` with `browser_navigate`.
+- Take a `browser_snapshot` to confirm the page loaded.
+
+## Notes
+
+- Do not use the default `docker-compose.yml` on Apple Silicon unless the user specifically wants to debug the database stack. Its SQL Server service is commonly x64-only.
+- The app container alone is enough to reach the nopCommerce installer.
+- To stop the app, use [stop-local-nopcommerce](../stop-local-nopcommerce/SKILL.md).

--- a/.cursor/skills/stop-local-nopcommerce/SKILL.md
+++ b/.cursor/skills/stop-local-nopcommerce/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: stop-local-nopcommerce
+description: Stops and removes the local nopCommerce Docker container started by start-local-nopcommerce. Use when the user asks to stop, shut down, bring down, tear down, or clean up the local nopCommerce server.
+---
+
+# Stop Local nopCommerce
+
+## Purpose
+
+Stop the `nopcommerce-local` container and remove it so port `8080` is free.
+
+Does not remove the `nopcommerce-local-amd64` image unless the user explicitly asks to delete images.
+
+## Workflow
+
+1. Check whether the container exists:
+
+```bash
+docker ps -a --filter name=^/nopcommerce-local$ --format '{{.Names}} {{.Status}}'
+```
+
+If nothing is returned, report that the server is not running and stop.
+
+2. Stop the container if it is running:
+
+```bash
+docker stop nopcommerce-local
+```
+
+3. Remove the container:
+
+```bash
+docker rm nopcommerce-local
+```
+
+4. Confirm cleanup:
+
+```bash
+docker ps -a --filter name=^/nopcommerce-local$ --format '{{.Names}}'
+```
+
+Expected: no output.
+
+Optionally verify port `8080` is no longer in use:
+
+```bash
+curl -I --max-time 3 http://localhost:8080 || true
+```
+
+Expected: connection refused or timeout.
+
+## Notes
+
+- Pair with [start-local-nopcommerce](../start-local-nopcommerce/SKILL.md) for bring-up.
+- To also delete the built image:
+
+```bash
+docker rmi nopcommerce-local-amd64
+```
+
+Only run that when the user asks to remove images or reclaim disk space.


### PR DESCRIPTION
Add cursor agent skills to start the app in Docker and open it in the browser, and how to stop and remove the container.