### PR TITLE
Fix N+1 query in product overview models (load customer wishlists once)

### DIFF
--- a/src/Presentation/Nop.Web/Factories/ProductModelFactory.cs
+++ b/src/Presentation/Nop.Web/Factories/ProductModelFactory.cs
@@ -789,13 +789,29 @@ public partial class ProductModelFactory : IProductModelFactory
     {
         ArgumentNullException.ThrowIfNull(product);
 
+        //custom wishlists
+        var currentCustomer = await _workContext.GetCurrentCustomerAsync();
+        var currentWishlists = await _customWishlistService.GetAllCustomWishlistsAsync(currentCustomer.Id);
+
+        return PrepareProductToWishlistModel(product, currentWishlists);
+    }
+
+    /// <summary>
+    /// Prepare the product to wishlist model from an already-loaded set of the customer's wishlists.
+    /// Callers that render many products in one request (e.g. catalog listings) should load the
+    /// wishlists once and reuse them here, rather than querying once per product.
+    /// </summary>
+    /// <param name="product">Product</param>
+    /// <param name="currentWishlists">The current customer's custom wishlists</param>
+    /// <returns>The product add to wishlist model</returns>
+    protected virtual ProductToWishlistModel PrepareProductToWishlistModel(Product product, IList<CustomWishlist> currentWishlists)
+    {
+        ArgumentNullException.ThrowIfNull(product);
+
         var model = new ProductToWishlistModel
         {
             ProductId = product.Id
         };
-        //custom wishlists
-        var currentCustomer = await _workContext.GetCurrentCustomerAsync();
-        var currentWishlists = await _customWishlistService.GetAllCustomWishlistsAsync(currentCustomer.Id);
         foreach (var wishlist in currentWishlists)
         {
             var customWishlistModel = new CustomWishlistModel
@@ -1382,6 +1398,11 @@ public partial class ProductModelFactory : IProductModelFactory
         ArgumentNullException.ThrowIfNull(products);
 
         var models = new List<ProductOverviewModel>();
+
+        //load the current customer's wishlists once; the list is the same for every product on the page
+        var currentCustomer = await _workContext.GetCurrentCustomerAsync();
+        var currentWishlists = await _customWishlistService.GetAllCustomWishlistsAsync(currentCustomer.Id);
+
         foreach (var product in products)
         {
             var model = new ProductOverviewModel
@@ -1414,7 +1435,7 @@ public partial class ProductModelFactory : IProductModelFactory
             model.ReviewOverviewModel = await PrepareProductReviewOverviewModelAsync(product);
 
             //custom wishlist items
-            model.ProductToWishlist = await PrepareProductToWishlistModelAsync(product);
+            model.ProductToWishlist = PrepareProductToWishlistModel(product, currentWishlists);
 
             models.Add(model);
         }


### PR DESCRIPTION
Fixes #8241

### Problem

`PrepareProductOverviewModelsAsync` calls `PrepareProductToWishlistModelAsync(product)` inside its per-product loop, and that method queries the current customer's custom wishlists via `ICustomWishlistService.GetAllCustomWishlistsAsync`. The wishlist set depends only on the customer, so it is identical for every product in the request — a listing page of N products issues N identical `SELECT ... FROM CustomWishlist WHERE CustomerId = @id` queries (observed ~28/page, ~56k over a 2,000-page crawl).

### Fix

Load the customer's wishlists **once** before the loop and reuse them via a new synchronous `PrepareProductToWishlistModel(product, currentWishlists)` overload. The existing async `PrepareProductToWishlistModelAsync(product)` delegates to it, so the single-product path (product details page) is unchanged.

On an N-product listing page this reduces `CustomWishlist` queries from N to 1. Behaviour is otherwise identical — no functional or schema change.
