### PR TITLE
#8212 Fix SQL deadlock in EntityRepository bulk Insert/Update/Delete

### DIFF
--- a/src/Libraries/Nop.Data/EntityRepository.cs
+++ b/src/Libraries/Nop.Data/EntityRepository.cs
@@ -123,6 +123,35 @@ public partial class EntityRepository<TEntity> : IRepository<TEntity> where TEnt
         return query.OfType<ISoftDeletedEntity>().Where(entry => !entry.Deleted).OfType<TEntity>();
     }
 
+    /// <summary>
+    /// Returns a <see cref="TransactionScope"/> with explicit <see cref="IsolationLevel.ReadCommitted"/>.
+    /// The default <c>new TransactionScope(...)</c> constructor uses <see cref="IsolationLevel.Serializable"/>,
+    /// which holds range locks (RangeS-S / RangeI-N on SQL Server) for the duration of bulk Insert/Update/Delete
+    /// and is the root cause of the deadlocks reported in #6482 and #6681. Row-level atomicity is guaranteed
+    /// by the transaction itself; range locks are not needed for these write paths.
+    /// <para>
+    /// Timeout is set explicitly to <see cref="TransactionManager.MaximumTimeout"/> per the MS-recommended pattern
+    /// — this matches the effective behavior of the previous single-argument <c>TransactionScope</c> constructor
+    /// (which left the scope timer unset). In practice the per-command <c>SqlCommand.CommandTimeout</c> (30s default)
+    /// fires first, so this scope-level value is a generous upper bound.
+    /// </para>
+    /// </summary>
+    /// <remarks>
+    /// See David Browne (Microsoft), <see href="https://learn.microsoft.com/en-us/archive/blogs/dbrowne/using-new-transactionscope-considered-harmful">
+    /// "using new TransactionScope() Considered Harmful"</see>:
+    /// <em>"in SQL Server SERIALIZABLE transactions are rarely useful and extremely deadlock-prone … its default constructor is setting up SQL Server applications to be deadlock-prone."</em>
+    /// </remarks>
+    private static TransactionScope CreateReadCommittedScope()
+    {
+        return new TransactionScope(TransactionScopeOption.Required,
+            new TransactionOptions
+            {
+                IsolationLevel = IsolationLevel.ReadCommitted,
+                Timeout = TransactionManager.MaximumTimeout
+            },
+            TransactionScopeAsyncFlowOption.Enabled);
+    }
+
     #endregion
 
     #region Methods
