### PR TITLE
Fix #8279: read XLSX decimal cells independently of the current culture

### DIFF
--- a/src/Libraries/Nop.Services/ExportImport/Help/PropertyByName.cs
+++ b/src/Libraries/Nop.Services/ExportImport/Help/PropertyByName.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using ClosedXML.Excel;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Nop.Core.Domain.Localization;
 
@@ -121,7 +122,7 @@ public partial class PropertyByName<T>
     {
         get
         {
-            if (PropertyValue == null || !decimal.TryParse(PropertyValue.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var rez))
+            if (!TryGetDecimalValue(out var rez))
                 return default;
             return rez;
         }
@@ -134,10 +135,33 @@ public partial class PropertyByName<T>
     {
         get
         {
-            if (PropertyValue == null || !decimal.TryParse(PropertyValue.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var rez))
+            if (!TryGetDecimalValue(out var rez))
                 return null;
             return rez;
         }
+    }
+
+    /// <summary>
+    /// Converts the property value to decimal
+    /// </summary>
+    /// <param name="value">The converted value, or the default one when the value cannot be converted</param>
+    /// <returns>Whether the property value could be converted</returns>
+    protected virtual bool TryGetDecimalValue(out decimal value)
+    {
+        value = default;
+        var propertyValue = PropertyValue;
+
+        //a numeric spreadsheet cell must be converted from its underlying number: ToString() formats it
+        //with the current culture ("43,5" under de-DE), and the invariant parse below would then read the
+        //decimal separator as a group separator and silently turn 43.5 into 435
+        if (propertyValue is XLCellValue { IsNumber: true } cellValue)
+            //formatted round-trip rather than a cast, so that a number outside the decimal range reports
+            //failure instead of throwing OverflowException and aborting the whole import
+            return decimal.TryParse(cellValue.GetNumber().ToString("R", CultureInfo.InvariantCulture),
+                NumberStyles.Float, CultureInfo.InvariantCulture, out value);
+
+        return propertyValue != null &&
+               decimal.TryParse(propertyValue.ToString(), NumberStyles.Any, CultureInfo.InvariantCulture, out value);
     }
 
     /// <summary>

--- a/src/Tests/Nop.Tests/Nop.Services.Tests/ExportImport/PropertyByNameTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Services.Tests/ExportImport/PropertyByNameTests.cs
@@ -1,0 +1,98 @@
+using System.Globalization;
+using AwesomeAssertions;
+using ClosedXML.Excel;
+using Nop.Core.Domain.Orders;
+using Nop.Services.ExportImport.Help;
+using NUnit.Framework;
+
+namespace Nop.Tests.Nop.Services.Tests.ExportImport;
+
+[TestFixture]
+public class PropertyByNameTests
+{
+    private static PropertyByName<Order> CreateProperty(object propertyValue)
+    {
+        return new PropertyByName<Order>("OrderSubtotalInclTax") { PropertyValue = propertyValue };
+    }
+
+    private static void InCulture(string cultureName, Action action)
+    {
+        var previousCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo(cultureName);
+            action();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+        }
+    }
+
+    [Test]
+    public void CanReadNumericCellValueRegardlessOfCurrentCulture()
+    {
+        //a culture whose decimal separator is a comma formats the cell as "43,5", which an invariant
+        //parse then reads as a group separator and turns into 435
+        foreach (var cultureName in new[] { "en-US", "de-DE", "cs-CZ", "fr-FR" })
+        {
+            InCulture(cultureName, () =>
+            {
+                var property = CreateProperty((XLCellValue)43.5M);
+
+                property.DecimalValue.Should().Be(43.5M, $"the cell holds 43.5 under {cultureName}");
+                property.DecimalValueNullable.Should().Be(43.5M, $"the cell holds 43.5 under {cultureName}");
+            });
+        }
+    }
+
+    [Test]
+    public void CanReadNegativeAndIntegralNumericCellValues()
+    {
+        InCulture("de-DE", () =>
+        {
+            CreateProperty((XLCellValue)(-1234.56M)).DecimalValue.Should().Be(-1234.56M);
+            CreateProperty((XLCellValue)0M).DecimalValue.Should().Be(0M);
+            CreateProperty((XLCellValue)1234M).DecimalValue.Should().Be(1234M);
+        });
+    }
+
+    [Test]
+    public void CanReadInvariantTextCellValue()
+    {
+        //text cells keep the invariant parsing, so an exported "43.5" still round-trips
+        InCulture("de-DE", () =>
+        {
+            var property = CreateProperty((XLCellValue)"43.5");
+
+            property.DecimalValue.Should().Be(43.5M);
+            property.DecimalValueNullable.Should().Be(43.5M);
+        });
+    }
+
+    [TestCase(double.MinValue)]
+    [TestCase(double.MaxValue)]
+    public void OutOfRangeNumericCellValueReturnsDefaultInsteadOfThrowing(double cellNumber)
+    {
+        var property = CreateProperty((XLCellValue)cellNumber);
+
+        property.DecimalValue.Should().Be(default);
+        property.DecimalValueNullable.Should().BeNull();
+    }
+
+    [Test]
+    public void NonNumericValueReturnsDefault()
+    {
+        var blank = CreateProperty(XLCellValue.FromObject(null));
+        blank.DecimalValue.Should().Be(default);
+        blank.DecimalValueNullable.Should().BeNull();
+
+        var text = CreateProperty((XLCellValue)"not a number");
+        text.DecimalValue.Should().Be(default);
+        text.DecimalValueNullable.Should().BeNull();
+
+        var missing = CreateProperty(null);
+        missing.DecimalValue.Should().Be(default);
+        missing.DecimalValueNullable.Should().BeNull();
+    }
+}


