### PR TITLE
Fix [FromHeader]/[FromBody] string parameters binding to null

### DIFF
--- a/src/Presentation/Nop.Web.Framework/Mvc/ModelBinding/Binders/NopModelBinderProvider.cs
+++ b/src/Presentation/Nop.Web.Framework/Mvc/ModelBinding/Binders/NopModelBinderProvider.cs
@@ -13,8 +13,15 @@ public partial class NopModelBinderProvider : IModelBinderProvider
         if (context.Metadata.PropertyName == nameof(BaseNopModel.CustomProperties) && context.Metadata.ModelType == typeof(Dictionary<string, string>))
             return new CustomPropertiesModelBinder();
 
-        if (!context.Metadata.IsComplexType && context.Metadata.ModelType == typeof(string)) 
-            return new StringModelBinder();
+        if (!context.Metadata.IsComplexType && context.Metadata.ModelType == typeof(string))
+        {
+            //only handle strings bound from value providers (query/route/form). A string with an explicit
+            //non-value-provider source ([FromHeader], [FromBody], [FromServices], ...) has to be left to the
+            //built-in binders; StringModelBinder reads value providers only and would bind it to null
+            var bindingSource = context.BindingInfo?.BindingSource;
+            if (bindingSource == null || BindingSource.ModelBinding.CanAcceptDataFrom(bindingSource))
+                return new StringModelBinder();
+        }
 
         return null;
     }

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Mvc/ModelBinding/Binders/NopModelBinderProviderTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Mvc/ModelBinding/Binders/NopModelBinderProviderTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Nop.Web.Framework.Mvc.ModelBinding.Binders;
+using NUnit.Framework;
+
+namespace Nop.Tests.Nop.Web.Tests.Mvc.ModelBinding.Binders;
+
+[TestFixture]
+public class NopModelBinderProviderTests
+{
+    [Test]
+    public void ShouldNotBindStringFromNonValueProviderSource()
+    {
+        GetBinder(BindingSource.Header).Should().BeNull();
+        GetBinder(BindingSource.Body).Should().BeNull();
+    }
+
+    [Test]
+    public void ShouldBindStringFromValueProviderSource()
+    {
+        GetBinder(null).Should().BeOfType<StringModelBinder>();
+        GetBinder(BindingSource.Query).Should().BeOfType<StringModelBinder>();
+    }
+
+    private static IModelBinder GetBinder(BindingSource bindingSource)
+    {
+        var metadataProvider = new EmptyModelMetadataProvider();
+        var context = new TestContext(
+            metadataProvider.GetMetadataForType(typeof(string)),
+            new BindingInfo { BindingSource = bindingSource },
+            metadataProvider);
+
+        return ((IModelBinderProvider)new NopModelBinderProvider()).GetBinder(context);
+    }
+
+    private sealed class TestContext(ModelMetadata metadata, BindingInfo bindingInfo, IModelMetadataProvider provider)
+        : ModelBinderProviderContext
+    {
+        public override BindingInfo BindingInfo { get; } = bindingInfo;
+
+        public override ModelMetadata Metadata { get; } = metadata;
+
+        public override IModelMetadataProvider MetadataProvider { get; } = provider;
+
+        public override IModelBinder CreateBinder(ModelMetadata metadata) => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Fixes #8257 - `[FromHeader]`/`[FromBody]` string action parameters always bind to `null`.

### Cause

`NopModelBinderProvider` is registered at index 1 of `MvcOptions.ModelBinderProviders` (in `ServiceCollectionExtensions`), ahead of the built-in `HeaderModelBinderProvider`/`BodyModelBinderProvider`. For any `string` it returns `StringModelBinder` without looking at `BindingInfo.BindingSource`, so it shadows those binders. `StringModelBinder` reads the value providers only (query/form/route), so a value that lives in the header or request body is never found and the parameter stays `null`.

### Fix

Return `StringModelBinder` only for strings bound from a value-provider source (query/route/form) or with no explicit source; leave the rest to the built-in binders. The trimming applied to form/query/route strings is unchanged.