@@ -441,7 +470,7 @@ public partial class EntityRepository<TEntity> : IRepository<TEntity> where TEnt
     {
         ArgumentNullException.ThrowIfNull(entities);
 
-        using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+        using var transaction = CreateReadCommittedScope();
         await _dataProvider.BulkInsertEntitiesAsync(entities);
         transaction.Complete();
 
@@ -462,7 +491,7 @@ public partial class EntityRepository<TEntity> : IRepository<TEntity> where TEnt
     {
         ArgumentNullException.ThrowIfNull(entities);
 
-        using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+        using var transaction = CreateReadCommittedScope();
         _dataProvider.BulkInsertEntities(entities);
         transaction.Complete();
 
@@ -632,7 +661,7 @@ public partial class EntityRepository<TEntity> : IRepository<TEntity> where TEnt
         if (!entities.Any())
             return;
 
-        using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+        using var transaction = CreateReadCommittedScope();
         
         if (typeof(TEntity).GetInterface(nameof(ISoftDeletedEntity)) == null)
             await _dataProvider.BulkDeleteEntitiesAsync(entities);
@@ -666,7 +695,7 @@ public partial class EntityRepository<TEntity> : IRepository<TEntity> where TEnt
         if (!entities.Any())
             return;
 
-        using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+        using var transaction = CreateReadCommittedScope();
 
         if (typeof(TEntity).GetInterface(nameof(ISoftDeletedEntity)) == null)
             _dataProvider.BulkDeleteEntities(entities);
@@ -700,7 +729,7 @@ public partial class EntityRepository<TEntity> : IRepository<TEntity> where TEnt
     {
         ArgumentNullException.ThrowIfNull(predicate);
 
-        using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+        using var transaction = CreateReadCommittedScope();
         var countDeletedRecords = await _dataProvider.BulkDeleteEntitiesAsync(predicate);
         transaction.Complete();
 
@@ -718,7 +747,7 @@ public partial class EntityRepository<TEntity> : IRepository<TEntity> where TEnt
     {
         ArgumentNullException.ThrowIfNull(predicate);
 
-        using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
+        using var transaction = CreateReadCommittedScope();
         var countDeletedRecords = _dataProvider.BulkDeleteEntities(predicate);
         transaction.Complete();
 


### PR DESCRIPTION
 Closes #8212
  Refs #6482 #6681

  ## Problem

  All 6 `TransactionScope` instances in `EntityRepository.cs` use the default constructor:

  ```csharp
  using var transaction = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
  ```

  This defaults `IsolationLevel` to `Serializable` — a known footgun on SQL Server, addressed in detail by Microsoft engineer David Browne's blog post **["using new TransactionScope() Considered 
  Harmful"](https://learn.microsoft.com/en-us/archive/blogs/dbrowne/using-new-transactionscope-considered-harmful)**:

  > *"in SQL Server SERIALIZABLE transactions are rarely useful and extremely deadlock-prone (...) its default constructor is setting up SQL Server applications to be deadlock-prone."*

  On SQL Server this produces range locks (RangeS-S / RangeI-N) held for the duration of bulk Insert/Update/Delete operations, leading to deadlocks under concurrent load (most visibly `ResetCheckoutDataAsync` during checkout confirm).

  See #8212 for the full reproduction, hot paths, relation to #6482/#6681 (both previously closed for lack of reproduction — we now provide both the theoretical mechanism and empirical evidence), and production before/after data showing **246 
  deadlocks → 0** at deploy time.

  ## Fix

  Adds a private helper `CreateReadCommittedScope()` matching the MS-recommended pattern from the blog post above:

  ```csharp
  private static TransactionScope CreateReadCommittedScope()
  {
      return new TransactionScope(TransactionScopeOption.Required,
          new TransactionOptions
          {
              IsolationLevel = IsolationLevel.ReadCommitted,
              Timeout = TransactionManager.MaximumTimeout
          },
          TransactionScopeAsyncFlowOption.Enabled);
  }
  ```

  Applied to all 6 bulk paths:
  - `InsertAsync(IList<TEntity>)` / `Insert(IList<TEntity>)` — bulk insert
  - `DeleteAsync(IList<TEntity>)` / `Delete(IList<TEntity>)` — bulk delete (entities)
  - `DeleteAsync(Expression<Func<TEntity, bool>>)` / `Delete(Expression<Func<TEntity, bool>>)` — bulk delete (predicate)

  ## Why ReadCommitted is safe here

  The bulk operation is itself a single LinqToDB call wrapped in the transaction. Row-level atomicity (each row's INSERT/UPDATE/DELETE is atomic) is guaranteed by the transaction itself. Serializable's range-lock semantics — preventing phantom
  reads across the affected index range — is not needed for these write-only paths, because there is no application-level read to re-execute.

  Under `READ_COMMITTED_SNAPSHOT = ON` (typical for nopCommerce deployments) readers don't block writers at all, and writers among themselves operate with row-level locks instead of range locks.

  ## Timeout — transparent disclosure of behavioral change
  
  The previous single-argument `TransactionScope(TransactionScopeAsyncFlowOption)` constructor **does not set a scope-level timeout** (no `_scopeTimer` is created). The 3-argument constructor we use here passes `TransactionOptions` through
  `TransactionManager.ValidateTimeout`, which maps the default `TimeSpan.Zero` to `MaximumTimeout` (10 minutes).

  To make this explicit and match the MS-recommended pattern, the helper sets `Timeout = TransactionManager.MaximumTimeout` directly. In practice this scope-level value is masked by `SqlCommand.CommandTimeout` (30s default), which fires first —
  verified in production without any observable behavioral change.

  ## Production verification

  See #8212 for the full before/after table. Summary: an equivalent fix deployed to one production store on **2026-05-20 ~09:00** dropped the deadlock rate from **246 deadlocks in 4 days before** to **0 deadlocks in 7+ days after**, with the
  inflection point exactly at the deploy time.

  ## Risk

  **Minimal.** ReadCommitted was the SQL Server default for nopCommerce code running outside `TransactionScope` wrappers — this fix only restores that default for the 6 bulk paths. Existing CRUD tests (`EntityRepositoryTests`) pass unchanged.

  ## Why no new test added
  
  A behavioral test would require mocking `INopDataProvider` to capture `Transaction.Current.IsolationLevel` at runtime — adding more code than the fix itself, and asserting on TransactionScope internals that aren't part of any public contract.
  Happy to add one if the maintainers prefer; the change is otherwise small enough to verify by inspection.
