### PR TITLE
Use UseAuthentication() extension to prevent duplicate auth middleware under minimal hosting

### DIFF
--- a/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/Presentation/Nop.Web.Framework/Infrastructure/Extensions/ApplicationBuilderExtensions.cs
@@ -401,7 +401,7 @@ public static class ApplicationBuilderExtensions
         if (!DataSettingsManager.IsDatabaseInstalled())
             return;
 
-        application.UseMiddleware<AuthenticationMiddleware>();
+        application.UseAuthentication();
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #8220

### Problem

`UseNopAuthentication` registers authentication with `application.UseMiddleware<AuthenticationMiddleware>()`. Under minimal hosting (`WebApplication`), the `UseAuthentication()` extension is what sets the `__AuthenticationMiddlewareSet` marker that prevents the framework from auto-adding authentication middleware. Without it, `WebApplication` auto-inserts a **second** `AuthenticationMiddleware` at the front of the pipeline, before `UseForwardedHeaders`.

### Effect

Remote-auth provider callbacks are handled by that front instance before forwarded headers run, so the token-exchange `redirect_uri` is built from the raw backend scheme (`http://`) while the authorize `redirect_uri` is `https://`. Behind a reverse proxy with an HTTP backend this breaks OAuth/social login (Google `redirect_uri_mismatch`, Facebook error 191). Full details and reproduction in #8220.

### Fix

Register via the `application.UseAuthentication()` extension. One-line change; the duplicate front instance is suppressed and the remaining instance (between `UseRouting` and `UseEndpoints`) runs after forwarded headers.

### Affected versions

Introduced in 4.50.0 (the switch to minimal hosting / `WebApplication`); present in every release since, including current `develop`. 4.40.x and earlier (Generic Host) are unaffected.

### Testing

Verified on an IIS ARR blue/green deployment (TLS-terminating proxy in front of HTTP loopback backends): external + social login (Google, Facebook) fail before the change and succeed after it; ordinary email/password login is unaffected.

### Note

The same pattern may apply to `UseAuthorization()` vs `UseMiddleware<AuthorizationMiddleware>()` if registered the same way; left out of scope here.
