### PR TITLE
#8283 Update the reference implementation in ProductModelFactoryTests

### DIFF
--- a/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Factories/ProductModelFactoryTests.cs
+++ b/src/Tests/Nop.Tests/Nop.Web.Tests/Public/Factories/ProductModelFactoryTests.cs
@@ -369,7 +369,7 @@ public class ProductModelFactoryTests : WebTest
 
                         //PAngV default baseprice (used in Germany)
                         priceModel.BasePricePAngV = await _priceFormatter.FormatBasePriceAsync(product, finalPriceWithDiscount);
-                        priceModel.BasePricePAngVValue = finalPriceWithDiscount;
+                        priceModel.BasePricePAngVValue = await GetBaseProductPriceAsync(product, finalPriceWithDiscount);
                     }
                 }
                 else
@@ -453,7 +453,7 @@ public class ProductModelFactoryTests : WebTest
 
                         //PAngV default baseprice (used in Germany)
                         priceModel.BasePricePAngV = await _priceFormatter.FormatBasePriceAsync(product, finalPriceBase);
-                        priceModel.BasePricePAngVValue = finalPriceBase;
+                        priceModel.BasePricePAngVValue = await GetBaseProductPriceAsync(product, finalPriceBase);
                     }
                 }
                 else
@@ -565,7 +565,7 @@ public class ProductModelFactoryTests : WebTest
 
                         //PAngV baseprice (used in Germany)
                         model.BasePricePAngV = await _priceFormatter.FormatBasePriceAsync(product, finalPriceWithDiscountBase);
-                        model.BasePricePAngVValue = finalPriceWithDiscountBase;
+                        model.BasePricePAngVValue = await GetBaseProductPriceAsync(product, finalPriceWithDiscountBase);
 
                         //rental
                         if (product.IsRental)


### PR DESCRIPTION
Fixes: #8283
  `ProductModelFactoryTests` compares production `ProductModelFactory` against a reference                                                                                                                                                         
  implementation kept in the test fixture (`ProductModelFactoryForTest`). #8261 moved production                                                                                                                                                   
  to `GetBaseProductPriceAsync`, but left the reference assigning the raw price, so                                                                                                                                                                
  `CanPreparePriceModel` fails on `4.90-bug-fixes`:                                                                                                                                                                                                
                                                                                                                                                                                                                                                   
  Expected object1PropertyValue to be 1200M because The property                                                                                                                                                                                   
  "ProductPriceModel.BasePricePAngVValue" of these objects is not equal, but found <null>.                                                                                                                                                         
                                                                                                                                                                                                                                                   
  The reference returns the raw 1200; production correctly returns `null` for a product with no                                                                                                                                                    
  base price configured.                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                   
  ## Change                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                   
  The three assignments in the reference implementation (`ProductModelFactoryTests.cs:372`, `:456`,                                                                                                                                                
  `:568`) now call `GetBaseProductPriceAsync`, matching production. Test code only — no production                                                                                                                                                 
  file is touched. 