### PR DESCRIPTION
Fixes #8279

## Problem

On a server whose culture uses a comma as the decimal separator (de-DE, cs-CZ, fr-FR, …), importing an XLSX file silently multiplies every fractional decimal value. A product priced `43.5` is imported as `435`, and the import reports success.

`PropertyByName<T>.DecimalValue` / `DecimalValueNullable` format the value with `PropertyValue.ToString()` and parse the result with `InvariantCulture`. During import `PropertyValue` holds an `XLCellValue` (assigned in `PropertyManager.ReadFromXlsx`), and `XLCellValue.ToString()` formats using **CurrentCulture**. So the cell `43.5` becomes `"43,5"`, and the invariant parse with `NumberStyles.Any` reads the comma as a *group* separator and returns `435`.

This is a regression from 4cd15f7 (#8239), which switched the parse to `InvariantCulture`. That change was right for `OrderController`, `ProductController`, `ProductAttributeParser` and the RFQ plugin, whose input comes from form fields and is always invariant. `PropertyByName` is different: its input is a culture-formatted spreadsheet value, where the previous `CurrentCulture` parse matched the formatting. Applying the same change here produced the mirror image of the bug #8239 set out to fix.

Affected: 4.90.5, 4.90.6 and current `develop`. 4.90.4 and earlier are correct.

## Fix

Convert a numeric cell from its underlying number instead of a culture-formatted string. Text cells keep the existing invariant parsing, so an exported `"43.5"` still round-trips.

The conversion goes through an invariant `"R"` round-trip rather than a `(decimal)` cast on purpose: a cell holding a number outside the `decimal` range then reports failure and yields `default`/`null`, instead of throwing `OverflowException` and aborting the whole import.

## Impact

`ImportManager` feeds `DecimalValue` into product prices (`Price`, `OldPrice`, `ProductCost`, `BasepriceAmount`, `AdditionalShippingCharge`, …), tier prices, attribute price/weight adjustments, category price ranges, and order item prices, taxes and totals.

## Tests

Added `PropertyByNameTests`, covering the numeric path across en-US, de-DE, cs-CZ and fr-FR, negative and integral values, invariant text cells, out-of-range doubles, and blank/non-numeric/null values. It passes under both a comma-decimal and a dot-decimal system culture.

`ExportManagerTests.CanExportOrdersXlsx` also already covered the decimal problem. Run on its own on a machine whose system culture uses a comma decimal separator, `develop` fails it with

```
Expected propertyValue to be 43.5M because The property "Order.OrderSubtotalInclTax"
of these objects is not equal, but found 435M.
```

and with this change it gets past that assertion.

**One thing to flag, unrelated to this PR:** `CanExportOrdersXlsx` then hits a second, pre-existing failure on `develop` — a `NullReferenceException` at `ExportManagerTests.cs:295`, where `GetCountryByAddressAsync(testShippingAddress)` returns null and `country.Name` dereferences it. I confirmed this is not caused by this change: on a **pristine `develop` checkout with no modifications**, under an en-US system culture where the decimal bug does not trigger, running the whole `ExportManagerTests` fixture reproduces the same NRE (1 failed, 4 passed). Running `CanExportOrdersXlsx` on its own under en-US passes, so it appears to depend on shared sample-data state across the fixture. I have not investigated further, as it is outside the scope of this fix — happy to open a separate issue if useful.

For reference, the same fix on a `release-4.90.6` base makes `CanExportOrdersXlsx` pass outright and keeps the full `Nop.Tests` suite green (2339 passed, 0 failed, 8 skipped); the NRE above appears to be newer than 4.90.6.

## Note

`DoubleValue` and `IntValue` have the same structural weakness — they parse with `CurrentCulture`, which happens to match `XLCellValue.ToString()` today, but leaves them exposed to the inverse problem for text cells holding invariant-formatted numbers. I left them alone to keep this change minimal; happy to extend the PR if you would prefer them fixed together.
