### PR TITLE
#8277 Show the "from" price prefix on grouped products only when prices actually differ

### DIFF
--- a/src/Presentation/Nop.Web/Factories/ProductModelFactory.cs
+++ b/src/Presentation/Nop.Web/Factories/ProductModelFactory.cs
@@ -246,8 +246,10 @@ public partial class ProductModelFactory : IProductModelFactory
             return;
 
         //we have at least one associated product
-        //find a minimum possible price
+        //find a minimum possible price, and track the maximum one to tell a real range apart
+        //from a single price shared by every associated product
         decimal? minPossiblePrice = null;
+        decimal? maxPossiblePrice = null;
         Product minPriceProduct = null;
         var customer = await _workContext.GetCurrentCustomerAsync();
         foreach (var associatedProduct in associatedProducts)
@@ -257,6 +259,9 @@ public partial class ProductModelFactory : IProductModelFactory
             //calculate price for the maximum quantity if we have tier prices, and choose minimal
             tmpMinPossiblePrice = Math.Min(tmpMinPossiblePrice,
                 (await _priceCalculationService.GetFinalPriceAsync(associatedProduct, customer, store, quantity: int.MaxValue)).finalPrice);
+
+            if (!maxPossiblePrice.HasValue || tmpMinPossiblePrice > maxPossiblePrice.Value)
+                maxPossiblePrice = tmpMinPossiblePrice;
 
             if (minPossiblePrice.HasValue && tmpMinPossiblePrice >= minPossiblePrice.Value)
                 continue;
@@ -284,9 +289,20 @@ public partial class ProductModelFactory : IProductModelFactory
             var (finalPriceBase, _) = await _taxService.GetProductPriceAsync(minPriceProduct, minPossiblePrice.Value);
             var finalPrice = await _currencyService.ConvertFromPrimaryStoreCurrencyAsync(finalPriceBase, await _workContext.GetWorkingCurrencyAsync());
 
+            var formattedPrice = await _priceFormatter.FormatPriceAsync(finalPrice);
+
+            //"from" only makes sense for an actual range; when every associated product costs
+            //the same (a grouped product with a single associated product, most of all) it is
+            //one exact price and the prefix would be misleading. Compared before tax and
+            //currency conversion - both are applied per product and comparing after them
+            //would require pricing every associated product again.
+            var hasPriceRange = maxPossiblePrice > minPossiblePrice;
+
             priceModel.OldPrice = null;
             priceModel.OldPriceValue = null;
-            priceModel.Price = string.Format(await _localizationService.GetResourceAsync("Products.PriceRangeFrom"), await _priceFormatter.FormatPriceAsync(finalPrice));
+            priceModel.Price = hasPriceRange
+                ? string.Format(await _localizationService.GetResourceAsync("Products.PriceRangeFrom"), formattedPrice)
+                : formattedPrice;
             priceModel.PriceValue = finalPrice;
 
             //PAngV default baseprice (used in Germany)

--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Factories/ProductModelFactoryTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Factories/ProductModelFactoryTests.cs
@@ -33,6 +33,7 @@ namespace Nop.Tests.Nop.Web.Tests.Public.Factories;
 [TestFixture]
 public class ProductModelFactoryTests : WebTest
 {
+    private IPriceFormatter _priceFormatter;
     private IProductModelFactory _productModelFactory;
     private IProductReviewService _productReviewService;
     private IProductService _productService;
@@ -43,6 +44,7 @@ public class ProductModelFactoryTests : WebTest
     [OneTimeSetUp]
     public void SetUp()
     {
+        _priceFormatter = GetService<IPriceFormatter>();
         _productModelFactory = GetService<IProductModelFactory>();
         _productReviewService = GetService<IProductReviewService>();
         _productService = GetService<IProductService>();
@@ -149,6 +151,89 @@ public class ProductModelFactoryTests : WebTest
         var group = model.Groups.FirstOrDefault();
 
         group.Should().NotBe(null);
+    }
+
+    [Test]
+    public async Task GroupedProductWithSinglePriceIsNotPrefixedWithPriceRange()
+    {
+        var (grouped, associated) = await CreateGroupedProductAsync([10M, 10M]);
+
+        try
+        {
+            var model = await _productModelFactoryForTest.NewPrepareProductPriceModelAsync(grouped, true);
+
+            //every associated product costs the same - there is no range to speak of, so the price
+            //is rendered exactly as formatted, without the "from" prefix wrapped around it
+            model.Price.Should().Be(await _priceFormatter.FormatPriceAsync(model.PriceValue.Value));
+        }
+        finally
+        {
+            await DeleteProductsAsync(grouped, associated);
+        }
+    }
+
+    [Test]
+    public async Task GroupedProductWithDifferentPricesKeepsPriceRangePrefix()
+    {
+        var (grouped, associated) = await CreateGroupedProductAsync([10M, 20M]);
+
+        try
+        {
+            var model = await _productModelFactoryForTest.NewPrepareProductPriceModelAsync(grouped, true);
+
+            //cheapest associated product wins the value, but the label says it is a starting point
+            var formattedPrice = await _priceFormatter.FormatPriceAsync(model.PriceValue.Value);
+            model.Price.Should().NotBe(formattedPrice);
+            model.Price.Should().Contain(formattedPrice);
+        }
+        finally
+        {
+            await DeleteProductsAsync(grouped, associated);
+        }
+    }
+
+    /// <summary>
+    /// Creates a grouped product with one associated product per given price
+    /// </summary>
+    private async Task<(Product Grouped, IList<Product> Associated)> CreateGroupedProductAsync(decimal[] prices)
+    {
+        var grouped = new Product
+        {
+            Name = "Grouped price range test",
+            ProductType = ProductType.GroupedProduct,
+            VisibleIndividually = true,
+            Published = true,
+            CreatedOnUtc = DateTime.UtcNow,
+            UpdatedOnUtc = DateTime.UtcNow
+        };
+        await _productService.InsertProductAsync(grouped);
+
+        var associated = new List<Product>();
+        foreach (var price in prices)
+        {
+            var product = new Product
+            {
+                Name = $"Associated {price}",
+                ProductType = ProductType.SimpleProduct,
+                ParentGroupedProductId = grouped.Id,
+                Price = price,
+                Published = true,
+                CreatedOnUtc = DateTime.UtcNow,
+                UpdatedOnUtc = DateTime.UtcNow
+            };
+            await _productService.InsertProductAsync(product);
+            associated.Add(product);
+        }
+
+        return (grouped, associated);
+    }
+
+    private async Task DeleteProductsAsync(Product grouped, IList<Product> associated)
+    {
+        foreach (var product in associated)
+            await _productService.DeleteProductAsync(product);
+
+        await _productService.DeleteProductAsync(grouped);
     }
 
     #region Nested class


### PR DESCRIPTION
Fixes #8277.

The loop now tracks `maxPossiblePrice` alongside `minPossiblePrice` and the `Products.PriceRangeFrom` prefix is applied only when they differ. Compared before tax and currency conversion — both are applied per product, so comparing after them would mean pricing every associated product again.

`PriceValue` is unchanged, only the displayed label.

Two tests cover both directions: equal prices render the plain formatted price, differing prices keep the prefix