### PR TITLE
PayPal Commerce: fix guest express checkout failing with "No available shipping options"

### DIFF
--- a/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Services/PayPalCommerceServiceManager.cs
+++ b/src/Plugins/Nop.Plugin.Payments.PayPalCommerce/Services/PayPalCommerceServiceManager.cs
@@ -664,6 +664,13 @@ public class PayPalCommerceServiceManager
         }
 
         var (shippingOptions, pickupPoints) = await PrepareShippingOptionsAsync(details);
+
+        //the customer has no shipping address yet (e.g. a guest using the buttons on the cart/product page),
+        //so there is nothing to estimate rates from; create the order without a shipping block and let PayPal
+        //collect the address (GET_FROM_FILE), the options are then computed and patched in UpdateOrderShippingAsync
+        if ((!shippingOptions?.Any() ?? true) && details.ShippingAddress is null)
+            return null;
+
         if (!shippingOptions?.Any() ?? true)
             throw new NopException("No available shipping options");
 
@@ -907,8 +914,11 @@ public class PayPalCommerceServiceManager
     /// Prepare patches to update an order
     /// </summary>
     /// <param name="purchaseUnit">Purchase unit details</param>
+    /// <param name="orderHasShipping">Whether the remote order already contains a shipping block; when it doesn't
+    /// (e.g. it was created for a customer without a shipping address), nested shipping members cannot be patched
+    /// and the whole object is added instead</param>
     /// <returns>List of patch objects</returns>
-    private static List<Patch<object>> PreparePatches(PurchaseUnit purchaseUnit)
+    private static List<Patch<object>> PreparePatches(PurchaseUnit purchaseUnit, bool orderHasShipping = true)
     {
         var patches = new List<Patch<object>>
         {
@@ -931,6 +941,21 @@ public class PayPalCommerceServiceManager
                 Value = purchaseUnit.SupplementaryData.Card
             }
         };
+
+        //an order created without a shipping block has no "shipping" parent to patch members of
+        //(RFC 6902 requires the parent to exist), so the whole object is added at once
+        //("add" replaces the value when the member already exists)
+        if (purchaseUnit.Shipping is not null && !orderHasShipping)
+        {
+            patches.Add(new()
+            {
+                Op = PatchOpType.ADD.ToString().ToLower(),
+                Path = "/purchase_units/@reference_id=='default'/shipping",
+                Value = purchaseUnit.Shipping
+            });
+
+            return patches;
+        }
 
         if (purchaseUnit.Shipping?.Name is not null)
         {
@@ -1763,7 +1788,7 @@ public class PayPalCommerceServiceManager
             else
             {
                 //order exists, so just update some details
-                var patches = PreparePatches(purchaseUnit);
+                var patches = PreparePatches(purchaseUnit, order.PurchaseUnits?.FirstOrDefault()?.Shipping is not null);
                 patches.Add(new()
                 {
                     Op = PatchOpType.REPLACE.ToString().ToLower(),
@@ -1897,7 +1922,7 @@ public class PayPalCommerceServiceManager
                 Items = items,
                 Amount = orderAmount,
                 SupplementaryData = new() { Card = cardData }
-            });
+            }, unit.Shipping is not null);
             var updateRequest = new UpdateOrderRequest<object>(patches) { OrderId = order.Id };
             await _httpClient.RequestAsync<UpdateOrderRequest<object>, EmptyResponse>(updateRequest, settings);
 


### PR DESCRIPTION
Fixes #8252 (likely also related to #8113)

## Problem

When a customer without a saved shipping address — typically a **guest** — clicks the PayPal buttons on the shopping cart or product page, the AJAX call to `PayPalCommercePublic/CreateOrder` fails with *"No available shipping options"* and the PayPal popup never opens. Guests are the primary audience of the express buttons, and with `shipping_preference = GET_FROM_FILE` (which the plugin already sends for the Cart/Product placements) the shipping address is *supposed* to be collected by PayPal — so requiring an address before creating the order makes the express flow unusable for them.

Root cause: `PrepareShippingDetailsAsync` → `PrepareShippingOptionsAsync` returns an empty result when `details.ShippingAddress is null && !_shippingSettings.AllowPickupInStore`, and `PrepareShippingDetailsAsync` then throws. For a guest, `details.ShippingAddress` (from `customer.ShippingAddressId`) is always null at that point.

## Fix

Two coordinated changes in `PayPalCommerceServiceManager`:

1. **`PrepareShippingDetailsAsync`**: when the options list is empty *and* there is no shipping address to estimate from, return `null` (create the PayPal order without a `shipping` block) instead of throwing. PayPal collects the buyer's address in the popup; the existing `onShippingAddressChange` → `UpdateOrderShippingAsync` flow then computes the real options and patches the order. The throw is kept for the case where an address exists but yields no options.

2. **`PreparePatches`**: the shipping patches use `op: "replace"` on `/shipping/name|address|options|type`. Per RFC 6902 these fail when the parent (`shipping`) doesn't exist — which is now the case for orders created without a shipping block. A new `orderHasShipping` parameter (passed from the fetched remote order at the two call sites) makes the method add the **whole shipping object** in that case:

   ```json
   { "op": "add", "path": "/purchase_units/@reference_id=='default'/shipping", "value": { ... } }
   ```

   `add` acts as an upsert on object members, so it is also safe if the block exists. Existing flows keep the member-wise `replace` behavior unchanged.

No interface, resource or view changes.

## Notes

- Registered customers with a saved shipping address are unaffected (which is probably why this slipped through).
- The buttons on the checkout payment-method page are unaffected (`SET_PROVIDED_ADDRESS` branch returns before the options are computed).
- The reusable-order check in `GetCreatedOrderAsync` (`unit.Shipping is null != !shippingIsRequired`) simply declines to reuse a guest order created without a shipping block and creates a fresh one — no change needed there.
- Verified end-to-end on a production store running a backport of this plugin: guest express flow now completes — order created → address picked in the PayPal popup → options patched → order approved and placed with the correct shipping option and address.

## How to reproduce the bug

1. Configure the plugin with buttons on the shopping cart page.
2. Disable `ShippingSettings.AllowPickupInStore`.
3. As a guest, add a shippable product to the cart and click the PayPal button on the cart page.
4. Before this fix: "No available shipping options" error, popup never opens. After: the flow completes normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

