### PR TITLE
Issue 8255: Fix NopUrlHelper.RouteUrl exception for fragment parameter

### DIFF
--- a/src/Presentation/Nop.Web.Framework/Mvc/Routing/NopUrlHelper.cs
+++ b/src/Presentation/Nop.Web.Framework/Mvc/Routing/NopUrlHelper.cs
@@ -208,6 +208,9 @@ public partial class NopUrlHelper : INopUrlHelper
         if (httpContext is null)
             return string.Empty;
 
+        if (!string.IsNullOrWhiteSpace(fragment) && !fragment.StartsWith('#'))
+            fragment = String.Concat("#", fragment);
+        
         if (!string.IsNullOrEmpty(protocol) || !string.IsNullOrEmpty(host))
         {
             //return URI with an absolute path


### PR DESCRIPTION
Reference to the bug ticket: - https://github.com/nopSolutions/nopCommerce/issues/8255

Problem:
When generating URLs, the fragment value could be passed without a leading “#”. This caused URL generation to fail or behave incorrectly, especially in the .NET 10 upgrade path.

Solution:
The code now normalizes the fragment before building the URL by adding a leading “#” when it is missing. This makes URL generation more robust and ensures fragments are formatted correctly for the underlying ASP.NET routing helper.

**Dev Sanity: -**

Fragment with string "abc" without "#" - no code changes - reproduced issue screenshot: -
<img width="1752" height="1010" alt="image" src="https://github.com/user-attachments/assets/126b95a7-bae6-4695-bbcb-254417c47b48" />


Fragment string being "abc" - replaced to #abc to avoid the exception with a check if the string starts whether # or not.

<img width="2559" height="1424" alt="image" src="https://github.com/user-attachments/assets/a7dce484-a599-4eec-92ec-80adafb2d413" />
