### PR TITLE
#8210 Fix file descriptor leak in PictureService.GetDefaultPictureUrl…

### DIFF
--- a/src/Libraries/Nop.Services/Media/PictureService.cs
+++ b/src/Libraries/Nop.Services/Media/PictureService.cs
@@ -465,7 +465,7 @@ public partial class PictureService : IPictureService
             try
             {
                 using var image = SKBitmap.Decode(filePath);
-                var codec = SKCodec.Create(filePath);
+                using var codec = SKCodec.Create(filePath);
                 var format = codec.EncodedFormat;
                 var pictureBinary = ImageResize(image, format, targetSize);
                 var mimeType = GetMimeTypeFromFileName(thumbFileName);

--- a/src/Tests/Nop.Tests/Nop.Services.Tests/Media/PictureServiceFileDescriptorTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Services.Tests/Media/PictureServiceFileDescriptorTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using Nop.Core.Domain.Media;
+using Nop.Services.Media;
+using NUnit.Framework;
+
+namespace Nop.Tests.Nop.Services.Tests.Media;
+
+[TestFixture]
+public class PictureServiceFileDescriptorTests : ServiceTest
+{
+    private IPictureService _pictureService;
+    private IThumbService _thumbService;
+    private readonly List<string> _generatedThumbPaths = [];
+
+    [OneTimeSetUp]
+    public void SetUp()
+    {
+        _pictureService = GetService<IPictureService>();
+        _thumbService = GetService<IThumbService>();
+    }
+
+    [OneTimeTearDown]
+    public void TearDown()
+    {
+        foreach (var path in _generatedThumbPaths)
+        {
+            try
+            {
+                if (File.Exists(path))
+                    File.Delete(path);
+            }
+            catch
+            {
+                // ignored — best-effort cleanup
+            }
+        }
+    }
+
+    [Test]
+    public async Task GetDefaultPictureUrlAsync_DoesNotLeakFileDescriptors()
+    {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+            Assert.Ignore("File descriptor counting requires /proc/self/fd (Linux) or /dev/fd (macOS).");
+
+        const int warmupIterations = 10;
+        const int testIterations = 100;
+        const int baseSize = 990_000;
+
+        for (var i = 0; i < warmupIterations; i++)
+        {
+            var size = baseSize + i;
+            await _pictureService.GetDefaultPictureUrlAsync(size, PictureType.Entity);
+            _generatedThumbPaths.Add(await GetDefaultThumbPathAsync(size));
+        }
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var fdsBefore = CountOpenFileDescriptors();
+
+        for (var i = 0; i < testIterations; i++)
+        {
+            var size = baseSize + warmupIterations + i;
+            await _pictureService.GetDefaultPictureUrlAsync(size, PictureType.Entity);
+            _generatedThumbPaths.Add(await GetDefaultThumbPathAsync(size));
+        }
+
+        // Snapshot BEFORE forcing GC — finalizers would close the leaked fds and mask the bug.
+        // Production symptom is exactly this "live" state: SKCodec instances sitting in older
+        // generations holding open fds until Gen2 GC runs (hours, eventually hitting ulimit -n).
+        var fdsAfterLoop = CountOpenFileDescriptors();
+        var leakedLive = fdsAfterLoop - fdsBefore;
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        var fdsAfterGc = CountOpenFileDescriptors();
+        var leakedAfterGc = fdsAfterGc - fdsBefore;
+
+        TestContext.Out.WriteLine($"[fd leak probe] live delta = {leakedLive}, after-GC delta = {leakedAfterGc}");
+
+        leakedLive.Should().Be(0,
+            $"GetDefaultPictureUrlAsync leaked {leakedLive} file descriptors across {testIterations} thumb generations " +
+            $"(after forced GC: {leakedAfterGc}). Likely an IDisposable (SKCodec/SKBitmap) is not wrapped in `using`.");
+    }
+
+    private async Task<string> GetDefaultThumbPathAsync(int targetSize)
+    {
+        var thumbFileName = $"default-image_{targetSize}.png";
+        return await _thumbService.GetThumbLocalPathByFileNameAsync(thumbFileName);
+    }
+
+    private static int CountOpenFileDescriptors()
+    {
+        var fdDir = OperatingSystem.IsLinux() ? "/proc/self/fd" : "/dev/fd";
+        return System.IO.Directory.EnumerateFileSystemEntries(fdDir).Count();
+    }
+}


### PR DESCRIPTION
Closes #8210

  ## Problem

  `SKCodec.Create(filePath)` in `PictureService.GetDefaultPictureUrlAsync` (~line 468) is not wrapped in `using`:

  ```csharp
  using var image = SKBitmap.Decode(filePath);   // ✓ disposed
  var codec = SKCodec.Create(filePath);          // ✗ leaked — IDisposable
  var format = codec.EncodedFormat;
  ```

  `SKCodec` is `IDisposable` and holds an open file handle to the default image until the GC finalizer runs. Under sustained load this accumulates file descriptors and eventually exhausts `ulimit -n`, causing cascading `IOException` and container
  restarts. See #8210 for full reproduction and production symptom.

  ## Why it slipped

  The two adjacent `SKCodec.Create()` calls in the same file already use `using` correctly:
  - `PictureService.cs:609` — `using var codec = SKCodec.Create(inputStream);`
  - `PictureService.cs:1014` — `using var codec = SKCodec.Create(input);`

  This branch was the outlier.

  ## Fix

  Single keyword:

  ```diff
                   using var image = SKBitmap.Decode(filePath);
  -                var codec = SKCodec.Create(filePath);
  +                using var codec = SKCodec.Create(filePath);
  ```

  ## Regression test
  
  Added `Nop.Services.Tests/Media/PictureServiceFileDescriptorTests`:
  - Runs 100 iterations of `GetDefaultPictureUrlAsync` with unique `targetSize` values (each iteration triggers the leak code path because the thumb file doesn't exist yet)
  - Snapshots open fd count via `/proc/self/fd` (Linux) or `/dev/fd` (macOS) **before** forcing GC, so finalizers don't mask the live leak
  - Cleans up generated thumb files in `[OneTimeTearDown]`
  - Skips on Windows (no `/proc` or `/dev/fd`)

  | | Before fix | After fix |
  |---|---|---|
  | `leakedLive` after 100 iter | **48** | **0** (deterministic across 3 runs) |
  | `leakedAfterGc` | 0 (GC reaped) | 0 |

  ## Out of scope (worth a separate look)

  `PictureService.cs:1014` and `:1017` also have `SKBitmap.Decode(...)` not wrapped in `using`. These leak Skia native heap (not file descriptors) and the test doesn't cover them — happy to file a separate PR if maintainers want.
